### PR TITLE
feat(boards): send-to-review workflow + state-driven sprints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
 # syntax=docker/dockerfile:1
 
-# 1. Build the SPA into web/dist.
-FROM node:20-alpine AS web
+# 1. Build the SPA into web/dist (arch-independent output; build on the host arch).
+FROM --platform=$BUILDPLATFORM node:20-alpine AS web
 WORKDIR /src/web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ ./
 RUN npm run build
 
-# 2. Build the self-contained Go binary (embeds web/dist via go:embed).
-FROM golang:1.26-alpine AS build
+# 2. Build the self-contained Go binary (embeds web/dist via go:embed). Built on
+#    the host arch and cross-compiled to the target arch (fast, no emulation).
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 ARG VERSION=docker
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=web /src/web/dist ./web/dist
-RUN CGO_ENABLED=0 go build -trimpath \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
     -ldflags "-s -w -X main.version=${VERSION}" \
     -o /aeman ./cmd/aeman
 # A nonroot-owned /data so a session-file volume mounted here is writable.

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,8 @@ A card maps a project item onto the well-known fields aeman understands (resolve
   "zoneOptionId": "...",
   "progress": 40,
   "day": "2026-06-26",
+  "startDate": "2026-06-24",
+  "sprintStart": "2026-06-24",
   "sprintTitle": "Sprint 3",
   "status": "In progress",
   "team": "Platform",
@@ -64,11 +66,21 @@ A card maps a project item onto the well-known fields aeman understands (resolve
 
 ### Create / update inputs
 
-`CreateCardInput`: `{ "title" (required), "zone", "assignee", "day", "status", "team", "progress", "fields" }`.
+`CreateCardInput`: `{ "title" (required), "zone", "assignee", "day", "start", "sprintStart", "status", "team", "progress", "fields", "startNewSprint" }`.
 
-`UpdateCardInput` is a partial patch — only the keys you send are changed: `{ "title", "zone", "progress", "day", "assignee", "status", "team", "fields" }`. For `zone`, `day`, `assignee`, `status` and `team`, an empty string clears the value. `fields` is an object keyed by board field name; aeman dispatches on each field's data type (single-select by option name, plus date/number/text).
+`UpdateCardInput` is a partial patch — only the keys you send are changed: `{ "title", "zone", "progress", "day", "start", "sprintStart", "assignee", "status", "team", "fields" }`. For `zone`, `day`, `start`, `sprintStart`, `assignee`, `status` and `team`, an empty string clears the value. `fields` is an object keyed by board field name; aeman dispatches on each field's data type (single-select by option name, plus date/number/text).
 
-Field roles are matched by name: zone (`zone`, `priority zone`, `зона`), progress (`progress`, `readiness`, `% done`, …), day (`day`, `date`, `due date`, …), sprint (`sprint`, `iteration`, …), status (`status`, `stage`, …), team (`team`, `group`, …).
+#### Sprint membership on create (`startNewSprint`)
+
+A card belongs to a sprint, identified by its `sprintStart` date (the day the sprint began). On create, aeman can place the card in the right sprint automatically. This logic engages when the card has a `team`, or when `startNewSprint` is set explicitly; a teamless create with the flag omitted keeps the legacy behaviour (no sprint dates are touched).
+
+- omitted (auto): join the team's **current sprint** (the latest `sprintStart` on or before today) if it is still running — i.e. at least one card of that sprint is not `done` — otherwise start a new sprint today.
+- `true`: force a new sprint (`sprintStart` = today).
+- `false`: force-join the team's current sprint (`sprintStart` = its start day; today if the team has none).
+
+When it engages, aeman sets `start` = `sprintStart` and defaults `day` to today (an explicit `day` is respected). Fields the board does not define are skipped, so the create never fails on a leaner board.
+
+Field roles are matched by name: zone (`zone`, `priority zone`, `зона`), progress (`progress`, `readiness`, `% done`, …), day (`day`, `date`, `due date`, …), start (`start`, `start date`, …), sprint start (`sprint start`, `sprintstart`, …), sprint (`sprint`, `iteration`, …), status (`status`, `stage`, …), team (`team`, `group`, …).
 
 ### Examples
 
@@ -98,7 +110,7 @@ curl -X POST 'http://127.0.0.1:8765/api/v1/cards/PVTI_xxx/notes?owner=acme&proje
 | --- | --- |
 | `get_board` | Board identity and field metadata. |
 | `list_cards` | All cards on the board. |
-| `create_card` | Create a draft-issue card (title required; optional zone/assignee/day/status/team/progress). |
+| `create_card` | Create a draft-issue card (title required; optional zone/assignee/day/status/team/progress/startNewSprint). |
 | `update_card` | Partial update by `itemId` (title/zone/progress/day/assignee/status/team). |
 | `move_card` | Reorder by `itemId`, optional `afterId`. |
 | `delete_card` | Delete by `itemId`. |

--- a/internal/ghprojects/board.go
+++ b/internal/ghprojects/board.go
@@ -275,6 +275,10 @@ func applyRole(card *Card, v *rawFieldValue, roles FieldRoles) {
 		card.Progress = v.Number
 	case roles.Day != nil && id == roles.Day.ID && v.Date != "":
 		card.Day = v.Date
+	case roles.Start != nil && id == roles.Start.ID && v.Date != "":
+		card.StartDate = v.Date
+	case roles.SprintStart != nil && id == roles.SprintStart.ID && v.Date != "":
+		card.SprintStart = v.Date
 	case roles.Sprint != nil && id == roles.Sprint.ID && v.Title != "":
 		card.SprintTitle = v.Title
 	case roles.Status != nil && id == roles.Status.ID && v.Name != "":

--- a/internal/ghprojects/fields.go
+++ b/internal/ghprojects/fields.go
@@ -5,12 +5,14 @@ import "strings"
 // roleAliases maps a field role to the field names (case-insensitive) that fill
 // it. It mirrors web/src/providers/fields.ts, extended with a "team" role.
 var roleAliases = map[string][]string{
-	"zone":     {"zone", "priority zone", "зона"},
-	"progress": {"progress", "readiness", "% done", "percent", "готовность"},
-	"day":      {"day", "date", "due date", "due", "день", "дата"},
-	"sprint":   {"sprint", "iteration", "спринт", "итерация"},
-	"status":   {"status", "stage", "статус"},
-	"team":     {"team", "group", "команда", "группа"},
+	"zone":        {"zone", "priority zone", "зона"},
+	"progress":    {"progress", "readiness", "% done", "percent", "готовность"},
+	"day":         {"day", "date", "due date", "due", "день", "дата"},
+	"start":       {"start", "start date", "начало", "старт"},
+	"sprintStart": {"sprint start", "sprintstart", "спринт старт"},
+	"sprint":      {"sprint", "iteration", "спринт", "итерация"},
+	"status":      {"status", "stage", "статус"},
+	"team":        {"team", "group", "команда", "группа"},
 }
 
 // roles maps the board's fields onto well-known roles by name.
@@ -26,6 +28,10 @@ func (b *Board) roles() FieldRoles {
 			r.Progress = f
 		case r.Day == nil && matchesAlias("day", name):
 			r.Day = f
+		case r.Start == nil && matchesAlias("start", name):
+			r.Start = f
+		case r.SprintStart == nil && matchesAlias("sprintStart", name):
+			r.SprintStart = f
 		case r.Sprint == nil && matchesAlias("sprint", name):
 			r.Sprint = f
 		case r.Status == nil && matchesAlias("status", name):

--- a/internal/ghprojects/model.go
+++ b/internal/ghprojects/model.go
@@ -68,13 +68,17 @@ type Card struct {
 	ZoneOptionID string   `json:"zoneOptionId,omitempty"`
 	// Progress is the readiness percentage (0..100) when the board has such a
 	// field; nil means unset.
-	Progress    *float64 `json:"progress,omitempty"`
-	Day         string   `json:"day,omitempty"`
-	SprintTitle string   `json:"sprintTitle,omitempty"`
-	Status      string   `json:"status,omitempty"`
-	Team        string   `json:"team,omitempty"`
-	CreatedAt   string   `json:"createdAt,omitempty"`
-	Notes       []Note   `json:"notes"`
+	Progress *float64 `json:"progress,omitempty"`
+	Day      string   `json:"day,omitempty"`
+	// StartDate is the day the card starts on; SprintStart is the start day of
+	// the sprint it belongs to (what the boards orient by).
+	StartDate   string `json:"startDate,omitempty"`
+	SprintStart string `json:"sprintStart,omitempty"`
+	SprintTitle string `json:"sprintTitle,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Team        string `json:"team,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	Notes       []Note `json:"notes"`
 	// Fields holds every field value keyed by its (verbatim) field name, so
 	// callers can read board-specific fields aeman has no dedicated role for.
 	Fields map[string]string `json:"fields,omitempty"`
@@ -93,40 +97,52 @@ type Board struct {
 
 // FieldRoles maps well-known roles onto the board's actual fields by name.
 type FieldRoles struct {
-	Zone     *ProjectField
-	Progress *ProjectField
-	Day      *ProjectField
-	Sprint   *ProjectField
-	Status   *ProjectField
-	Team     *ProjectField
+	Zone        *ProjectField
+	Progress    *ProjectField
+	Day         *ProjectField
+	Start       *ProjectField
+	SprintStart *ProjectField
+	Sprint      *ProjectField
+	Status      *ProjectField
+	Team        *ProjectField
 }
 
 // CreateCardInput describes a draft-issue card to create on a board. Only Title
 // is required; the remaining fields are applied when the board has a matching
 // role.
 type CreateCardInput struct {
-	Title    string            `json:"title"`
-	Zone     ZoneKey           `json:"zone,omitempty"`
-	Assignee string            `json:"assignee,omitempty"`
-	Day      string            `json:"day,omitempty"`
-	Status   string            `json:"status,omitempty"`
-	Team     string            `json:"team,omitempty"`
-	Progress *float64          `json:"progress,omitempty"`
-	Fields   map[string]string `json:"fields,omitempty"`
+	Title       string            `json:"title"`
+	Zone        ZoneKey           `json:"zone,omitempty"`
+	Assignee    string            `json:"assignee,omitempty"`
+	Day         string            `json:"day,omitempty"`
+	Start       string            `json:"start,omitempty"`
+	SprintStart string            `json:"sprintStart,omitempty"`
+	Status      string            `json:"status,omitempty"`
+	Team        string            `json:"team,omitempty"`
+	Progress    *float64          `json:"progress,omitempty"`
+	Fields      map[string]string `json:"fields,omitempty"`
+	// StartNewSprint controls how the card joins a sprint when it has a team (or
+	// the flag is set explicitly): nil = auto (join the team's running sprint, or
+	// start a new one today when it is all done / absent), true = force a new
+	// sprint today, false = force-join the current sprint (today if none). When
+	// engaged it sets startDate = sprintStart and defaults day to today.
+	StartNewSprint *bool `json:"startNewSprint,omitempty"`
 }
 
 // UpdateCardInput describes a partial update to a card. A nil pointer leaves the
 // corresponding field untouched. For Zone, Day, Assignee, Status and Team an
 // empty string clears the value.
 type UpdateCardInput struct {
-	Title    *string           `json:"title,omitempty"`
-	Zone     *ZoneKey          `json:"zone,omitempty"`
-	Progress *float64          `json:"progress,omitempty"`
-	Day      *string           `json:"day,omitempty"`
-	Assignee *string           `json:"assignee,omitempty"`
-	Status   *string           `json:"status,omitempty"`
-	Team     *string           `json:"team,omitempty"`
-	Fields   map[string]string `json:"fields,omitempty"`
+	Title       *string           `json:"title,omitempty"`
+	Zone        *ZoneKey          `json:"zone,omitempty"`
+	Progress    *float64          `json:"progress,omitempty"`
+	Day         *string           `json:"day,omitempty"`
+	Start       *string           `json:"start,omitempty"`
+	SprintStart *string           `json:"sprintStart,omitempty"`
+	Assignee    *string           `json:"assignee,omitempty"`
+	Status      *string           `json:"status,omitempty"`
+	Team        *string           `json:"team,omitempty"`
+	Fields      map[string]string `json:"fields,omitempty"`
 }
 
 // cardByItemID returns a pointer to the card with the given item id, or nil.
@@ -147,4 +163,75 @@ func (b *Board) fieldByName(name string) *ProjectField {
 		}
 	}
 	return nil
+}
+
+// stageField returns the board's "stage" field (the locked/review/done status),
+// matched by name the way the frontend does, or nil. It is distinct from the
+// default GitHub "Status" field.
+func (b *Board) stageField() *ProjectField {
+	for i := range b.Fields {
+		if equalFold(b.Fields[i].Name, "stage") || equalFold(b.Fields[i].Name, "состояние") {
+			return &b.Fields[i]
+		}
+	}
+	return nil
+}
+
+// cardDone reports whether the card sits in the "done" stage. It reads the stage
+// field value off the card's verbatim Fields map, mirroring the frontend's
+// stage === "done" check.
+func (b *Board) cardDone(card *Card) bool {
+	f := b.stageField()
+	if f == nil {
+		return false
+	}
+	return equalFold(card.Fields[f.Name], "done")
+}
+
+// currentSprint returns the team's current sprint start (the latest SprintStart
+// on or before today) and whether it is still running (any card of that sprint
+// is not done). It mirrors web/src/sprint.ts. An empty cur means the team has no
+// sprint on or before today.
+func (b *Board) currentSprint(team, today string) (cur string, running bool) {
+	for i := range b.Cards {
+		c := &b.Cards[i]
+		if c.Team != team || c.SprintStart == "" || c.SprintStart > today {
+			continue
+		}
+		if c.SprintStart > cur {
+			cur = c.SprintStart
+		}
+	}
+	if cur == "" {
+		return "", false
+	}
+	for i := range b.Cards {
+		c := &b.Cards[i]
+		if c.Team == team && c.SprintStart == cur && !b.cardDone(c) {
+			return cur, true
+		}
+	}
+	return cur, false
+}
+
+// sprintStartForNew resolves the sprint a new card should belong to, honouring
+// the startNewSprint preference (nil = auto). It mirrors the Team board's create
+// rule: auto joins the running sprint or starts a new one today; true forces a
+// new sprint today; false force-joins the current sprint (today if none).
+func (b *Board) sprintStartForNew(team string, startNewSprint *bool, today string) string {
+	cur, running := b.currentSprint(team, today)
+	switch {
+	case startNewSprint != nil && *startNewSprint:
+		return today
+	case startNewSprint != nil && !*startNewSprint:
+		if cur != "" {
+			return cur
+		}
+		return today
+	default:
+		if running {
+			return cur
+		}
+		return today
+	}
 }

--- a/internal/ghprojects/mutations.go
+++ b/internal/ghprojects/mutations.go
@@ -49,6 +49,26 @@ func (c *Client) CreateCard(ctx context.Context, board *Board, in CreateCardInpu
 	if strings.TrimSpace(in.Title) == "" {
 		return nil, fmt.Errorf("title is required")
 	}
+
+	// Sprint-aware date assignment, mirroring the Team board's create rule. It
+	// engages when the caller sets startNewSprint, or when the card has a team
+	// (so a teamless create with no flag keeps the legacy behaviour). Start date
+	// always equals the sprint start; day defaults to today. Fields the board
+	// lacks are skipped, so this never fails a create on a leaner board.
+	if in.StartNewSprint != nil || in.Team != "" {
+		today := time.Now().Format("2006-01-02")
+		sprintStart := board.sprintStartForNew(in.Team, in.StartNewSprint, today)
+		roles := board.roles()
+		if roles.SprintStart != nil {
+			in.SprintStart = sprintStart
+		}
+		if roles.Start != nil {
+			in.Start = sprintStart
+		}
+		if in.Day == "" && roles.Day != nil {
+			in.Day = today
+		}
+	}
 	var assigneeIDs []string
 	if in.Assignee != "" {
 		id, err := c.resolveUserID(ctx, in.Assignee)
@@ -81,6 +101,12 @@ func (c *Client) CreateCard(ctx context.Context, board *Board, in CreateCardInpu
 	}
 	if in.Day != "" {
 		update.Day = &in.Day
+	}
+	if in.Start != "" {
+		update.Start = &in.Start
+	}
+	if in.SprintStart != "" {
+		update.SprintStart = &in.SprintStart
 	}
 	if in.Status != "" {
 		update.Status = &in.Status
@@ -134,6 +160,16 @@ func (c *Client) applyUpdate(
 	}
 	if in.Day != nil {
 		if err := c.setDateRole(ctx, board, itemID, board.roles().Day, "day", *in.Day); err != nil {
+			return err
+		}
+	}
+	if in.Start != nil {
+		if err := c.setDateRole(ctx, board, itemID, board.roles().Start, "start", *in.Start); err != nil {
+			return err
+		}
+	}
+	if in.SprintStart != nil {
+		if err := c.setDateRole(ctx, board, itemID, board.roles().SprintStart, "sprintStart", *in.SprintStart); err != nil {
 			return err
 		}
 	}

--- a/internal/ghprojects/sprint_test.go
+++ b/internal/ghprojects/sprint_test.go
@@ -1,0 +1,73 @@
+package ghprojects
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+// sprintBoard builds a board with a Stage field and the given cards, exercising
+// the current-sprint computation that backs the startNewSprint create flag.
+func sprintBoard() *Board {
+	done := map[string]string{"Stage": "Done"}
+	return &Board{
+		Fields: []ProjectField{
+			{ID: "SS", Name: "Sprint Start", DataType: "DATE"},
+			{ID: "ST", Name: "Stage", DataType: "SINGLE_SELECT"},
+		},
+		Cards: []Card{
+			// Team A: an older sprint and a later one (06-20), both all done.
+			{ItemID: "1", Team: "A", SprintStart: "2026-06-10", Fields: done},
+			{ItemID: "2", Team: "A", SprintStart: "2026-06-20", Fields: done},
+			// Team B: current sprint still running (a card is not done).
+			{ItemID: "3", Team: "B", SprintStart: "2026-06-18", Fields: map[string]string{"Stage": "Review"}},
+			// A future sprint must be ignored when resolving "current".
+			{ItemID: "4", Team: "B", SprintStart: "2026-07-01", Fields: map[string]string{"Stage": "Review"}},
+		},
+	}
+}
+
+func TestCurrentSprint(t *testing.T) {
+	board := sprintBoard()
+	const today = "2026-06-25"
+
+	cases := []struct {
+		team        string
+		wantCur     string
+		wantRunning bool
+	}{
+		{"A", "2026-06-20", false}, // latest sprint all done
+		{"B", "2026-06-18", true},  // running; future 07-01 ignored
+		{"C", "", false},           // no sprint at all
+	}
+	for _, c := range cases {
+		cur, running := board.currentSprint(c.team, today)
+		if cur != c.wantCur || running != c.wantRunning {
+			t.Errorf("currentSprint(%q) = (%q,%v), want (%q,%v)",
+				c.team, cur, running, c.wantCur, c.wantRunning)
+		}
+	}
+}
+
+func TestSprintStartForNew(t *testing.T) {
+	board := sprintBoard()
+	const today = "2026-06-25"
+
+	cases := []struct {
+		name           string
+		team           string
+		startNewSprint *bool
+		want           string
+	}{
+		{"A auto starts new (current all done)", "A", nil, today},
+		{"A force-join the done sprint", "A", boolPtr(false), "2026-06-20"},
+		{"A force new", "A", boolPtr(true), today},
+		{"B auto joins running", "B", nil, "2026-06-18"},
+		{"B force new", "B", boolPtr(true), today},
+		{"C auto with no sprint", "C", nil, today},
+		{"C force-join falls back to today", "C", boolPtr(false), today},
+	}
+	for _, c := range cases {
+		if got := board.sprintStartForNew(c.team, c.startNewSprint, today); got != c.want {
+			t.Errorf("%s: sprintStartForNew = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -62,6 +62,11 @@ type createCardInput struct {
 	Status   string   `json:"status,omitempty" jsonschema:"status/stage single-select option name"`
 	Team     string   `json:"team,omitempty" jsonschema:"team field value"`
 	Progress *float64 `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
+	// StartNewSprint controls sprint membership for a team card: omit for auto
+	// (join the team's running sprint, else start a new one today), true to force
+	// a new sprint today, false to force-join the current sprint. When engaged,
+	// startDate = sprintStart and day defaults to today.
+	StartNewSprint *bool `json:"startNewSprint,omitempty" jsonschema:"force a new sprint (true) or join the current one (false); omit for auto"`
 }
 
 func (h *server) createCard(ctx context.Context, _ *mcp.CallToolRequest, in createCardInput) (*mcp.CallToolResult, ghprojects.Card, error) {
@@ -70,13 +75,14 @@ func (h *server) createCard(ctx context.Context, _ *mcp.CallToolRequest, in crea
 		return nil, ghprojects.Card{}, err
 	}
 	card, err := client.CreateCard(ctx, board, ghprojects.CreateCardInput{
-		Title:    in.Title,
-		Zone:     ghprojects.ZoneKey(in.Zone),
-		Assignee: in.Assignee,
-		Day:      in.Day,
-		Status:   in.Status,
-		Team:     in.Team,
-		Progress: in.Progress,
+		Title:          in.Title,
+		Zone:           ghprojects.ZoneKey(in.Zone),
+		Assignee:       in.Assignee,
+		Day:            in.Day,
+		Status:         in.Status,
+		Team:           in.Team,
+		Progress:       in.Progress,
+		StartNewSprint: in.StartNewSprint,
 	})
 	if err != nil {
 		return nil, ghprojects.Card{}, err

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -33,6 +33,14 @@ interface CardProps {
   users?: Record<string, GhUser>;
   onSetTeam?: (card: CardModel, team: string | null) => void;
   onSetAssignee?: (card: CardModel, login: string | null) => void;
+  /** Send the card to review: creates a linked review card for the chosen
+   *  reviewer and puts this card on the review stage (hidden on review cards). */
+  onSendToReview?: (card: CardModel, reviewerLogin: string) => void;
+  /** Reviewer suggestions for the "send to review" picker (same-team people). */
+  reviewerCandidates?: string[];
+  /** This card has a linked review card; deleting it cascades (the board owns
+   *  the combined confirmation, so the card skips its own delete prompt). */
+  hasLinkedReview?: boolean;
   /** The day the board is showing; the age badge is measured up to it. */
   asOf?: string;
   /** Edit the card's start/end dates from the age badge (when provided). */
@@ -76,6 +84,9 @@ export function Card({
   users,
   onSetTeam,
   onSetAssignee,
+  onSendToReview,
+  reviewerCandidates,
+  hasLinkedReview,
   asOf,
   onSetDates,
   weekMode,
@@ -98,6 +109,8 @@ export function Card({
   const [dragValue, setDragValue] = useState<number | null>(null);
   const [assignOpen, setAssignOpen] = useState(false);
   const [personInput, setPersonInput] = useState("");
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [reviewerInput, setReviewerInput] = useState("");
   const menuRef = useRef<HTMLDivElement | null>(null);
   const assignRef = useRef<HTMLDivElement | null>(null);
   const barRef = useRef<HTMLDivElement | null>(null);
@@ -147,6 +160,12 @@ export function Card({
 
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    // Cards with a linked review card delegate the (combined) confirmation to
+    // the board, which deletes both the original and its review card.
+    if (hasLinkedReview) {
+      onDelete(card);
+      return;
+    }
     if (window.confirm(`Delete "${card.title}"?`)) {
       onDelete(card);
     }
@@ -174,6 +193,19 @@ export function Card({
     setAssignOpen(false);
     setPersonInput("");
     onSetAssignee?.(card, login);
+  };
+
+  // Open the reviewer picker from the stage menu's "Send to review" item.
+  const openSendToReview = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setMenuOpen(false);
+    setReviewOpen(true);
+  };
+
+  const pickReviewer = (login: string) => {
+    setReviewOpen(false);
+    setReviewerInput("");
+    onSendToReview?.(card, login);
   };
 
   const openDates = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -240,7 +272,9 @@ export function Card({
     <div
       className={`card${selected ? " card-selected" : ""}${
         card.plan ? ` card-plan-${card.plan}` : ""
-      }${taken ? " card-plan-taken" : ""}${dimAvatar ? " card-dim-avatar" : ""}`}
+      }${taken ? " card-plan-taken" : ""}${card.reviewOf ? " card-review" : ""}${
+        dimAvatar ? " card-dim-avatar" : ""
+      }`}
       onClick={() => onSelect(card)}
       onDoubleClick={() => onOpen(card)}
       title={card.title}
@@ -299,22 +333,25 @@ export function Card({
             onClose={() => setMenuOpen(false)}
             className="card-stage-menu"
           >
-            {STAGE_ORDER.map((stage) => (
-              <button
-                key={stage}
-                type="button"
-                className={`card-stage-item${card.stage === stage ? " card-stage-item-active" : ""}`}
-                onClick={(e) =>
-                  stage === "locked" ? requestLock(e) : pickStage(e, stage)
-                }
-              >
-                <span
-                  className="card-stage-dot"
-                  style={{ background: STAGES[stage].color }}
-                />
-                {STAGES[stage].label}
-              </button>
-            ))}
+            {STAGE_ORDER.map((stage) =>
+              // A review card cannot be put on the "review" stage itself.
+              stage === "review" && card.reviewOf ? null : (
+                <button
+                  key={stage}
+                  type="button"
+                  className={`card-stage-item${card.stage === stage ? " card-stage-item-active" : ""}`}
+                  onClick={(e) =>
+                    stage === "locked" ? requestLock(e) : pickStage(e, stage)
+                  }
+                >
+                  <span
+                    className="card-stage-dot"
+                    style={{ background: STAGES[stage].color }}
+                  />
+                  {STAGES[stage].label}
+                </button>
+              ),
+            )}
             <button
               type="button"
               className="card-stage-item card-stage-clear"
@@ -322,6 +359,54 @@ export function Card({
             >
               Clear
             </button>
+            {onSendToReview && !card.reviewOf && (
+              <button
+                type="button"
+                className="card-stage-item card-stage-send-review"
+                onClick={openSendToReview}
+              >
+                Send to review…
+              </button>
+            )}
+          </Dropdown>
+          <Dropdown
+            open={reviewOpen}
+            anchorRef={menuRef}
+            onClose={() => setReviewOpen(false)}
+            className="card-stage-menu card-review-menu"
+          >
+            <div className="card-assign-head">Reviewer</div>
+            {(reviewerCandidates ?? []).map((p) => (
+              <button
+                key={`rev-${p}`}
+                type="button"
+                className="card-stage-item"
+                onClick={() => pickReviewer(p)}
+              >
+                <img
+                  className="avatar-img"
+                  src={avatarUrlFor(p, users?.[p])}
+                  alt={p}
+                />
+                {displayName(p, users?.[p])}
+              </button>
+            ))}
+            <input
+              type="text"
+              className="add-card-input card-assign-input"
+              placeholder="reviewer login…"
+              value={reviewerInput}
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => setReviewerInput(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === "Enter" && reviewerInput.trim()) {
+                  pickReviewer(reviewerInput.trim());
+                } else if (e.key === "Escape") {
+                  setReviewOpen(false);
+                }
+              }}
+            />
           </Dropdown>
         </div>
         <button

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -186,6 +186,26 @@ export function MeBoard({
     reload();
   };
 
+  // Drive an original card's review stage from its review card's progress:
+  // at 100% the original leaves review; below 100% it (re)enters review.
+  const syncOriginalReview = (original: CardModel, reviewProgress: number) => {
+    let next: StageKey | null | undefined;
+    if (reviewProgress === 100 && original.stage === "review") {
+      next = null;
+    } else if (reviewProgress < 100 && original.stage !== "review") {
+      next = "review";
+    }
+    if (next === undefined) {
+      return;
+    }
+    const prevStage = original.stage;
+    patchCard(original.itemId, { stage: next ?? undefined });
+    void provider.setStage(board, original, next).catch((err: unknown) => {
+      patchCard(original.itemId, { stage: prevStage });
+      onError(errMessage(err));
+    });
+  };
+
   const handleProgress = (card: CardModel, value: number) => {
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
@@ -214,6 +234,14 @@ export function MeBoard({
         onError(errMessage(err));
       }
     })();
+
+    // When this is a review card, its progress drives the original's review stage.
+    if (card.reviewOf) {
+      const original = board.cards.find((c) => c.itemId === card.reviewOf);
+      if (original) {
+        syncOriginalReview(original, value);
+      }
+    }
   };
 
   const handleStage = (card: CardModel, stage: StageKey | null) => {
@@ -225,11 +253,23 @@ export function MeBoard({
     if (stage === "done") {
       patch.progress = 100;
     }
+    // review/locked cards can never sit at 100%: knock a full card down to 90%.
+    const dropTo90 =
+      (stage === "review" || stage === "locked") && card.progress === 100;
+    if (dropTo90) {
+      patch.progress = 90;
+    }
     patchCard(card.itemId, patch);
     void provider.setStage(board, card, stage).catch((err: unknown) => {
       patchCard(card.itemId, prev);
       onError(errMessage(err));
     });
+    if (dropTo90) {
+      void provider.setProgress(board, card, 90).catch((err: unknown) => {
+        patchCard(card.itemId, { progress: prev.progress });
+        onError(errMessage(err));
+      });
+    }
   };
 
   const handleSetTeam = (card: CardModel, team: string | null) => {
@@ -264,9 +304,108 @@ export function MeBoard({
   };
 
   const handleDelete = (card: CardModel) => {
+    // If a review card links back to this one, delete both (with one confirm).
+    const linkedReview = board.cards.find((c) => c.reviewOf === card.itemId);
+    if (linkedReview) {
+      if (
+        !window.confirm(
+          `Delete this card and its linked review card «${linkedReview.title}»?`,
+        )
+      ) {
+        return;
+      }
+      removeCard(linkedReview.itemId);
+      void provider.deleteCard(board, linkedReview).catch((err: unknown) => {
+        addCard(linkedReview);
+        onError(errMessage(err));
+      });
+    }
     removeCard(card.itemId);
     void provider.deleteCard(board, card).catch((err: unknown) => {
       addCard(card);
+      onError(errMessage(err));
+    });
+  };
+
+  // Item ids of cards that already have a linked review card (delete cascades).
+  const reviewedItemIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const c of board.cards) {
+      if (c.reviewOf) {
+        s.add(c.reviewOf);
+      }
+    }
+    return s;
+  }, [board.cards]);
+
+  // Reviewer suggestions: people on the same team as the card, minus its own
+  // assignee(s). The picker also accepts a free-text login.
+  const reviewersFor = (card: CardModel): string[] => {
+    const set = new Set<string>();
+    for (const c of board.cards) {
+      if ((c.team ?? "") !== (card.team ?? "")) {
+        continue;
+      }
+      for (const login of c.assignees) {
+        set.add(login);
+      }
+    }
+    for (const a of card.assignees) {
+      set.delete(a);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b));
+  };
+
+  // Send a card to review: create a linked review card for the reviewer (in the
+  // yellow/unplanned zone on the Me board) and put the original on review.
+  const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
+    const team = card.team ?? null;
+    const zone: ZoneKey = "yellow";
+    const sprintStart = sprintForNewCard(board.cards, team, selectedDate);
+    const title = `review: ${card.title}`;
+    const tempId = `tmp-${new Date().toISOString()}`;
+    const optimistic: CardModel = {
+      itemId: tempId,
+      title,
+      isDraft: true,
+      assignees: [reviewerLogin],
+      zone,
+      zoneOptionId: optionIdForZone(roles.zone, zone),
+      day: selectedDate,
+      startDate: selectedDate,
+      sprintStart,
+      team: team ?? undefined,
+      reviewOf: card.itemId,
+      createdAt: new Date().toISOString(),
+      description: "",
+      notes: [],
+    };
+    addCard(optimistic);
+    void provider
+      .createCard(board, {
+        title,
+        zone,
+        day: selectedDate,
+        start: selectedDate,
+        sprintStart,
+        assigneeLogin: reviewerLogin,
+        team,
+        reviewOf: card.itemId,
+      })
+      .then((created) => {
+        removeCard(tempId);
+        addCard(created);
+      })
+      .catch((err: unknown) => {
+        removeCard(tempId);
+        onError(errMessage(err));
+      });
+
+    // Put the original on the review stage.
+    const prevStage = card.stage;
+    patchCard(card.itemId, { stage: "review" });
+    void provider.setStage(board, card, "review").catch((err: unknown) => {
+      patchCard(card.itemId, { stage: prevStage });
       onError(errMessage(err));
     });
   };
@@ -523,7 +662,11 @@ export function MeBoard({
                   onOpen={onOpen}
                   onRequestLock={onRequestLock}
                   teams={teams}
+                  users={users}
                   onSetTeam={handleSetTeam}
+                  onSendToReview={handleSendToReview}
+                  reviewerCandidates={reviewersFor(card)}
+                  hasLinkedReview={reviewedItemIds.has(card.itemId)}
                   asOf={selectedDate}
                   dimAvatar={
                     teamFilter === null || (card.team ?? "") !== teamFilter

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -401,13 +401,9 @@ export function MeBoard({
         onError(errMessage(err));
       });
 
-    // Put the original on the review stage.
-    const prevStage = card.stage;
-    patchCard(card.itemId, { stage: "review" });
-    void provider.setStage(board, card, "review").catch((err: unknown) => {
-      patchCard(card.itemId, { stage: prevStage });
-      onError(errMessage(err));
-    });
+    // Put the original on review. handleStage also drops a 100% card to 90%,
+    // since review/locked can't sit at full.
+    handleStage(card, "review");
   };
 
   // The 4 sortable groups: one per zone, in ZONE_ORDER (top → bottom).

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -10,7 +10,7 @@ import type {
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
 import { todayIso, localDateIso, addDays } from "../date";
-import { currentSprintByTeam, sprintForNewCard } from "../sprint";
+import { currentSprint } from "../sprint";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
 import { AddCard } from "./AddCard";
@@ -96,15 +96,10 @@ export function MeBoard({
     [board.cards, viewMe],
   );
 
-  // Per team, the latest sprint started on or before the selected day.
-  const currentSprint = useMemo(
-    () => currentSprintByTeam(mine, selectedDate),
-    [mine, selectedDate],
-  );
-
   // A card shows within its [start, sprint] range, and keeps showing on later
-  // days while it stays its team's current sprint — so in Me cards stay visible
-  // the next day until a new sprint is started.
+  // days while it is still its team's current sprint (per the explicit state) —
+  // so in Me cards stay visible until a new sprint is started (even by someone
+  // else, or by an unassigned card advancing the team's pointer).
   const myCards = useMemo(
     () =>
       mine.filter((c) => {
@@ -113,9 +108,11 @@ export function MeBoard({
         if (!start || !sprint || selectedDate < start) {
           return false;
         }
-        return selectedDate <= sprint || currentSprint.get(c.team ?? "") === sprint;
+        return (
+          selectedDate <= sprint || currentSprint(board, c.team ?? null) === sprint
+        );
       }),
-    [mine, currentSprint, selectedDate],
+    [mine, board, selectedDate],
   );
 
   const byZone = useMemo(() => {
@@ -275,10 +272,10 @@ export function MeBoard({
   const handleSetTeam = (card: CardModel, team: string | null) => {
     const prevTeam = card.team;
     const prevSprint = card.sprintStart;
-    // Join the new team's running sprint, so a card moved between teams stays
-    // visible instead of dropping off when its old sprint predates the new
-    // team's current one (mirrors how a freshly created card joins a sprint).
-    const sprintStart = sprintForNewCard(board.cards, team ?? null, selectedDate);
+    // Join the new team's current sprint (its explicit state), so a card moved
+    // between teams stays visible instead of dropping off when its old sprint
+    // predates the new team's current one. Fall back to the selected day.
+    const sprintStart = currentSprint(board, team) ?? selectedDate;
     patchCard(card.itemId, { team: team ?? undefined, sprintStart });
     void provider.setTeam(board, card, team).catch((err: unknown) => {
       patchCard(card.itemId, { team: prevTeam });
@@ -361,7 +358,7 @@ export function MeBoard({
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
     const zone: ZoneKey = "yellow";
-    const sprintStart = sprintForNewCard(board.cards, team, selectedDate);
+    const sprintStart = currentSprint(board, team) ?? selectedDate;
     const title = `review: ${card.title}`;
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
@@ -458,11 +455,10 @@ export function MeBoard({
 
   const handleCreate = (zone: ZoneKey, title: string, team?: string | null) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // Join the team's current sprint instead of starting a new one, so adding a
-    // card on a later day does not look like a new sprint and hide the rest. The
-    // start date is the day it was created, so a card added during a running
-    // sprint does not appear retroactively on the sprint's earlier days.
-    const sprintStart = sprintForNewCard(board.cards, team ?? null, selectedDate);
+    // Join the team's current sprint (its explicit state) instead of starting a
+    // new one, so adding a card on a later day does not look like a new sprint
+    // and hide the rest. Fall back to the selected day when the team has none.
+    const sprintStart = currentSprint(board, team ?? null) ?? selectedDate;
     const optimistic: CardModel = {
       itemId: tempId,
       title,

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -865,13 +865,9 @@ export function TeamBoard({
         onError(errMessage(err));
       });
 
-    // Put the original on the review stage.
-    const prevStage = card.stage;
-    patchCard(card.itemId, { stage: "review" });
-    void provider.setStage(board, card, "review").catch((err: unknown) => {
-      patchCard(card.itemId, { stage: prevStage });
-      onError(errMessage(err));
-    });
+    // Put the original on review. handleStage also drops a 100% card to 90%,
+    // since review/locked can't sit at full.
+    handleStage(card, "review");
   };
 
   const handleSetDates = (

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -15,8 +15,8 @@ import type {
 } from "../providers/types";
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
-import { todayIso, addDays, activeOnDay, mondayOf } from "../date";
-import { currentSprintByTeam, sprintForNewCard } from "../sprint";
+import { todayIso, addDays, mondayOf } from "../date";
+import { currentSprint, previousSprint } from "../sprint";
 import { teamColor } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
@@ -59,17 +59,6 @@ type TeamMeta =
 
 const UNASSIGNED = "";
 
-/** A Team grid create awaiting the start-new-sprint vs join-current choice. */
-interface PendingCreate {
-  engineer: string;
-  zone: ZoneKey;
-  title: string;
-  /** Target team (null = the no-team group). */
-  team: string | null;
-  /** The team's current sprint start (max sprintStart ≤ today), "" if none. */
-  cur: string;
-}
-
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
@@ -99,7 +88,6 @@ export function TeamBoard({
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [sprintMenuOpen, setSprintMenuOpen] = useState(false);
   const sprintRef = useRef<HTMLDivElement | null>(null);
-  const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(null);
   const [carryWeekOpen, setCarryWeekOpen] = useState(false);
   const carryWeekRef = useRef<HTMLDivElement | null>(null);
   const [columnOrder, setColumnOrder] = useState<string[]>(() => {
@@ -204,29 +192,29 @@ export function TeamBoard({
     [board.cards, teamFilter],
   );
 
-  // A card shows on every day of its [startDate, sprintStart] range — i.e. on its
-  // sprint day. The day after the sprint day goes empty, which is the cue for the
-  // lead to carry the cards over (or start a new sprint).
+  // The grid shows the sprint of the selected day: cards whose sprintStart is
+  // exactly that day. The day after the sprint goes empty, which is the cue for
+  // the lead to carry the cards over (start the next sprint).
   const filteredCards = useMemo(
-    () =>
-      inFilter.filter((c) =>
-        activeOnDay(c.startDate, c.sprintStart, selectedDate),
-      ),
+    () => inFilter.filter((c) => c.sprintStart === selectedDate),
     [inFilter, selectedDate],
   );
 
-  // Latest sprint start on or before today among the visible (team-filtered)
-  // cards — where "Go to current sprint" jumps. Null when there is no sprint.
-  const currentSprintStart = useMemo(() => {
-    const today = todayIso();
-    let latest = "";
-    for (const c of inFilter) {
-      if (c.sprintStart && c.sprintStart <= today && c.sprintStart > latest) {
-        latest = c.sprintStart;
+  // The previous sprint to jump to for the "Last sprint" button: the filtered
+  // team's previous sprint, or the latest previous across teams when unfiltered.
+  // Null when there is no previous sprint to go back to.
+  const lastSprintStart = useMemo(() => {
+    if (teamFilter !== null) {
+      return previousSprint(board, teamFilter);
+    }
+    let latest: string | null = null;
+    for (const s of Object.values(board.sprintStates)) {
+      if (s.previous && (latest === null || s.previous > latest)) {
+        latest = s.previous;
       }
     }
-    return latest || null;
-  }, [inFilter]);
+    return latest;
+  }, [board, teamFilter]);
 
   const currentWeek = useMemo(() => mondayOf(selectedDate), [selectedDate]);
 
@@ -393,6 +381,9 @@ export function TeamBoard({
     const zone = dropZone ?? card.zone ?? "gray";
     const optionId = optionIdForZone(roles.zone, zone) ?? card.zoneOptionId;
     const zoneChanged = zone !== card.zone;
+    // Join the card's team's current sprint (its explicit state), falling back to
+    // the selected day when the team has none yet.
+    const sprintStart = currentSprint(board, card.team ?? null) ?? selectedDate;
     const prev: Partial<CardModel> = {
       assignees: card.assignees,
       zone: card.zone,
@@ -403,7 +394,7 @@ export function TeamBoard({
       assignees: login ? [login] : [],
       zone,
       zoneOptionId: optionId,
-      sprintStart: selectedDate,
+      sprintStart,
     });
     void (async () => {
       try {
@@ -411,7 +402,7 @@ export function TeamBoard({
         if (zoneChanged && optionId) {
           await provider.setZone(board, card, optionId);
         }
-        await provider.setSprintStart(board, card, selectedDate);
+        await provider.setSprintStart(board, card, sprintStart);
       } catch (err: unknown) {
         patchCard(card.itemId, prev);
         onError(errMessage(err));
@@ -753,20 +744,10 @@ export function TeamBoard({
     });
   };
 
-  // The latest sprint/week on the board for the card's team strictly before the
-  // card's current one — where deleting demotes the card instead of removing it.
-  const previousSprintFor = (card: CardModel): string | null => {
-    const team = card.team ?? "";
-    const cur = card.sprintStart;
-    if (!cur) return null;
-    let prev: string | null = null;
-    for (const c of board.cards) {
-      if (c.itemId === card.itemId || (c.team ?? "") !== team) continue;
-      if (!c.sprintStart || c.sprintStart >= cur) continue;
-      if (prev === null || c.sprintStart > prev) prev = c.sprintStart;
-    }
-    return prev;
-  };
+  // The team's explicit previous sprint — where deleting a grid card demotes it
+  // (back to last sprint) instead of removing it.
+  const previousSprintFor = (card: CardModel): string | null =>
+    previousSprint(board, card.team ?? null);
 
   const previousWeekFor = (card: CardModel): string | null => {
     const team = card.team ?? "";
@@ -861,10 +842,10 @@ export function TeamBoard({
   const handleSetTeam = (card: CardModel, team: string | null) => {
     const prevTeam = card.team;
     const prevSprint = card.sprintStart;
-    // Join the new team's running sprint, so a card moved between teams stays
-    // visible instead of dropping off when its old sprint predates the new
-    // team's current one (mirrors how a freshly created card joins a sprint).
-    const sprintStart = sprintForNewCard(board.cards, team ?? null, selectedDate);
+    // Join the new team's current sprint (its explicit state), so a card moved
+    // between teams stays visible instead of dropping off when its old sprint
+    // predates the new team's current one. Fall back to the selected day.
+    const sprintStart = currentSprint(board, team) ?? selectedDate;
     patchCard(card.itemId, { team: team ?? undefined, sprintStart });
     void provider.setTeam(board, card, team).catch((err: unknown) => {
       patchCard(card.itemId, { team: prevTeam });
@@ -923,7 +904,7 @@ export function TeamBoard({
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
     const zone: ZoneKey = card.zone ?? "gray";
-    const sprintStart = sprintForNewCard(board.cards, team, selectedDate);
+    const sprintStart = currentSprint(board, team) ?? selectedDate;
     const title = `review: ${card.title}`;
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
@@ -990,8 +971,7 @@ export function TeamBoard({
   };
 
   // Optimistically create a Team grid card with explicit sprint dates and push
-  // it to the provider. Shared by the silent-join and start-new-sprint paths;
-  // only startDate/sprintStart/day differ between them.
+  // it to the provider.
   const createTeamCard = (
     engineer: string,
     zone: ZoneKey,
@@ -1037,10 +1017,10 @@ export function TeamBoard({
       });
   };
 
-  // Creating a Team card joins the team's running sprint; when that sprint is all
-  // done (or the team has none) it asks whether to start a new sprint. Start date
-  // is always the sprint's start day, so the card shows only on that day and the
-  // day after stays empty.
+  // Creating a Team card joins the team's current sprint (from its explicit
+  // state). A team with no sprint yet starts its first one off this card. Start
+  // date is the sprint's start day, so the card shows only on that day and the
+  // day after stays empty (the cue to carry over).
   const handleCreate = (
     engineer: string,
     zone: ZoneKey,
@@ -1048,66 +1028,52 @@ export function TeamBoard({
     team?: string | null,
   ) => {
     const teamKey = team ?? null;
-    const today = todayIso();
-    // The team's current sprint: max sprintStart ≤ today; "" if it has none.
-    const cur = currentSprintByTeam(board.cards, today).get(team ?? "") ?? "";
-    const running =
-      cur !== "" &&
-      board.cards.some(
-        (c) =>
-          (c.team ?? "") === (team ?? "") &&
-          c.sprintStart === cur &&
-          c.stage !== "done",
-      );
-    if (running) {
-      // Join the running sprint silently: start date = the sprint's start day,
-      // day = today.
-      createTeamCard(engineer, zone, title, teamKey, cur, cur, today);
-      return;
+    let sprint = currentSprint(board, teamKey);
+    if (sprint === null) {
+      // First sprint for this team: record it on the state card, then reload to
+      // pick up the advance (later cards then join it).
+      sprint = selectedDate;
+      void provider
+        .setSprintState(board, teamKey, selectedDate, null)
+        .then(() => reload())
+        .catch((err: unknown) => onError(errMessage(err)));
     }
-    // The current sprint is all done (or the team has none) — starting this card
-    // would start a NEW sprint, so confirm first.
-    setPendingCreate({ engineer, zone, title, team: teamKey, cur });
+    createTeamCard(engineer, zone, title, teamKey, sprint, sprint, todayIso());
   };
 
-  // Carry over a team's unfinished cards from earlier sprints into the selected
-  // day's sprint. `team` is null for the no-team group.
-  const startSprint = (team: string | null) => {
+  // Carry over: advance the team's sprint to today (the prior current becomes the
+  // previous) and pull its unfinished cards forward. Always advances, even with
+  // nothing to carry. `team` is null for the no-team group.
+  const startSprint = async (team: string | null) => {
     setSprintMenuOpen(false);
     const label = team ?? "no team";
+    const old = currentSprint(board, team);
+    const today = todayIso();
     const carry = board.cards.filter(
       (c) =>
         (team === null ? c.team == null : c.team === team) &&
+        c.sprintStart === old &&
         c.stage !== "done" &&
-        !c.itemId.startsWith("tmp-") &&
-        // Only cards that were actually in an earlier sprint — not date-less
-        // orphans (which have no sprintStart and aren't visible on any day).
-        c.sprintStart != null &&
-        c.sprintStart < selectedDate,
+        !c.itemId.startsWith("tmp-"),
     );
-    if (carry.length === 0) {
-      onError(
-        `Nothing to carry over for "${label}" — add cards on ${selectedDate} to start the sprint.`,
-      );
-      return;
-    }
     if (
       !window.confirm(
-        `Carry over ${carry.length} unfinished card(s) for "${label}" into ${selectedDate}?`,
+        `Start a new sprint for «${label}» (${today})? ${carry.length} unfinished card(s) carried over.`,
       )
     ) {
       return;
     }
-    for (const card of carry) {
-      const prev = card.sprintStart;
-      patchCard(card.itemId, { sprintStart: selectedDate });
-      void provider
-        .setSprintStart(board, card, selectedDate)
-        .catch((err: unknown) => {
-          patchCard(card.itemId, { sprintStart: prev });
-          onError(errMessage(err));
-        });
+    try {
+      await provider.setSprintState(board, team, today, old);
+      for (const card of carry) {
+        patchCard(card.itemId, { sprintStart: today });
+        await provider.setSprintStart(board, card, today);
+      }
+    } catch (err: unknown) {
+      onError(errMessage(err));
     }
+    // Re-read the advanced state (and reconcile the carried cards).
+    reload();
   };
 
   return (
@@ -1168,15 +1134,15 @@ export function TeamBoard({
           type="button"
           className="btn"
           onClick={() => {
-            if (currentSprintStart) {
-              setSelectedDate(currentSprintStart);
+            if (lastSprintStart) {
+              setSelectedDate(lastSprintStart);
             }
           }}
-          disabled={!currentSprintStart}
-          title="Go to the current sprint's start day"
-          aria-label="Go to current sprint"
+          disabled={!lastSprintStart}
+          title="Go to the previous sprint's start day"
+          aria-label="Go to last sprint"
         >
-          ⏮ Current sprint
+          ⏮ Last sprint
         </button>
         <div className="sprint-wrap" ref={sprintRef}>
           <button
@@ -1186,10 +1152,10 @@ export function TeamBoard({
               if (teamFilter === null) {
                 setSprintMenuOpen((o) => !o);
               } else {
-                startSprint(teamFilter === "" ? null : teamFilter);
+                void startSprint(teamFilter === "" ? null : teamFilter);
               }
             }}
-            title={`Carry unfinished cards into the ${selectedDate} sprint`}
+            title={`Start a new sprint (today) for the selected team`}
           >
             Carry over{teamFilter === null ? " ▾" : " →"}
           </button>
@@ -1200,7 +1166,7 @@ export function TeamBoard({
                   key={t}
                   type="button"
                   className="card-stage-item"
-                  onClick={() => startSprint(t)}
+                  onClick={() => void startSprint(t)}
                 >
                   <span className="team-dot" style={{ background: teamColor(t) }} />
                   {t}
@@ -1209,7 +1175,7 @@ export function TeamBoard({
               <button
                 type="button"
                 className="card-stage-item card-stage-clear"
-                onClick={() => startSprint(null)}
+                onClick={() => void startSprint(null)}
               >
                 no team
               </button>
@@ -1512,84 +1478,6 @@ export function TeamBoard({
           onReorder={onReorderTeams}
           onClose={() => setTeamsModalOpen(false)}
         />
-      )}
-      {pendingCreate && (
-        <div className="modal-backdrop" onClick={() => setPendingCreate(null)}>
-          <div
-            className="modal"
-            role="dialog"
-            aria-modal="true"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="modal-header">
-              <h2 className="modal-title">Start a new sprint?</h2>
-              <button
-                type="button"
-                className="modal-close"
-                onClick={() => setPendingCreate(null)}
-                aria-label="Close"
-              >
-                ✕
-              </button>
-            </div>
-            <div className="modal-body">
-              <p>
-                All cards of the current sprint are done (or there is no sprint).
-                This card will start a new sprint for «
-                {pendingCreate.team ?? "no team"}».
-              </p>
-            </div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="btn"
-                onClick={() => setPendingCreate(null)}
-              >
-                Cancel
-              </button>
-              {pendingCreate.cur !== "" && (
-                <button
-                  type="button"
-                  className="btn"
-                  onClick={() => {
-                    const pc = pendingCreate;
-                    setPendingCreate(null);
-                    createTeamCard(
-                      pc.engineer,
-                      pc.zone,
-                      pc.title,
-                      pc.team,
-                      pc.cur,
-                      pc.cur,
-                      selectedDate,
-                    );
-                  }}
-                >
-                  Add to current sprint
-                </button>
-              )}
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={() => {
-                  const pc = pendingCreate;
-                  setPendingCreate(null);
-                  createTeamCard(
-                    pc.engineer,
-                    pc.zone,
-                    pc.title,
-                    pc.team,
-                    selectedDate,
-                    selectedDate,
-                    selectedDate,
-                  );
-                }}
-              >
-                Start new sprint
-              </button>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   );

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -596,6 +596,26 @@ export function TeamBoard({
     })();
   };
 
+  // Drive an original card's review stage from its review card's progress:
+  // at 100% the original leaves review; below 100% it (re)enters review.
+  const syncOriginalReview = (original: CardModel, reviewProgress: number) => {
+    let next: StageKey | null | undefined;
+    if (reviewProgress === 100 && original.stage === "review") {
+      next = null;
+    } else if (reviewProgress < 100 && original.stage !== "review") {
+      next = "review";
+    }
+    if (next === undefined) {
+      return;
+    }
+    const prevStage = original.stage;
+    patchCard(original.itemId, { stage: next ?? undefined });
+    void provider.setStage(board, original, next).catch((err: unknown) => {
+      patchCard(original.itemId, { stage: prevStage });
+      onError(errMessage(err));
+    });
+  };
+
   const handleProgress = (card: CardModel, value: number) => {
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
@@ -624,6 +644,14 @@ export function TeamBoard({
         onError(errMessage(err));
       }
     })();
+
+    // When this is a review card, its progress drives the original's review stage.
+    if (card.reviewOf) {
+      const original = board.cards.find((c) => c.itemId === card.reviewOf);
+      if (original) {
+        syncOriginalReview(original, value);
+      }
+    }
   };
 
   const handleStage = (card: CardModel, stage: StageKey | null) => {
@@ -635,11 +663,23 @@ export function TeamBoard({
     if (stage === "done") {
       patch.progress = 100;
     }
+    // review/locked cards can never sit at 100%: knock a full card down to 90%.
+    const dropTo90 =
+      (stage === "review" || stage === "locked") && card.progress === 100;
+    if (dropTo90) {
+      patch.progress = 90;
+    }
     patchCard(card.itemId, patch);
     void provider.setStage(board, card, stage).catch((err: unknown) => {
       patchCard(card.itemId, prev);
       onError(errMessage(err));
     });
+    if (dropTo90) {
+      void provider.setProgress(board, card, 90).catch((err: unknown) => {
+        patchCard(card.itemId, { progress: prev.progress });
+        onError(errMessage(err));
+      });
+    }
   };
 
   const handleRename = (card: CardModel, title: string) => {
@@ -652,6 +692,22 @@ export function TeamBoard({
   };
 
   const handleDelete = (card: CardModel) => {
+    // If a review card links back to this one, delete both (with one confirm).
+    const linkedReview = board.cards.find((c) => c.reviewOf === card.itemId);
+    if (linkedReview) {
+      if (
+        !window.confirm(
+          `Delete this card and its linked review card «${linkedReview.title}»?`,
+        )
+      ) {
+        return;
+      }
+      removeCard(linkedReview.itemId);
+      void provider.deleteCard(board, linkedReview).catch((err: unknown) => {
+        addCard(linkedReview);
+        onError(errMessage(err));
+      });
+    }
     removeCard(card.itemId);
     void provider.deleteCard(board, card).catch((err: unknown) => {
       addCard(card);
@@ -731,6 +787,89 @@ export function TeamBoard({
     patchCard(card.itemId, { assignees: login ? [login] : [] });
     void provider.setAssignee(board, card, login).catch((err: unknown) => {
       patchCard(card.itemId, { assignees: prev });
+      onError(errMessage(err));
+    });
+  };
+
+  // Item ids of cards that already have a linked review card (delete cascades).
+  const reviewedItemIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const c of board.cards) {
+      if (c.reviewOf) {
+        s.add(c.reviewOf);
+      }
+    }
+    return s;
+  }, [board.cards]);
+
+  // Reviewer suggestions: people on the same team as the card, minus its own
+  // assignee(s). The picker also accepts a free-text login.
+  const reviewersFor = (card: CardModel): string[] => {
+    const set = new Set<string>();
+    for (const c of board.cards) {
+      if ((c.team ?? "") !== (card.team ?? "")) {
+        continue;
+      }
+      for (const login of c.assignees) {
+        set.add(login);
+      }
+    }
+    for (const a of card.assignees) {
+      set.delete(a);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b));
+  };
+
+  // Send a card to review: create a linked review card for the reviewer (in the
+  // original's zone on the Team board) and put the original on the review stage.
+  const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
+    const team = card.team ?? null;
+    const zone: ZoneKey = card.zone ?? "gray";
+    const sprintStart = sprintForNewCard(board.cards, team, selectedDate);
+    const title = `review: ${card.title}`;
+    const tempId = `tmp-${new Date().toISOString()}`;
+    const optimistic: CardModel = {
+      itemId: tempId,
+      title,
+      isDraft: true,
+      assignees: [reviewerLogin],
+      zone,
+      zoneOptionId: optionIdForZone(roles.zone, zone) ?? card.zoneOptionId,
+      day: selectedDate,
+      startDate: selectedDate,
+      sprintStart,
+      team: team ?? undefined,
+      reviewOf: card.itemId,
+      createdAt: new Date().toISOString(),
+      description: "",
+      notes: [],
+    };
+    addCard(optimistic);
+    void provider
+      .createCard(board, {
+        title,
+        zone,
+        day: selectedDate,
+        start: selectedDate,
+        sprintStart,
+        assigneeLogin: reviewerLogin,
+        team,
+        reviewOf: card.itemId,
+      })
+      .then((created) => {
+        removeCard(tempId);
+        addCard(created);
+      })
+      .catch((err: unknown) => {
+        removeCard(tempId);
+        onError(errMessage(err));
+      });
+
+    // Put the original on the review stage.
+    const prevStage = card.stage;
+    patchCard(card.itemId, { stage: "review" });
+    void provider.setStage(board, card, "review").catch((err: unknown) => {
+      patchCard(card.itemId, { stage: prevStage });
       onError(errMessage(err));
     });
   };
@@ -959,6 +1098,9 @@ export function TeamBoard({
               users={users}
               onSetTeam={handleSetTeam}
               onSetAssignee={handleSetAssignee}
+              onSendToReview={handleSendToReview}
+              reviewerCandidates={reviewersFor(card)}
+              hasLinkedReview={reviewedItemIds.has(card.itemId)}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               weekMode
@@ -981,6 +1123,9 @@ export function TeamBoard({
               users={users}
               onSetTeam={handleSetTeam}
               onSetAssignee={handleSetAssignee}
+              onSendToReview={handleSendToReview}
+              reviewerCandidates={reviewersFor(card)}
+              hasLinkedReview={reviewedItemIds.has(card.itemId)}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               dimAvatar

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -15,7 +15,7 @@ import type {
 } from "../providers/types";
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
-import { todayIso, addDays, mondayOf } from "../date";
+import { todayIso, addDays, activeOnDay, mondayOf } from "../date";
 import { currentSprint, previousSprint } from "../sprint";
 import { teamColor } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
@@ -192,29 +192,56 @@ export function TeamBoard({
     [board.cards, teamFilter],
   );
 
-  // The grid shows the sprint of the selected day: cards whose sprintStart is
-  // exactly that day. The day after the sprint goes empty, which is the cue for
-  // the lead to carry the cards over (start the next sprint).
+  // A card shows on every day of its [startDate, sprintStart] span. A fresh card
+  // (start === sprintStart) shows on its one sprint day; a card carried into a
+  // later sprint (sprintStart advanced past startDate) shows in BOTH its original
+  // sprint and the new one — carry over extends the task's span, not moves it.
   const filteredCards = useMemo(
-    () => inFilter.filter((c) => c.sprintStart === selectedDate),
+    () =>
+      inFilter.filter((c) =>
+        activeOnDay(c.startDate, c.sprintStart, selectedDate),
+      ),
     [inFilter, selectedDate],
   );
 
-  // The previous sprint to jump to for the "Last sprint" button: the filtered
-  // team's previous sprint, or the latest previous across teams when unfiltered.
-  // Null when there is no previous sprint to go back to.
-  const lastSprintStart = useMemo(() => {
+  // The sprint-jump button. Standing on the current sprint, it offers the
+  // previous one ("« Last sprint"). Standing anywhere else, it returns to the
+  // current sprint, the arrow pointing the way ("Current sprint »" when it is
+  // ahead in time, "« Current sprint" when it is behind). Uses the filtered
+  // team's sprint, or the latest across teams when unfiltered. Null = nowhere to
+  // jump.
+  const sprintJump = useMemo<{
+    target: string;
+    label: string;
+    dir: "back" | "fwd";
+  } | null>(() => {
+    let cur: string | null;
+    let prev: string | null;
     if (teamFilter !== null) {
-      return previousSprint(board, teamFilter);
-    }
-    let latest: string | null = null;
-    for (const s of Object.values(board.sprintStates)) {
-      if (s.previous && (latest === null || s.previous > latest)) {
-        latest = s.previous;
+      cur = currentSprint(board, teamFilter);
+      prev = previousSprint(board, teamFilter);
+    } else {
+      cur = null;
+      prev = null;
+      for (const s of Object.values(board.sprintStates)) {
+        if (s.current && (cur === null || s.current > cur)) {
+          cur = s.current;
+        }
+        if (s.previous && (prev === null || s.previous > prev)) {
+          prev = s.previous;
+        }
       }
     }
-    return latest;
-  }, [board, teamFilter]);
+    if (cur === null) {
+      return null;
+    }
+    if (selectedDate === cur) {
+      return prev ? { target: prev, label: "Last sprint", dir: "back" } : null;
+    }
+    return selectedDate < cur
+      ? { target: cur, label: "Current sprint", dir: "fwd" }
+      : { target: cur, label: "Current sprint", dir: "back" };
+  }, [board, teamFilter, selectedDate]);
 
   const currentWeek = useMemo(() => mondayOf(selectedDate), [selectedDate]);
 
@@ -1049,6 +1076,12 @@ export function TeamBoard({
     const label = team ?? "no team";
     const old = currentSprint(board, team);
     const today = todayIso();
+    // Idempotent: if the sprint is already today's, do not re-advance — that would
+    // overwrite the previous sprint, making previous = current = today.
+    if (old === today) {
+      onError(`«${label}» is already on today's sprint.`);
+      return;
+    }
     const carry = board.cards.filter(
       (c) =>
         (team === null ? c.team == null : c.team === team) &&
@@ -1134,15 +1167,17 @@ export function TeamBoard({
           type="button"
           className="btn"
           onClick={() => {
-            if (lastSprintStart) {
-              setSelectedDate(lastSprintStart);
+            if (sprintJump) {
+              setSelectedDate(sprintJump.target);
             }
           }}
-          disabled={!lastSprintStart}
-          title="Go to the previous sprint's start day"
-          aria-label="Go to last sprint"
+          disabled={!sprintJump}
+          title="Jump to a sprint's day"
+          aria-label="Jump to sprint"
         >
-          ⏮ Last sprint
+          {sprintJump?.dir === "fwd"
+            ? `${sprintJump.label} »`
+            : `« ${sprintJump?.label ?? "Last sprint"}`}
         </button>
         <div className="sprint-wrap" ref={sprintRef}>
           <button

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -168,6 +168,29 @@ export function TeamBoard({
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [sprintMenuOpen]);
 
+  // A tab left open past midnight keeps a stale "today", so the weekly plan and
+  // newly-planned cards (week = mondayOf(selectedDate)) would land on the old
+  // week and vanish from the real current week. When the tab regains focus,
+  // catch the selected day up to the real today — unless the user navigated to a
+  // specific other day. (The grid create already reads the live date directly.)
+  const lastToday = useRef(todayIso());
+  useEffect(() => {
+    const sync = () => {
+      const now = todayIso();
+      if (now === lastToday.current) {
+        return;
+      }
+      setSelectedDate((d) => (d === lastToday.current ? now : d));
+      lastToday.current = now;
+    };
+    document.addEventListener("visibilitychange", sync);
+    window.addEventListener("focus", sync);
+    return () => {
+      document.removeEventListener("visibilitychange", sync);
+      window.removeEventListener("focus", sync);
+    };
+  }, []);
+
   const roles = useMemo(() => fieldRoles(board), [board]);
 
   // Single-select: no filter shows all; otherwise match the card's group.

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -284,36 +284,39 @@ export function TeamBoard({
       });
   };
 
-  // Weekly carry over: move unfinished plan cards of the current week to next
-  // week (its own cycle, separate from the daily Carry over).
+  // Weekly carry over: pull a team's unfinished plan cards from earlier weeks
+  // into the current (selected) week — the weekly analogue of the daily sprint
+  // carry over, so a new week's empty plan can absorb last week's leftovers.
   const handleCarryWeek = (team: string | null) => {
     setCarryWeekOpen(false);
     const label = team ?? "no team";
-    const nextWeek = addDays(currentWeek, 7);
     const carry = board.cards.filter(
       (c) =>
         c.plan &&
-        c.week === currentWeek &&
+        c.week != null &&
+        c.week < currentWeek &&
         c.stage !== "done" &&
         // Skip not-yet-persisted optimistic cards (temporary ids).
         !c.itemId.startsWith("tmp-") &&
         (team === null ? c.team == null : c.team === team),
     );
     if (carry.length === 0) {
-      onError(`No unfinished plan cards for "${label}" to carry to next week.`);
+      onError(
+        `No unfinished plan cards from earlier weeks for "${label}" to carry into the week of ${currentWeek}.`,
+      );
       return;
     }
     if (
       !window.confirm(
-        `Carry over ${carry.length} unfinished plan card(s) for "${label}" to the week of ${nextWeek}?`,
+        `Carry over ${carry.length} unfinished plan card(s) for "${label}" into the week of ${currentWeek}?`,
       )
     ) {
       return;
     }
     for (const card of carry) {
       const prev = card.week;
-      patchCard(card.itemId, { week: nextWeek });
-      void provider.setWeek(board, card, nextWeek).catch((err: unknown) => {
+      patchCard(card.itemId, { week: currentWeek });
+      void provider.setWeek(board, card, currentWeek).catch((err: unknown) => {
         patchCard(card.itemId, { week: prev });
         onError(errMessage(err));
       });

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -15,7 +15,7 @@ import type {
 } from "../providers/types";
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
-import { todayIso, addDays, mondayOf } from "../date";
+import { todayIso, addDays, activeOnDay, mondayOf } from "../date";
 import { currentSprintByTeam, sprintForNewCard } from "../sprint";
 import { teamColor } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
@@ -59,6 +59,17 @@ type TeamMeta =
 
 const UNASSIGNED = "";
 
+/** A Team grid create awaiting the start-new-sprint vs join-current choice. */
+interface PendingCreate {
+  engineer: string;
+  zone: ZoneKey;
+  title: string;
+  /** Target team (null = the no-team group). */
+  team: string | null;
+  /** The team's current sprint start (max sprintStart ≤ today), "" if none. */
+  cur: string;
+}
+
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
@@ -88,6 +99,7 @@ export function TeamBoard({
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [sprintMenuOpen, setSprintMenuOpen] = useState(false);
   const sprintRef = useRef<HTMLDivElement | null>(null);
+  const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(null);
   const [carryWeekOpen, setCarryWeekOpen] = useState(false);
   const carryWeekRef = useRef<HTMLDivElement | null>(null);
   const [columnOrder, setColumnOrder] = useState<string[]>(() => {
@@ -169,29 +181,29 @@ export function TeamBoard({
     [board.cards, teamFilter],
   );
 
-  // Per-team current sprint: the latest sprintStart on or before the day.
-  const currentSprint = useMemo(
-    () => currentSprintByTeam(inFilter, selectedDate),
+  // A card shows on every day of its [startDate, sprintStart] range — i.e. on its
+  // sprint day. The day after the sprint day goes empty, which is the cue for the
+  // lead to carry the cards over (or start a new sprint).
+  const filteredCards = useMemo(
+    () =>
+      inFilter.filter((c) =>
+        activeOnDay(c.startDate, c.sprintStart, selectedDate),
+      ),
     [inFilter, selectedDate],
   );
 
-  // A card shows from its start through its sprint day, and a card of the team's
-  // CURRENT sprint stays visible on the selected day even past its sprintStart —
-  // so adding a card (which joins the running sprint) doesn't drop the others.
-  const filteredCards = useMemo(
-    () =>
-      inFilter.filter((c) => {
-        const start = c.startDate ?? c.sprintStart;
-        const sprint = c.sprintStart;
-        if (!start || !sprint || selectedDate < start) {
-          return false;
-        }
-        return (
-          selectedDate <= sprint || currentSprint.get(c.team ?? "") === sprint
-        );
-      }),
-    [inFilter, currentSprint, selectedDate],
-  );
+  // Latest sprint start on or before today among the visible (team-filtered)
+  // cards — where "Go to current sprint" jumps. Null when there is no sprint.
+  const currentSprintStart = useMemo(() => {
+    const today = todayIso();
+    let latest = "";
+    for (const c of inFilter) {
+      if (c.sprintStart && c.sprintStart <= today && c.sprintStart > latest) {
+        latest = c.sprintStart;
+      }
+    }
+    return latest || null;
+  }, [inFilter]);
 
   const currentWeek = useMemo(() => mondayOf(selectedDate), [selectedDate]);
 
@@ -891,25 +903,27 @@ export function TeamBoard({
     })();
   };
 
-  const handleCreate = (
+  // Optimistically create a Team grid card with explicit sprint dates and push
+  // it to the provider. Shared by the silent-join and start-new-sprint paths;
+  // only startDate/sprintStart/day differ between them.
+  const createTeamCard = (
     engineer: string,
     zone: ZoneKey,
     title: string,
-    team?: string | null,
+    team: string | null,
+    startDate: string,
+    sprintStart: string,
+    day: string,
   ) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // Join the team's running sprint instead of starting a new one (an empty day
-    // still starts a fresh sprint, since sprintForNewCard falls back to today), so
-    // adding a card doesn't drop the other cards of the current sprint.
-    const sprintStart = sprintForNewCard(board.cards, team ?? null, selectedDate);
     const optimistic: CardModel = {
       itemId: tempId,
       title,
       isDraft: true,
       assignees: engineer ? [engineer] : [],
       zone,
-      day: selectedDate,
-      startDate: selectedDate,
+      day,
+      startDate,
       sprintStart,
       team: team ?? undefined,
       createdAt: new Date().toISOString(),
@@ -921,11 +935,11 @@ export function TeamBoard({
       .createCard(board, {
         title,
         zone,
-        day: selectedDate,
-        start: selectedDate,
+        day,
+        start: startDate,
         sprintStart,
         assigneeLogin: engineer || null,
-        team: team ?? null,
+        team,
       })
       .then((card) => {
         removeCard(tempId);
@@ -935,6 +949,39 @@ export function TeamBoard({
         removeCard(tempId);
         onError(errMessage(err));
       });
+  };
+
+  // Creating a Team card joins the team's running sprint; when that sprint is all
+  // done (or the team has none) it asks whether to start a new sprint. Start date
+  // is always the sprint's start day, so the card shows only on that day and the
+  // day after stays empty.
+  const handleCreate = (
+    engineer: string,
+    zone: ZoneKey,
+    title: string,
+    team?: string | null,
+  ) => {
+    const teamKey = team ?? null;
+    const today = todayIso();
+    // The team's current sprint: max sprintStart ≤ today; "" if it has none.
+    const cur = currentSprintByTeam(board.cards, today).get(team ?? "") ?? "";
+    const running =
+      cur !== "" &&
+      board.cards.some(
+        (c) =>
+          (c.team ?? "") === (team ?? "") &&
+          c.sprintStart === cur &&
+          c.stage !== "done",
+      );
+    if (running) {
+      // Join the running sprint silently: start date = the sprint's start day,
+      // day = today.
+      createTeamCard(engineer, zone, title, teamKey, cur, cur, today);
+      return;
+    }
+    // The current sprint is all done (or the team has none) — starting this card
+    // would start a NEW sprint, so confirm first.
+    setPendingCreate({ engineer, zone, title, team: teamKey, cur });
   };
 
   // Carry over a team's unfinished cards from earlier sprints into the selected
@@ -1030,6 +1077,20 @@ export function TeamBoard({
           aria-label="Shuffle columns"
         >
           ⇄
+        </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => {
+            if (currentSprintStart) {
+              setSelectedDate(currentSprintStart);
+            }
+          }}
+          disabled={!currentSprintStart}
+          title="Go to the current sprint's start day"
+          aria-label="Go to current sprint"
+        >
+          ⏮ Current sprint
         </button>
         <div className="sprint-wrap" ref={sprintRef}>
           <button
@@ -1365,6 +1426,84 @@ export function TeamBoard({
           onReorder={onReorderTeams}
           onClose={() => setTeamsModalOpen(false)}
         />
+      )}
+      {pendingCreate && (
+        <div className="modal-backdrop" onClick={() => setPendingCreate(null)}>
+          <div
+            className="modal"
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="modal-header">
+              <h2 className="modal-title">Start a new sprint?</h2>
+              <button
+                type="button"
+                className="modal-close"
+                onClick={() => setPendingCreate(null)}
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="modal-body">
+              <p>
+                All cards of the current sprint are done (or there is no sprint).
+                This card will start a new sprint for «
+                {pendingCreate.team ?? "no team"}».
+              </p>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn"
+                onClick={() => setPendingCreate(null)}
+              >
+                Cancel
+              </button>
+              {pendingCreate.cur !== "" && (
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => {
+                    const pc = pendingCreate;
+                    setPendingCreate(null);
+                    createTeamCard(
+                      pc.engineer,
+                      pc.zone,
+                      pc.title,
+                      pc.team,
+                      pc.cur,
+                      pc.cur,
+                      selectedDate,
+                    );
+                  }}
+                >
+                  Add to current sprint
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => {
+                  const pc = pendingCreate;
+                  setPendingCreate(null);
+                  createTeamCard(
+                    pc.engineer,
+                    pc.zone,
+                    pc.title,
+                    pc.team,
+                    selectedDate,
+                    selectedDate,
+                    selectedDate,
+                  );
+                }}
+              >
+                Start new sprint
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -730,10 +730,60 @@ export function TeamBoard({
     });
   };
 
+  // The latest sprint/week on the board for the card's team strictly before the
+  // card's current one — where deleting demotes the card instead of removing it.
+  const previousSprintFor = (card: CardModel): string | null => {
+    const team = card.team ?? "";
+    const cur = card.sprintStart;
+    if (!cur) return null;
+    let prev: string | null = null;
+    for (const c of board.cards) {
+      if (c.itemId === card.itemId || (c.team ?? "") !== team) continue;
+      if (!c.sprintStart || c.sprintStart >= cur) continue;
+      if (prev === null || c.sprintStart > prev) prev = c.sprintStart;
+    }
+    return prev;
+  };
+
+  const previousWeekFor = (card: CardModel): string | null => {
+    const team = card.team ?? "";
+    const cur = card.week;
+    if (!cur) return null;
+    let prev: string | null = null;
+    for (const c of board.cards) {
+      if (c.itemId === card.itemId || (c.team ?? "") !== team) continue;
+      if (!c.week || c.week >= cur) continue;
+      if (prev === null || c.week > prev) prev = c.week;
+    }
+    return prev;
+  };
+
   // Deleting a taken plan card from the grid releases it (clears assignee + the
-  // daily sprint) instead of deleting it, so it stays in the weekly plan.
+  // daily sprint) instead of deleting it, so it stays in the weekly plan. A plain
+  // grid card is demoted to its previous sprint (if any) rather than deleted.
   const handleGridDelete = (card: CardModel) => {
     if (!card.plan) {
+      const prevSprint = previousSprintFor(card);
+      if (prevSprint) {
+        const prev: Partial<CardModel> = {
+          startDate: card.startDate,
+          sprintStart: card.sprintStart,
+        };
+        patchCard(card.itemId, {
+          startDate: prevSprint,
+          sprintStart: prevSprint,
+        });
+        void (async () => {
+          try {
+            await provider.setStart(board, card, prevSprint);
+            await provider.setSprintStart(board, card, prevSprint);
+          } catch (err: unknown) {
+            patchCard(card.itemId, prev);
+            onError(errMessage(err));
+          }
+        })();
+        return;
+      }
       handleDelete(card);
       return;
     }
@@ -754,10 +804,20 @@ export function TeamBoard({
   };
 
   // Remove a card from the weekly plan. If it was taken into work (assigned) it
-  // stays on the board — only the weekly marker (Plan + Week) is cleared;
-  // otherwise it is a pure plan card and gets deleted.
+  // stays on the board — only the weekly marker (Plan + Week) is cleared. A pure
+  // plan card is demoted to its previous week (if any) instead of being deleted.
   const removeFromPlan = (card: CardModel) => {
     if (card.assignees.length === 0) {
+      const prevWeek = previousWeekFor(card);
+      if (prevWeek) {
+        const prev: Partial<CardModel> = { week: card.week };
+        patchCard(card.itemId, { week: prevWeek });
+        void provider.setWeek(board, card, prevWeek).catch((err: unknown) => {
+          patchCard(card.itemId, prev);
+          onError(errMessage(err));
+        });
+        return;
+      }
       handleDelete(card);
       return;
     }

--- a/web/src/providers/fields.ts
+++ b/web/src/providers/fields.ts
@@ -13,6 +13,7 @@ const ALIASES: Record<keyof FieldRoles, string[]> = {
   status: ["status", "статус"],
   stage: ["stage", "состояние"],
   team: ["team", "команда"],
+  reviewOf: ["review of", "reviewof"],
 };
 
 /** fieldRoles maps a board's fields onto well-known roles by name. */

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -248,6 +248,8 @@ function mapItem(item: RawItem, roles: FieldRoles): Card {
       card.status = value.name;
     } else if (roles.team && fieldID === roles.team.id && value.text) {
       card.team = value.text;
+    } else if (roles.reviewOf && fieldID === roles.reviewOf.id && value.text) {
+      card.reviewOf = value.text;
     }
   }
   return card;
@@ -339,6 +341,7 @@ const FIELD_SPECS: Partial<Record<keyof FieldRoles, FieldSpec>> = {
   },
   week: { name: "Week", dataType: "DATE" },
   team: { name: "Team", dataType: "TEXT" },
+  reviewOf: { name: "Review Of", dataType: "TEXT" },
 };
 
 interface CreatedField {
@@ -673,6 +676,15 @@ export const githubProvider: Provider = {
         value: input.team,
       });
     }
+    if (input.reviewOf) {
+      const field = await ensureField(board, "reviewOf", "Review Of");
+      await graphql(SET_TEXT, {
+        project: board.id,
+        item: item.id,
+        field: field.id,
+        value: input.reviewOf,
+      });
+    }
     if (input.plan) {
       const planField = await ensureField(board, "plan", "Plan");
       const optionId = planField.options?.find(
@@ -711,6 +723,7 @@ export const githubProvider: Provider = {
       plan: input.plan ?? undefined,
       week: input.week ?? undefined,
       team: input.team ?? undefined,
+      reviewOf: input.reviewOf ?? undefined,
       // The item was just created; without this the age badge (and its date
       // editor) would not render until the next full board reload.
       createdAt: new Date().toISOString(),

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -101,7 +101,10 @@ interface RawProject {
   title: string;
   url: string;
   fields: { nodes: RawField[] };
-  items: { nodes: RawItem[] };
+  items: {
+    nodes: RawItem[];
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
 }
 
 interface ProjectResult {
@@ -282,19 +285,51 @@ function mapProject(owner: string, raw: RawProject): Board {
 }
 
 async function loadProject(owner: string, number: number): Promise<RawProject> {
+  // Resolve org-vs-user once, then page through every item. A board can hold more
+  // than the 100-item GraphQL page size, and without paging the newest cards fall
+  // off the load and "disappear" after a refresh.
+  let first: RawProject | undefined;
+  let isOrg = true;
   try {
-    const data = await graphql<ProjectResult>(ORG_PROJECT_QUERY, { owner, number });
-    if (data.organization?.projectV2) {
-      return data.organization.projectV2;
-    }
+    const data = await graphql<ProjectResult>(ORG_PROJECT_QUERY, {
+      owner,
+      number,
+      after: null,
+    });
+    first = data.organization?.projectV2 ?? undefined;
   } catch {
     // Owner is likely a user, not an org; fall through to the user query.
   }
-  const data = await graphql<ProjectResult>(USER_PROJECT_QUERY, { owner, number });
-  if (data.user?.projectV2) {
-    return data.user.projectV2;
+  if (!first) {
+    isOrg = false;
+    const data = await graphql<ProjectResult>(USER_PROJECT_QUERY, {
+      owner,
+      number,
+      after: null,
+    });
+    first = data.user?.projectV2 ?? undefined;
   }
-  throw new Error(`Project #${number} not found for "${owner}"`);
+  if (!first) {
+    throw new Error(`Project #${number} not found for "${owner}"`);
+  }
+
+  const nodes = [...first.items.nodes];
+  let pageInfo = first.items.pageInfo;
+  const query = isOrg ? ORG_PROJECT_QUERY : USER_PROJECT_QUERY;
+  while (pageInfo?.hasNextPage && pageInfo.endCursor) {
+    const data = await graphql<ProjectResult>(query, {
+      owner,
+      number,
+      after: pageInfo.endCursor,
+    });
+    const page = isOrg ? data.organization?.projectV2 : data.user?.projectV2;
+    if (!page) {
+      break;
+    }
+    nodes.push(...page.items.nodes);
+    pageInfo = page.items.pageInfo;
+  }
+  return { ...first, items: { ...first.items, nodes } };
 }
 
 // Specs for lazily-created project fields. A missing field is created the first

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -16,6 +16,7 @@ import type {
   Note,
   ProjectField,
   Provider,
+  SprintState,
   StageKey,
 } from "../types";
 import {
@@ -116,6 +117,10 @@ interface ProjectsListResult {
   organization?: { projectsV2: { nodes: BoardSummary[] } } | null;
   user?: { projectsV2: { nodes: BoardSummary[] } } | null;
 }
+
+// SPRINT_STATE_TITLE marks the hidden per-team draft card that stores the team's
+// sprint pointer (current/previous start dates). It never shows on a board view.
+const SPRINT_STATE_TITLE = "aeman:sprint-state";
 
 // LOG_MARKER separates a draft card's description from its appended action log.
 const LOG_MARKER = "<!-- aeman:log -->";
@@ -258,6 +263,36 @@ function mapItem(item: RawItem, roles: FieldRoles): Card {
   return card;
 }
 
+/** parseSprintState reads a sprint-state card into its team key and pointer:
+ * Team text = the team ("" = no-team group), Sprint Start = current sprint,
+ * Start = previous sprint. */
+function parseSprintState(
+  item: RawItem,
+  roles: FieldRoles,
+): { team: string; state: SprintState } {
+  let team = "";
+  let current: string | null = null;
+  let previous: string | null = null;
+  for (const value of item.fieldValues.nodes) {
+    const fieldID = value.field?.id;
+    if (!fieldID) {
+      continue;
+    }
+    if (roles.team && fieldID === roles.team.id && value.text) {
+      team = value.text;
+    } else if (
+      roles.sprintStart &&
+      fieldID === roles.sprintStart.id &&
+      value.date
+    ) {
+      current = value.date;
+    } else if (roles.start && fieldID === roles.start.id && value.date) {
+      previous = value.date;
+    }
+  }
+  return { team, state: { current, previous, itemId: item.id } };
+}
+
 function mapProject(owner: string, raw: RawProject): Board {
   const fields: ProjectField[] = raw.fields.nodes
     .filter((f): f is RawField & { id: string; name: string } =>
@@ -278,9 +313,23 @@ function mapProject(owner: string, raw: RawProject): Board {
     owner,
     fields,
     cards: [],
+    sprintStates: {},
   };
   const roles = fieldRoles(board);
-  board.cards = raw.items.nodes.map((item) => mapItem(item, roles));
+  // Split the hidden sprint-state cards out of the normal cards: they carry the
+  // per-team sprint pointers and must never render on a board view.
+  const cards: Card[] = [];
+  const sprintStates: Record<string, SprintState> = {};
+  for (const item of raw.items.nodes) {
+    if (item.content?.title === SPRINT_STATE_TITLE) {
+      const { team, state } = parseSprintState(item, roles);
+      sprintStates[team] = state;
+    } else {
+      cards.push(mapItem(item, roles));
+    }
+  }
+  board.cards = cards;
+  board.sprintStates = sprintStates;
   return board;
 }
 
@@ -527,6 +576,67 @@ export const githubProvider: Provider = {
       field: field.id,
       value: date,
     });
+  },
+
+  async setSprintState(
+    board: Board,
+    team: string | null,
+    current: string | null,
+    previous: string | null,
+  ): Promise<void> {
+    // Reuse the team's existing hidden state card, or create one (a draft titled
+    // SPRINT_STATE_TITLE, no assignees) tagged with the team name.
+    let itemId = board.sprintStates[team ?? ""]?.itemId;
+    if (!itemId) {
+      const created = await graphql<{
+        addProjectV2DraftIssue: { projectItem: { id: string } };
+      }>(ADD_DRAFT, {
+        project: board.id,
+        title: SPRINT_STATE_TITLE,
+        assignees: [],
+      });
+      itemId = created.addProjectV2DraftIssue.projectItem.id;
+      if (team !== null) {
+        const teamField = await ensureField(board, "team", "Team");
+        await graphql(SET_TEXT, {
+          project: board.id,
+          item: itemId,
+          field: teamField.id,
+          value: team,
+        });
+      }
+    }
+    // Sprint Start = the current sprint; Start = the previous sprint.
+    const sprintField = await ensureField(board, "sprintStart", "Sprint Start");
+    if (current === null) {
+      await graphql(CLEAR_FIELD, {
+        project: board.id,
+        item: itemId,
+        field: sprintField.id,
+      });
+    } else {
+      await graphql(SET_DATE, {
+        project: board.id,
+        item: itemId,
+        field: sprintField.id,
+        value: current,
+      });
+    }
+    const startField = await ensureField(board, "start", "Start");
+    if (previous === null) {
+      await graphql(CLEAR_FIELD, {
+        project: board.id,
+        item: itemId,
+        field: startField.id,
+      });
+    } else {
+      await graphql(SET_DATE, {
+        project: board.id,
+        item: itemId,
+        field: startField.id,
+        value: previous,
+      });
+    }
   },
 
   async setPlan(board: Board, card: Card, plan: "wed" | "fri" | null): Promise<void> {

--- a/web/src/providers/github/queries.ts
+++ b/web/src/providers/github/queries.ts
@@ -14,7 +14,8 @@ const PROJECT_BODY = `
       ... on ProjectV2SingleSelectField { id name dataType options { id name color } }
     }
   }
-  items(first: 100) {
+  items(first: 100, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       type
@@ -67,11 +68,11 @@ const PROJECT_BODY = `
   }
 `;
 
-export const ORG_PROJECT_QUERY = `query($owner: String!, $number: Int!) {
+export const ORG_PROJECT_QUERY = `query($owner: String!, $number: Int!, $after: String) {
   organization(login: $owner) { projectV2(number: $number) { ${PROJECT_BODY} } }
 }`;
 
-export const USER_PROJECT_QUERY = `query($owner: String!, $number: Int!) {
+export const USER_PROJECT_QUERY = `query($owner: String!, $number: Int!, $after: String) {
   user(login: $owner) { projectV2(number: $number) { ${PROJECT_BODY} } }
 }`;
 

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -99,6 +99,14 @@ export interface NewCardInput {
   reviewOf?: string | null;
 }
 
+/** SprintState is a team's explicit sprint pointer, stored on a hidden
+ * "sprint-state" card: its current and previous sprint start dates. */
+export interface SprintState {
+  current: string | null;
+  previous: string | null;
+  itemId: string;
+}
+
 export interface Board {
   id: string;
   number: number;
@@ -107,6 +115,8 @@ export interface Board {
   owner: string;
   fields: ProjectField[];
   cards: Card[];
+  /** Per-team sprint pointers, keyed by team name ("" = the no-team group). */
+  sprintStates: Record<string, SprintState>;
 }
 
 /** FieldRoles resolves well-known fields by their (case-insensitive) name. */
@@ -135,6 +145,14 @@ export interface Provider {
   setDay(board: Board, card: Card, day: string | null): Promise<void>;
   setStart(board: Board, card: Card, date: string | null): Promise<void>;
   setSprintStart(board: Board, card: Card, date: string | null): Promise<void>;
+  /** Set a team's sprint pointer (current/previous start dates), creating the
+   * hidden state card if the team has none yet. team = null is the no-team group. */
+  setSprintState(
+    board: Board,
+    team: string | null,
+    current: string | null,
+    previous: string | null,
+  ): Promise<void>;
   setPlan(board: Board, card: Card, plan: "wed" | "fri" | null): Promise<void>;
   setWeek(board: Board, card: Card, date: string | null): Promise<void>;
   setAssignee(board: Board, card: Card, login: string | null): Promise<void>;

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -63,6 +63,9 @@ export interface Card {
   stage?: StageKey;
   /** Team label the card belongs to (a free-text field, used for filtering). */
   team?: string;
+  /** On a review card, the itemId of the original card it reviews (review →
+   * original; find the reverse by scanning for `reviewOf === original.itemId`). */
+  reviewOf?: string;
   /** ISO date (yyyy-mm-dd) the card is planned to finish/be due on. */
   day?: string;
   /** ISO date (yyyy-mm-dd) the card starts on (set at creation). */
@@ -92,6 +95,8 @@ export interface NewCardInput {
   week?: string | null;
   assigneeLogin?: string | null;
   team?: string | null;
+  /** On a review card, the itemId of the original card it reviews. */
+  reviewOf?: string | null;
 }
 
 export interface Board {
@@ -117,6 +122,7 @@ export interface FieldRoles {
   status?: ProjectField;
   stage?: ProjectField;
   team?: ProjectField;
+  reviewOf?: ProjectField;
 }
 
 export interface Provider {

--- a/web/src/sprint.ts
+++ b/web/src/sprint.ts
@@ -1,6 +1,21 @@
-import type { Card } from "./providers/types";
+import type { Board, Card } from "./providers/types";
 
 const teamKey = (team: string | null | undefined): string => team ?? "";
+
+/** currentSprint returns a team's current sprint start from its state card
+ * (null when the team has no sprint yet). team = null is the no-team group. */
+export function currentSprint(board: Board, team: string | null): string | null {
+  return board.sprintStates[team ?? ""]?.current ?? null;
+}
+
+/** previousSprint returns a team's previous sprint start from its state card
+ * (null when the team has no prior sprint). team = null is the no-team group. */
+export function previousSprint(
+  board: Board,
+  team: string | null,
+): string | null {
+  return board.sprintStates[team ?? ""]?.previous ?? null;
+}
 
 /** currentSprintByTeam maps each team key (team name, or "" for no team) to its
  * current sprint date: the latest sprintStart on or before `asOf`. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -410,9 +410,11 @@ button {
   box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.35);
 }
 
-/* Plan-linked cards in working views get a coloured left stripe by band. */
+/* Plan-linked cards in working views get a coloured left stripe by band; review
+   cards (linked back to an original) get a yellow stripe the same way. */
 .card-plan-wed::before,
-.card-plan-fri::before {
+.card-plan-fri::before,
+.card-review::before {
   content: "";
   position: absolute;
   left: 0;
@@ -428,6 +430,10 @@ button {
 
 .card-plan-fri::before {
   background: #8b5cf6;
+}
+
+.card-review::before {
+  background: #d4a72c;
 }
 
 /* A plan card taken into work (assigned on the board) gets a light-blue tint. */
@@ -1230,6 +1236,13 @@ button.card-age {
   border-top: 1px solid var(--line-soft);
   margin-top: 1px;
   border-radius: 0 0 4px 4px;
+}
+
+/* "Send to review" sits apart from the stage options, with its amber accent. */
+.card-stage-send-review {
+  color: #b8860b;
+  border-top: 1px solid var(--line-soft);
+  margin-top: 1px;
 }
 
 .card-stage-dot {


### PR DESCRIPTION
Stacked on #1 — base is `feat/api-mcp-server`; merge after (or together with) #1. Board work: a send-to-review workflow plus an explicit, state-driven sprint model.

## 1. Send-to-review workflow (Team + Me)

A card can be handed to a reviewer, spawning a separate, linked review card whose completion drives the original's review status.

- **Send to review** opens a reviewer picker (same-team people + free-text login); choosing one creates a linked `review: <title>` card assigned to the reviewer and puts the original on the `review` stage. Target zone: the original's zone (Team) / the yellow zone (Me).
- The review card is independent (draggable, reassignable). Bidirectional sync: review card at 100% → original leaves `review`; back below 100% → original re-enters `review`.
- A review card can't itself be reviewed; a manual `review` is preserved. Deleting a card with a linked review card asks once and deletes both. Review cards show a yellow left stripe.
- `review`/`locked` cards can never sit at 100% (set on a full card → drops to 90%).

## 2. Explicit, state-driven sprints (replaces the max-`sprintStart` heuristic)

Each team's sprint pointer now lives on a hidden per-team `aeman:sprint-state` card (no assignee, excluded from every view) storing the **current** and **previous** sprint start dates. Nothing is inferred from the spread of card dates anymore.

- **Create** a Team card → joins the team's current sprint (no prompt). A team with no sprint yet starts its first one from that card.
- **Carry over** → advances the state (previous = current, current = today) and extends the team's unfinished cards' span to today. Always works, even with nothing to carry (no more "Nothing to carry over"), and is idempotent — pressing it again the same day does not overwrite the previous sprint.
- **Team grid** shows a card on its whole `[startDate, sprintStart]` span: a fresh card on its one sprint day, and a card carried into a later sprint in BOTH its original and new sprint (carry over extends the task, it does not move it). **Me** keeps a card while its sprint is still its team's current sprint, so starting a new sprint (even via an unassigned card) drops last sprint's cards out of Me.
- The **sprint-jump button** is directional: "« Last sprint" while on the current sprint, "Current sprint »" / "« Current sprint" to return to the current sprint when it is ahead of / behind the viewed day.
- Deleting (×) a plain grid card demotes it to the team's previous sprint instead of removing it; only a card with no earlier sprint is deleted.

## 3. Robustness & weekly plan

- **Paginate board items** — `loadBoard` followed only the first 100 items, so once a board passed 100 cards the newest ones never loaded and "vanished" after a refresh. It now pages through every item via the GraphQL cursor.
- **Weekly Carry over** pulls unfinished plan cards from earlier weeks into the current week.
- **Stale-day catch-up** — a tab left open past midnight catches the selected day up to the real today on focus.

## Build/deploy

The Docker image now cross-compiles (build on the host arch, target via GOOS/GOARCH), so a `linux/amd64` image builds fast on arm64 and the deploy ships a prebuilt image via ghcr (the small server can't build in-place).

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein
