### PR TITLE
feat(boards): review counterpart, multi-team filter, title tooltip

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -73,10 +73,19 @@ export function App() {
   const [addedTeams, setAddedTeams] = useState<string[]>(
     () => readStringList(LS_TEAM_ROSTER) ?? [],
   );
-  // Single-select team filter: null = all, "" = no team, else a team name.
-  const [teamFilter, setTeamFilter] = useState<string | null>(() => {
+  // Team filter: null = all, else the selected groups ("" = no-team). Multi-select
+  // — Shift-click a chip to add/remove it.
+  const [teamFilter, setTeamFilter] = useState<string[] | null>(() => {
     const v = localStorage.getItem(LS_TEAM_FILTER);
-    return v && !v.startsWith("[") ? v : null;
+    if (!v) {
+      return null;
+    }
+    try {
+      const arr: unknown = JSON.parse(v);
+      return Array.isArray(arr) && arr.length ? (arr as string[]) : null;
+    } catch {
+      return [v]; // legacy single-value filter
+    }
   });
 
   // Bootstrap: fetch config and seed owner/project from localStorage or defaults.
@@ -157,8 +166,14 @@ export function App() {
       writeStringList(LS_TEAM_ROSTER, next);
       return next;
     });
-    // Clear the filter if it pointed at the removed team.
-    setTeamFilter((cur) => (cur === team ? null : cur));
+    // Drop the removed team from the filter (clearing it if it becomes empty).
+    setTeamFilter((cur) => {
+      if (cur === null) {
+        return cur;
+      }
+      const next = cur.filter((k) => k !== team);
+      return next.length ? next : null;
+    });
   }, []);
 
   // Persist the filter whenever it changes (null means "all", we store nothing).
@@ -166,7 +181,7 @@ export function App() {
     if (teamFilter === null) {
       localStorage.removeItem(LS_TEAM_FILTER);
     } else {
-      localStorage.setItem(LS_TEAM_FILTER, teamFilter);
+      localStorage.setItem(LS_TEAM_FILTER, JSON.stringify(teamFilter));
     }
   }, [teamFilter]);
 
@@ -297,7 +312,9 @@ export function App() {
         writeStringList(LS_TEAM_ROSTER, next);
         return next;
       });
-      setTeamFilter((cur) => (cur === from ? t : cur));
+      setTeamFilter((cur) =>
+        cur === null ? cur : cur.map((k) => (k === from ? t : k)),
+      );
       setBoard((cur) => {
         if (!cur) {
           return cur;

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -613,7 +613,7 @@ export function Card({
                   />
                 </div>
               )}
-              {!card.reviewOf && onSetReviewAssignee && (
+              {card.stage === "review" && onSetReviewAssignee && (
                 <div className="card-assign-col">
                   <div className="card-assign-head">Reviewer</div>
                   {(people ?? []).map((p) => (

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import type { Card as CardModel, StageKey } from "../providers/types";
-import { STAGES, STAGE_ORDER, DEFAULT_BAR_COLOR } from "../stages";
+import { STAGES, STAGE_ORDER, DEFAULT_BAR_COLOR, isInProgress } from "../stages";
 import { teamColor, teamInitial } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { addDays, daysSince, todayIso, mondayOf } from "../date";
@@ -23,6 +23,9 @@ interface CardProps {
   onProgress: (card: CardModel, value: number) => void;
   onDelete: (card: CardModel) => void;
   onStage: (card: CardModel, stage: StageKey | null) => void;
+  /** Pick the implicit "In Progress" status: clears the stage and clamps the
+   *  card's progress into [10, 90]. */
+  onInProgress: (card: CardModel) => void;
   onRename: (card: CardModel, title: string) => void;
   onOpen: (card: CardModel) => void;
   /** Locking requires a reason, gathered in a modal lifted to App. */
@@ -77,6 +80,7 @@ export function Card({
   onProgress,
   onDelete,
   onStage,
+  onInProgress,
   onRename,
   onOpen,
   onRequestLock,
@@ -177,6 +181,12 @@ export function Card({
     e.stopPropagation();
     setMenuOpen(false);
     onStage(card, stage);
+  };
+
+  const pickInProgress = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setMenuOpen(false);
+    onInProgress(card);
   };
 
   // Locking opens a modal (lifted to App) to gather the reason note.
@@ -324,6 +334,17 @@ export function Card({
             onClose={() => setMenuOpen(false)}
             className="card-stage-menu"
           >
+            <button
+              type="button"
+              className={`card-stage-item${isInProgress(card) ? " card-stage-item-active" : ""}`}
+              onClick={pickInProgress}
+            >
+              <span
+                className="card-stage-dot"
+                style={{ background: DEFAULT_BAR_COLOR }}
+              />
+              In Progress
+            </button>
             {STAGE_ORDER.map((stage) =>
               // A review card cannot be put on the "review" stage itself.
               stage === "review" && card.reviewOf ? null : (
@@ -343,13 +364,6 @@ export function Card({
                 </button>
               ),
             )}
-            <button
-              type="button"
-              className="card-stage-item card-stage-clear"
-              onClick={(e) => pickStage(e, null)}
-            >
-              Clear
-            </button>
           </Dropdown>
         </div>
         <button

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -114,6 +114,7 @@ export function Card({
   const [dragValue, setDragValue] = useState<number | null>(null);
   const [assignOpen, setAssignOpen] = useState(false);
   const [personInput, setPersonInput] = useState("");
+  const [reviewerInput, setReviewerInput] = useState("");
   const menuRef = useRef<HTMLDivElement | null>(null);
   const assignRef = useRef<HTMLDivElement | null>(null);
   const barRef = useRef<HTMLDivElement | null>(null);
@@ -661,6 +662,24 @@ export function Card({
                   >
                     Remove reviewer
                   </button>
+                  <input
+                    type="text"
+                    className="add-card-input card-assign-input"
+                    placeholder="reviewer login…"
+                    value={reviewerInput}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => setReviewerInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      e.stopPropagation();
+                      if (e.key === "Enter" && reviewerInput.trim()) {
+                        onSetReviewAssignee(card, reviewerInput.trim());
+                        setReviewerInput("");
+                        setAssignOpen(false);
+                      } else if (e.key === "Escape") {
+                        setAssignOpen(false);
+                      }
+                    }}
+                  />
                 </div>
               )}
             </div>

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -33,11 +33,6 @@ interface CardProps {
   users?: Record<string, GhUser>;
   onSetTeam?: (card: CardModel, team: string | null) => void;
   onSetAssignee?: (card: CardModel, login: string | null) => void;
-  /** Send the card to review: creates a linked review card for the chosen
-   *  reviewer and puts this card on the review stage (hidden on review cards). */
-  onSendToReview?: (card: CardModel, reviewerLogin: string) => void;
-  /** Reviewer suggestions for the "send to review" picker (same-team people). */
-  reviewerCandidates?: string[];
   /** This card has a linked review card; deleting it cascades (the board owns
    *  the combined confirmation, so the card skips its own delete prompt). */
   hasLinkedReview?: boolean;
@@ -90,8 +85,6 @@ export function Card({
   users,
   onSetTeam,
   onSetAssignee,
-  onSendToReview,
-  reviewerCandidates,
   hasLinkedReview,
   counterpartAssignees,
   onSetReviewAssignee,
@@ -117,8 +110,6 @@ export function Card({
   const [dragValue, setDragValue] = useState<number | null>(null);
   const [assignOpen, setAssignOpen] = useState(false);
   const [personInput, setPersonInput] = useState("");
-  const [reviewOpen, setReviewOpen] = useState(false);
-  const [reviewerInput, setReviewerInput] = useState("");
   const menuRef = useRef<HTMLDivElement | null>(null);
   const assignRef = useRef<HTMLDivElement | null>(null);
   const barRef = useRef<HTMLDivElement | null>(null);
@@ -201,19 +192,6 @@ export function Card({
     setAssignOpen(false);
     setPersonInput("");
     onSetAssignee?.(card, login);
-  };
-
-  // Open the reviewer picker from the stage menu's "Send to review" item.
-  const openSendToReview = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    setMenuOpen(false);
-    setReviewOpen(true);
-  };
-
-  const pickReviewer = (login: string) => {
-    setReviewOpen(false);
-    setReviewerInput("");
-    onSendToReview?.(card, login);
   };
 
   const openDates = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -369,54 +347,6 @@ export function Card({
             >
               Clear
             </button>
-            {onSendToReview && !card.reviewOf && (
-              <button
-                type="button"
-                className="card-stage-item card-stage-send-review"
-                onClick={openSendToReview}
-              >
-                Send to review…
-              </button>
-            )}
-          </Dropdown>
-          <Dropdown
-            open={reviewOpen}
-            anchorRef={menuRef}
-            onClose={() => setReviewOpen(false)}
-            className="card-stage-menu card-review-menu"
-          >
-            <div className="card-assign-head">Reviewer</div>
-            {(reviewerCandidates ?? []).map((p) => (
-              <button
-                key={`rev-${p}`}
-                type="button"
-                className="card-stage-item"
-                onClick={() => pickReviewer(p)}
-              >
-                <img
-                  className="avatar-img"
-                  src={avatarUrlFor(p, users?.[p])}
-                  alt={p}
-                />
-                {displayName(p, users?.[p])}
-              </button>
-            ))}
-            <input
-              type="text"
-              className="add-card-input card-assign-input"
-              placeholder="reviewer login…"
-              value={reviewerInput}
-              onClick={(e) => e.stopPropagation()}
-              onChange={(e) => setReviewerInput(e.target.value)}
-              onKeyDown={(e) => {
-                e.stopPropagation();
-                if (e.key === "Enter" && reviewerInput.trim()) {
-                  pickReviewer(reviewerInput.trim());
-                } else if (e.key === "Escape") {
-                  setReviewOpen(false);
-                }
-              }}
-            />
           </Dropdown>
         </div>
         <button
@@ -683,7 +613,7 @@ export function Card({
                   />
                 </div>
               )}
-              {hasLinkedReview && onSetReviewAssignee && (
+              {!card.reviewOf && onSetReviewAssignee && (
                 <div className="card-assign-col">
                   <div className="card-assign-head">Reviewer</div>
                   {(people ?? []).map((p) => (

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -139,7 +139,10 @@ export function Card({
     }
     const rect = barRef.current.getBoundingClientRect();
     const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0;
-    const snapped = Math.min(100, Math.max(0, Math.round(frac * 10) * 10));
+    // review/locked keep at least one filled segment; other cards can reach 0%
+    // (which clears the status).
+    const min = card.stage === "review" || card.stage === "locked" ? 10 : 0;
+    const snapped = Math.min(100, Math.max(min, Math.round(frac * 10) * 10));
     if (snapped !== dragValue) {
       setDragValue(snapped);
     }

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -302,7 +302,9 @@ export function Card({
           onBlur={() => setEditing(false)}
         />
       ) : (
-        <span className="card-title">{card.title}</span>
+        <span className="card-title" title={card.title}>
+          {card.title}
+        </span>
       )}
 
       {ref && <span className="card-ticket">{ref}</span>}

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -44,6 +44,9 @@ interface CardProps {
   /** Assignees of the linked counterpart card — the reviewer(s) on an original
    *  under review, the implementer(s) on a review card. */
   counterpartAssignees?: string[];
+  /** Manage the linked review card from the counterpart menu: a login reassigns
+   *  the review card, null deletes it. Only when this card has a linked review. */
+  onSetReviewAssignee?: (card: CardModel, login: string | null) => void;
   /** The day the board is showing; the age badge is measured up to it. */
   asOf?: string;
   /** Edit the card's start/end dates from the age badge (when provided). */
@@ -91,6 +94,7 @@ export function Card({
   reviewerCandidates,
   hasLinkedReview,
   counterpartAssignees,
+  onSetReviewAssignee,
   asOf,
   onSetDates,
   weekMode,
@@ -677,6 +681,39 @@ export function Card({
                       }
                     }}
                   />
+                </div>
+              )}
+              {hasLinkedReview && onSetReviewAssignee && (
+                <div className="card-assign-col">
+                  <div className="card-assign-head">Reviewer</div>
+                  {(people ?? []).map((p) => (
+                    <button
+                      key={`r-${p}`}
+                      type="button"
+                      className={`card-stage-item${(counterpartAssignees ?? []).includes(p) ? " card-stage-item-active" : ""}`}
+                      onClick={() => {
+                        onSetReviewAssignee(card, p);
+                        setAssignOpen(false);
+                      }}
+                    >
+                      <img
+                        className="avatar-img"
+                        src={avatarUrlFor(p, users?.[p])}
+                        alt={p}
+                      />
+                      {displayName(p, users?.[p])}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    className="card-stage-item card-stage-clear"
+                    onClick={() => {
+                      onSetReviewAssignee(card, null);
+                      setAssignOpen(false);
+                    }}
+                  >
+                    Remove reviewer
+                  </button>
                 </div>
               )}
             </div>

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -531,28 +531,7 @@ export function Card({
         </div>
       )}
 
-      {counterpartAssignees && counterpartAssignees.length > 0 && (
-        <span
-          className={`card-counterpart card-counterpart-${card.reviewOf ? "impl" : "review"}`}
-          title={`${card.reviewOf ? "In implementation" : "On review"}: ${counterpartAssignees
-            .map((p) => displayName(p, users?.[p]))
-            .join(", ")}`}
-        >
-          <span className="card-counterpart-icon" aria-hidden>
-            {card.reviewOf ? "🛠" : "🔍"}
-          </span>
-          {counterpartAssignees.slice(0, 3).map((p) => (
-            <img
-              key={p}
-              className="avatar-img card-counterpart-avatar"
-              src={avatarUrlFor(p, users?.[p])}
-              alt={displayName(p, users?.[p])}
-            />
-          ))}
-        </span>
-      )}
-
-      {(card.team || canAssign) && (
+      {(card.team || canAssign || (counterpartAssignees?.length ?? 0) > 0) && (
         <div className="card-assign" ref={assignRef}>
           {card.team ? (
             <button
@@ -590,12 +569,49 @@ export function Card({
               +
             </button>
           )}
+          {counterpartAssignees && counterpartAssignees.length > 0 && (
+            <button
+              type="button"
+              className="card-counterpart-avatar-btn"
+              title={`${card.reviewOf ? "In implementation" : "On review"}: ${counterpartAssignees
+                .map((p) => displayName(p, users?.[p]))
+                .join(", ")}`}
+              onClick={
+                canAssign
+                  ? (e) => {
+                      e.stopPropagation();
+                      setAssignOpen((o) => !o);
+                    }
+                  : undefined
+              }
+            >
+              <img
+                className="card-counterpart-avatar"
+                src={avatarUrlFor(
+                  counterpartAssignees[0],
+                  users?.[counterpartAssignees[0]],
+                )}
+                alt={displayName(
+                  counterpartAssignees[0],
+                  users?.[counterpartAssignees[0]],
+                )}
+              />
+            </button>
+          )}
           <Dropdown
             open={assignOpen}
             anchorRef={assignRef}
             onClose={() => setAssignOpen(false)}
             className="card-stage-menu card-assign-menu"
           >
+            {counterpartAssignees && counterpartAssignees.length > 0 && (
+              <div className="card-counterpart-head">
+                {card.reviewOf ? "In implementation" : "On review"}:{" "}
+                {counterpartAssignees
+                  .map((p) => displayName(p, users?.[p]))
+                  .join(", ")}
+              </div>
+            )}
             <div className="card-assign-cols">
               {onSetTeam && (
                 <div className="card-assign-col">

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -41,6 +41,9 @@ interface CardProps {
   /** This card has a linked review card; deleting it cascades (the board owns
    *  the combined confirmation, so the card skips its own delete prompt). */
   hasLinkedReview?: boolean;
+  /** Assignees of the linked counterpart card — the reviewer(s) on an original
+   *  under review, the implementer(s) on a review card. */
+  counterpartAssignees?: string[];
   /** The day the board is showing; the age badge is measured up to it. */
   asOf?: string;
   /** Edit the card's start/end dates from the age badge (when provided). */
@@ -87,6 +90,7 @@ export function Card({
   onSendToReview,
   reviewerCandidates,
   hasLinkedReview,
+  counterpartAssignees,
   asOf,
   onSetDates,
   weekMode,
@@ -523,6 +527,27 @@ export function Card({
             </Dropdown>
           )}
         </div>
+      )}
+
+      {counterpartAssignees && counterpartAssignees.length > 0 && (
+        <span
+          className={`card-counterpart card-counterpart-${card.reviewOf ? "impl" : "review"}`}
+          title={`${card.reviewOf ? "In implementation" : "On review"}: ${counterpartAssignees
+            .map((p) => displayName(p, users?.[p]))
+            .join(", ")}`}
+        >
+          <span className="card-counterpart-icon" aria-hidden>
+            {card.reviewOf ? "🛠" : "🔍"}
+          </span>
+          {counterpartAssignees.slice(0, 3).map((p) => (
+            <img
+              key={p}
+              className="avatar-img card-counterpart-avatar"
+              src={avatarUrlFor(p, users?.[p])}
+              alt={displayName(p, users?.[p])}
+            />
+          ))}
+        </span>
       )}
 
       {(card.team || canAssign) && (

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -29,8 +29,8 @@ interface MeBoardProps {
   /** Known teams to offer in the team selector. */
   teams: string[];
   /** Shared single-select team (also the team for new cards); null = none. */
-  teamFilter: string | null;
-  onSetFilter: (key: string | null) => void;
+  teamFilter: string[] | null;
+  onSetFilter: (keys: string[] | null) => void;
   onAddTeam: (team: string) => void;
   onRemoveTeam: (team: string) => void;
   onRenameTeam: (from: string, to: string) => void;
@@ -571,7 +571,7 @@ export function MeBoard({
         <TeamChips
           label="Team"
           teams={teams}
-          selectedKey={teamFilter}
+          selectedKeys={teamFilter}
           onSelect={onSetFilter}
           onAdd={onAddTeam}
           onRemove={onRemoveTeam}
@@ -671,7 +671,7 @@ export function MeBoard({
                   counterpartAssignees={counterpartAssigneesFor(card)}
                   asOf={selectedDate}
                   dimAvatar={
-                    teamFilter === null || (card.team ?? "") !== teamFilter
+                    teamFilter === null || !teamFilter.includes(card.team ?? "")
                   }
                 />
               )}
@@ -703,7 +703,9 @@ export function MeBoard({
                     <div className="zone-cards">
                       {body}
                       <AddCard
-                        forcedTeam={teamFilter || null}
+                        forcedTeam={
+                          teamFilter?.length === 1 ? teamFilter[0] || null : null
+                        }
                         onCreate={(title, team) =>
                           handleCreate(group.meta.zone, title, team)
                         }

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -346,6 +346,29 @@ export function MeBoard({
     return linked?.assignees ?? [];
   };
 
+  // Reassign the linked review card to another person, or (login = null) delete
+  // it — driven from the counterpart avatar's menu.
+  const handleSetReviewAssignee = (card: CardModel, login: string | null) => {
+    const reviewCard = board.cards.find((c) => c.reviewOf === card.itemId);
+    if (!reviewCard) {
+      return;
+    }
+    if (login === null) {
+      removeCard(reviewCard.itemId);
+      void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
+        addCard(reviewCard);
+        onError(errMessage(err));
+      });
+      return;
+    }
+    const prev = reviewCard.assignees;
+    patchCard(reviewCard.itemId, { assignees: [login] });
+    void provider.setAssignee(board, reviewCard, login).catch((err: unknown) => {
+      patchCard(reviewCard.itemId, { assignees: prev });
+      onError(errMessage(err));
+    });
+  };
+
   const reviewersFor = (card: CardModel): string[] => {
     const set = new Set<string>();
     for (const c of board.cards) {
@@ -669,6 +692,7 @@ export function MeBoard({
                   reviewerCandidates={reviewersFor(card)}
                   hasLinkedReview={reviewedItemIds.has(card.itemId)}
                   counterpartAssignees={counterpartAssigneesFor(card)}
+                  onSetReviewAssignee={handleSetReviewAssignee}
                   asOf={selectedDate}
                   dimAvatar={
                     teamFilter === null || !teamFilter.includes(card.team ?? "")

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -203,7 +203,12 @@ export function MeBoard({
     });
   };
 
-  const handleProgress = (card: CardModel, value: number) => {
+  const handleProgress = (card: CardModel, raw: number) => {
+    // review/locked cards never drop below the one-segment minimum (10%).
+    const value =
+      (card.stage === "review" || card.stage === "locked") && raw < 10
+        ? 10
+        : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
     // Auto-link progress and "done": 100% sets done (unless review/locked is on),

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -80,13 +80,29 @@ export function MeBoard({
   const [impOpen, setImpOpen] = useState(false);
   const impRef = useRef<HTMLDivElement | null>(null);
   const viewMe = impersonated ?? me;
-  const people = useMemo(
+  // Other people with cards — offered in the "View as" impersonate picker.
+  const others = useMemo(
     () =>
       [...new Set(board.cards.flatMap((c) => c.assignees))]
         .filter((p) => p && p !== me)
         .sort(),
     [board.cards, me],
   );
+
+  // People to offer when picking a reviewer: everyone seen on the board, plus
+  // me — the same roster the Team board's assign menu uses.
+  const people = useMemo(() => {
+    const set = new Set<string>();
+    for (const card of board.cards) {
+      for (const login of card.assignees) {
+        set.add(login);
+      }
+    }
+    if (me) {
+      set.add(me);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [board.cards, me]);
 
   const roles = useMemo(() => fieldRoles(board), [board]);
 
@@ -271,6 +287,41 @@ export function MeBoard({
         patchCard(card.itemId, { progress: prev.progress });
         onError(errMessage(err));
       });
+    }
+  };
+
+  // "In Progress" is the implicit status (no stage, progress in [10, 90]).
+  // Picking it clears any stage and clamps progress into that band: under 10
+  // becomes 10, a done/full card drops to 90, otherwise the value is kept.
+  const handleInProgress = (card: CardModel) => {
+    const cur = card.progress ?? 0;
+    let value = cur;
+    if (cur < 10) {
+      value = 10;
+    } else if (card.stage === "done" || cur >= 100) {
+      value = 90;
+    }
+    const prev: Partial<CardModel> = { stage: card.stage, progress: card.progress };
+    patchCard(card.itemId, { stage: undefined, progress: value });
+    void (async () => {
+      try {
+        await provider.setStage(board, card, null);
+        if (value !== cur) {
+          await provider.setProgress(board, card, value);
+        }
+      } catch (err: unknown) {
+        patchCard(card.itemId, prev);
+        onError(errMessage(err));
+      }
+    })();
+
+    // A review card's progress drives its original's review stage; keep that
+    // in sync when In Progress changes it (e.g. a done review card reopens it).
+    if (card.reviewOf && value !== cur) {
+      const original = board.cards.find((c) => c.itemId === card.reviewOf);
+      if (original) {
+        syncOriginalReview(original, value);
+      }
     }
   };
 
@@ -635,7 +686,7 @@ export function MeBoard({
                 ← Back to me
               </button>
             )}
-            {people.map((p) => (
+            {others.map((p) => (
               <button
                 key={p}
                 type="button"
@@ -654,7 +705,7 @@ export function MeBoard({
                 {displayName(p, users[p])}
               </button>
             ))}
-            {people.length === 0 && (
+            {others.length === 0 && (
               <div className="sprint-empty">No other people with cards</div>
             )}
           </Dropdown>
@@ -675,10 +726,12 @@ export function MeBoard({
                   onProgress={handleProgress}
                   onDelete={handleDelete}
                   onStage={handleStage}
+                  onInProgress={handleInProgress}
                   onRename={handleRename}
                   onOpen={onOpen}
                   onRequestLock={onRequestLock}
                   teams={teams}
+                  people={people}
                   users={users}
                   onSetTeam={handleSetTeam}
                   hasLinkedReview={reviewedItemIds.has(card.itemId)}
@@ -698,6 +751,7 @@ export function MeBoard({
                   onProgress={() => {}}
                   onDelete={() => {}}
                   onStage={() => {}}
+                  onInProgress={() => {}}
                   onRename={() => {}}
                   onOpen={() => {}}
                   onRequestLock={() => {}}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -350,15 +350,19 @@ export function MeBoard({
   // it — driven from the counterpart avatar's menu.
   const handleSetReviewAssignee = (card: CardModel, login: string | null) => {
     const reviewCard = board.cards.find((c) => c.reviewOf === card.itemId);
-    if (!reviewCard) {
+    if (login === null) {
+      if (reviewCard) {
+        removeCard(reviewCard.itemId);
+        void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
+          addCard(reviewCard);
+          onError(errMessage(err));
+        });
+      }
       return;
     }
-    if (login === null) {
-      removeCard(reviewCard.itemId);
-      void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
-        addCard(reviewCard);
-        onError(errMessage(err));
-      });
+    if (!reviewCard) {
+      // No review yet — assigning a reviewer sends the card to review.
+      handleSendToReview(card, login);
       return;
     }
     const prev = reviewCard.assignees;
@@ -367,22 +371,6 @@ export function MeBoard({
       patchCard(reviewCard.itemId, { assignees: prev });
       onError(errMessage(err));
     });
-  };
-
-  const reviewersFor = (card: CardModel): string[] => {
-    const set = new Set<string>();
-    for (const c of board.cards) {
-      if ((c.team ?? "") !== (card.team ?? "")) {
-        continue;
-      }
-      for (const login of c.assignees) {
-        set.add(login);
-      }
-    }
-    for (const a of card.assignees) {
-      set.delete(a);
-    }
-    return [...set].sort((a, b) => a.localeCompare(b));
   };
 
   // Send a card to review: create a linked review card for the reviewer (in the
@@ -688,8 +676,6 @@ export function MeBoard({
                   teams={teams}
                   users={users}
                   onSetTeam={handleSetTeam}
-                  onSendToReview={handleSendToReview}
-                  reviewerCandidates={reviewersFor(card)}
                   hasLinkedReview={reviewedItemIds.has(card.itemId)}
                   counterpartAssignees={counterpartAssigneesFor(card)}
                   onSetReviewAssignee={handleSetReviewAssignee}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -337,6 +337,15 @@ export function MeBoard({
 
   // Reviewer suggestions: people on the same team as the card, minus its own
   // assignee(s). The picker also accepts a free-text login.
+  // Assignees of a card's linked review counterpart: an original's reviewer(s),
+  // or a review card's implementer(s).
+  const counterpartAssigneesFor = (card: CardModel): string[] => {
+    const linked = card.reviewOf
+      ? board.cards.find((c) => c.itemId === card.reviewOf)
+      : board.cards.find((c) => c.reviewOf === card.itemId);
+    return linked?.assignees ?? [];
+  };
+
   const reviewersFor = (card: CardModel): string[] => {
     const set = new Set<string>();
     for (const c of board.cards) {
@@ -659,6 +668,7 @@ export function MeBoard({
                   onSendToReview={handleSendToReview}
                   reviewerCandidates={reviewersFor(card)}
                   hasLinkedReview={reviewedItemIds.has(card.itemId)}
+                  counterpartAssignees={counterpartAssigneesFor(card)}
                   asOf={selectedDate}
                   dimAvatar={
                     teamFilter === null || (card.team ?? "") !== teamFilter

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -672,7 +672,12 @@ export function TeamBoard({
     });
   };
 
-  const handleProgress = (card: CardModel, value: number) => {
+  const handleProgress = (card: CardModel, raw: number) => {
+    // review/locked cards never drop below the one-segment minimum (10%).
+    const value =
+      (card.stage === "review" || card.stage === "locked") && raw < 10
+        ? 10
+        : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
     // Auto-link progress and "done": 100% sets done (unless review/locked is on),

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -919,6 +919,29 @@ export function TeamBoard({
     return linked?.assignees ?? [];
   };
 
+  // Reassign the linked review card to another person, or (login = null) delete
+  // it — driven from the counterpart avatar's menu.
+  const handleSetReviewAssignee = (card: CardModel, login: string | null) => {
+    const reviewCard = board.cards.find((c) => c.reviewOf === card.itemId);
+    if (!reviewCard) {
+      return;
+    }
+    if (login === null) {
+      removeCard(reviewCard.itemId);
+      void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
+        addCard(reviewCard);
+        onError(errMessage(err));
+      });
+      return;
+    }
+    const prev = reviewCard.assignees;
+    patchCard(reviewCard.itemId, { assignees: [login] });
+    void provider.setAssignee(board, reviewCard, login).catch((err: unknown) => {
+      patchCard(reviewCard.itemId, { assignees: prev });
+      onError(errMessage(err));
+    });
+  };
+
   const reviewersFor = (card: CardModel): string[] => {
     const set = new Set<string>();
     for (const c of board.cards) {
@@ -1255,6 +1278,7 @@ export function TeamBoard({
               reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
               counterpartAssignees={counterpartAssigneesFor(card)}
+              onSetReviewAssignee={handleSetReviewAssignee}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               weekMode
@@ -1281,6 +1305,7 @@ export function TeamBoard({
               reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
               counterpartAssignees={counterpartAssigneesFor(card)}
+              onSetReviewAssignee={handleSetReviewAssignee}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               dimAvatar

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -36,8 +36,8 @@ interface TeamBoardProps {
   /** Known teams (the roster), shown as filter chips. */
   roster: string[];
   /** Single-select team filter: null = all, "" = no team, else a team name. */
-  teamFilter: string | null;
-  onSetFilter: (key: string | null) => void;
+  teamFilter: string[] | null;
+  onSetFilter: (keys: string[] | null) => void;
   onAddTeam: (team: string) => void;
   onRemoveTeam: (team: string) => void;
   onRenameTeam: (from: string, to: string) => void;
@@ -183,7 +183,7 @@ export function TeamBoard({
 
   // Single-select: no filter shows all; otherwise match the card's group.
   const passesFilter = (card: CardModel): boolean =>
-    teamFilter === null || (card.team ?? "") === teamFilter;
+    teamFilter === null || teamFilter.includes(card.team ?? "");
 
   // Cards passing the team filter (the scope before applying the sprint).
   const inFilter = useMemo(
@@ -217,9 +217,9 @@ export function TeamBoard({
   } | null>(() => {
     let cur: string | null;
     let prev: string | null;
-    if (teamFilter !== null) {
-      cur = currentSprint(board, teamFilter);
-      prev = previousSprint(board, teamFilter);
+    if (teamFilter?.length === 1) {
+      cur = currentSprint(board, teamFilter[0]);
+      prev = previousSprint(board, teamFilter[0]);
     } else {
       cur = null;
       prev = null;
@@ -496,7 +496,7 @@ export function TeamBoard({
 
   // New cards default to the filtered team; null = all (show picker), "" = no team.
   const forcedTeam = useMemo(
-    () => (teamFilter === null ? undefined : teamFilter || null),
+    () => (teamFilter?.length === 1 ? teamFilter[0] || null : undefined),
     [teamFilter],
   );
 
@@ -1153,7 +1153,7 @@ export function TeamBoard({
         <TeamChips
           label="Team"
           teams={roster}
-          selectedKey={teamFilter}
+          selectedKeys={teamFilter}
           onSelect={onSetFilter}
           onAdd={onAddTeam}
           onRemove={onRemoveTeam}
@@ -1193,17 +1193,17 @@ export function TeamBoard({
             type="button"
             className="btn sprint-btn"
             onClick={() => {
-              if (teamFilter === null) {
-                setSprintMenuOpen((o) => !o);
+              if (teamFilter?.length === 1) {
+                void startSprint(teamFilter[0] === "" ? null : teamFilter[0]);
               } else {
-                void startSprint(teamFilter === "" ? null : teamFilter);
+                setSprintMenuOpen((o) => !o);
               }
             }}
             title={`Start a new sprint (today) for the selected team`}
           >
-            Carry over{teamFilter === null ? " ▾" : " →"}
+            Carry over{teamFilter?.length === 1 ? " →" : " ▾"}
           </button>
-          {teamFilter === null && sprintMenuOpen && (
+          {teamFilter?.length !== 1 && sprintMenuOpen && (
             <div className="card-stage-menu sprint-menu">
               {roster.map((t) => (
                 <button
@@ -1437,19 +1437,19 @@ export function TeamBoard({
                             type="button"
                             className="btn"
                             onClick={() => {
-                              if (teamFilter === null) {
-                                setCarryWeekOpen((o) => !o);
-                              } else {
+                              if (teamFilter?.length === 1) {
                                 handleCarryWeek(
-                                  teamFilter === "" ? null : teamFilter,
+                                  teamFilter[0] === "" ? null : teamFilter[0],
                                 );
+                              } else {
+                                setCarryWeekOpen((o) => !o);
                               }
                             }}
                             title="Move unfinished plan cards to next week"
                           >
-                            Carry over week{teamFilter === null ? " ▾" : " →"}
+                            Carry over week{teamFilter?.length === 1 ? " →" : " ▾"}
                           </button>
-                          {teamFilter === null && (
+                          {teamFilter?.length !== 1 && (
                             <Dropdown
                               open={carryWeekOpen}
                               anchorRef={carryWeekRef}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -923,15 +923,19 @@ export function TeamBoard({
   // it — driven from the counterpart avatar's menu.
   const handleSetReviewAssignee = (card: CardModel, login: string | null) => {
     const reviewCard = board.cards.find((c) => c.reviewOf === card.itemId);
-    if (!reviewCard) {
+    if (login === null) {
+      if (reviewCard) {
+        removeCard(reviewCard.itemId);
+        void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
+          addCard(reviewCard);
+          onError(errMessage(err));
+        });
+      }
       return;
     }
-    if (login === null) {
-      removeCard(reviewCard.itemId);
-      void provider.deleteCard(board, reviewCard).catch((err: unknown) => {
-        addCard(reviewCard);
-        onError(errMessage(err));
-      });
+    if (!reviewCard) {
+      // No review yet — assigning a reviewer sends the card to review.
+      handleSendToReview(card, login);
       return;
     }
     const prev = reviewCard.assignees;
@@ -940,22 +944,6 @@ export function TeamBoard({
       patchCard(reviewCard.itemId, { assignees: prev });
       onError(errMessage(err));
     });
-  };
-
-  const reviewersFor = (card: CardModel): string[] => {
-    const set = new Set<string>();
-    for (const c of board.cards) {
-      if ((c.team ?? "") !== (card.team ?? "")) {
-        continue;
-      }
-      for (const login of c.assignees) {
-        set.add(login);
-      }
-    }
-    for (const a of card.assignees) {
-      set.delete(a);
-    }
-    return [...set].sort((a, b) => a.localeCompare(b));
   };
 
   // Send a card to review: create a linked review card for the reviewer (in the
@@ -1274,8 +1262,6 @@ export function TeamBoard({
               users={users}
               onSetTeam={handleSetTeam}
               onSetAssignee={handleSetAssignee}
-              onSendToReview={handleSendToReview}
-              reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
               counterpartAssignees={counterpartAssigneesFor(card)}
               onSetReviewAssignee={handleSetReviewAssignee}
@@ -1301,8 +1287,6 @@ export function TeamBoard({
               users={users}
               onSetTeam={handleSetTeam}
               onSetAssignee={handleSetAssignee}
-              onSendToReview={handleSendToReview}
-              reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
               counterpartAssignees={counterpartAssigneesFor(card)}
               onSetReviewAssignee={handleSetReviewAssignee}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -743,6 +743,41 @@ export function TeamBoard({
     }
   };
 
+  // "In Progress" is the implicit status (no stage, progress in [10, 90]).
+  // Picking it clears any stage and clamps progress into that band: under 10
+  // becomes 10, a done/full card drops to 90, otherwise the value is kept.
+  const handleInProgress = (card: CardModel) => {
+    const cur = card.progress ?? 0;
+    let value = cur;
+    if (cur < 10) {
+      value = 10;
+    } else if (card.stage === "done" || cur >= 100) {
+      value = 90;
+    }
+    const prev: Partial<CardModel> = { stage: card.stage, progress: card.progress };
+    patchCard(card.itemId, { stage: undefined, progress: value });
+    void (async () => {
+      try {
+        await provider.setStage(board, card, null);
+        if (value !== cur) {
+          await provider.setProgress(board, card, value);
+        }
+      } catch (err: unknown) {
+        patchCard(card.itemId, prev);
+        onError(errMessage(err));
+      }
+    })();
+
+    // A review card's progress drives its original's review stage; keep that
+    // in sync when In Progress changes it (e.g. a done review card reopens it).
+    if (card.reviewOf && value !== cur) {
+      const original = board.cards.find((c) => c.itemId === card.reviewOf);
+      if (original) {
+        syncOriginalReview(original, value);
+      }
+    }
+  };
+
   const handleRename = (card: CardModel, title: string) => {
     const prev = card.title;
     patchCard(card.itemId, { title });
@@ -1259,6 +1294,7 @@ export function TeamBoard({
               onProgress={handleProgress}
               onDelete={removeFromPlan}
               onStage={handleStage}
+              onInProgress={handleInProgress}
               onRename={handleRename}
               onOpen={onOpen}
               onRequestLock={onRequestLock}
@@ -1284,6 +1320,7 @@ export function TeamBoard({
               onProgress={handleProgress}
               onDelete={handleGridDelete}
               onStage={handleStage}
+              onInProgress={handleInProgress}
               onRename={handleRename}
               onOpen={onOpen}
               onRequestLock={onRequestLock}
@@ -1309,6 +1346,7 @@ export function TeamBoard({
               onProgress={() => {}}
               onDelete={() => {}}
               onStage={() => {}}
+              onInProgress={() => {}}
               onRename={() => {}}
               onOpen={() => {}}
               onRequestLock={() => {}}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -910,6 +910,15 @@ export function TeamBoard({
 
   // Reviewer suggestions: people on the same team as the card, minus its own
   // assignee(s). The picker also accepts a free-text login.
+  // Assignees of a card's linked review counterpart: an original's reviewer(s),
+  // or a review card's implementer(s).
+  const counterpartAssigneesFor = (card: CardModel): string[] => {
+    const linked = card.reviewOf
+      ? board.cards.find((c) => c.itemId === card.reviewOf)
+      : board.cards.find((c) => c.reviewOf === card.itemId);
+    return linked?.assignees ?? [];
+  };
+
   const reviewersFor = (card: CardModel): string[] => {
     const set = new Set<string>();
     for (const c of board.cards) {
@@ -1245,6 +1254,7 @@ export function TeamBoard({
               onSendToReview={handleSendToReview}
               reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
+              counterpartAssignees={counterpartAssigneesFor(card)}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               weekMode
@@ -1270,6 +1280,7 @@ export function TeamBoard({
               onSendToReview={handleSendToReview}
               reviewerCandidates={reviewersFor(card)}
               hasLinkedReview={reviewedItemIds.has(card.itemId)}
+              counterpartAssignees={counterpartAssigneesFor(card)}
               asOf={selectedDate}
               onSetDates={handleSetDates}
               dimAvatar

--- a/web/src/components/TeamChips.tsx
+++ b/web/src/components/TeamChips.tsx
@@ -4,10 +4,11 @@ interface TeamChipsProps {
   label: string;
   /** Roster of teams to show as chips. */
   teams: string[];
-  /** The selected group key, or null for none. "" is the no-team group. */
-  selectedKey: string | null;
-  /** Select a group, or null to clear. */
-  onSelect: (key: string | null) => void;
+  /** The selected group keys, or null for all (no filter). "" is the no-team
+   *  group. Multi-select: Shift-click adds/removes a chip. */
+  selectedKeys: string[] | null;
+  /** Set the selection, or null to clear (show all). */
+  onSelect: (keys: string[] | null) => void;
   onAdd: (name: string) => void;
   onRemove: (team: string) => void;
   onRename: (from: string, to: string) => void;
@@ -23,7 +24,7 @@ interface TeamChipsProps {
 export function TeamChips({
   label,
   teams,
-  selectedKey,
+  selectedKeys,
   onSelect,
   onAdd,
   onRemove,
@@ -54,15 +55,28 @@ export function TeamChips({
     }
   };
 
-  // Single-select: clicking the active chip clears the selection.
-  const toggle = (key: string) => onSelect(selectedKey === key ? null : key);
+  // Plain click selects just this chip (clearing it if it was the only one);
+  // Shift-click adds/removes the chip in a multi-select.
+  const handleClick = (key: string, shift: boolean) => {
+    if (shift) {
+      const base = selectedKeys ?? [];
+      const next = base.includes(key)
+        ? base.filter((k) => k !== key)
+        : [...base, key];
+      onSelect(next.length ? next : null);
+      return;
+    }
+    onSelect(
+      selectedKeys?.length === 1 && selectedKeys[0] === key ? null : [key],
+    );
+  };
 
   return (
     <div className="field field-inline team-select">
       <span>{label}</span>
       <div className="team-chips">
         {teams.map((t) => {
-          const on = selectedKey === t;
+          const on = selectedKeys?.includes(t) ?? false;
           if (editingTeam === t) {
             return (
               <span className="team-chip team-filter-chip" key={t}>
@@ -92,7 +106,7 @@ export function TeamChips({
               <button
                 type="button"
                 className="team-chip-toggle"
-                onClick={() => toggle(t)}
+                onClick={(e) => handleClick(t, e.shiftKey)}
                 onDoubleClick={
                   canManage
                     ? () => {
@@ -103,7 +117,9 @@ export function TeamChips({
                 }
                 aria-pressed={on}
                 title={
-                  canManage ? "Click to select · double-click to rename" : "Click to select"
+                  canManage
+                    ? "Click to select · Shift-click to add · double-click to rename"
+                    : "Click to select · Shift-click to add"
                 }
               >
                 <span className="team-chip-name">{t}</span>
@@ -124,13 +140,13 @@ export function TeamChips({
         })}
         {noTeamChip && (
           <span
-            className={`team-chip team-filter-chip${selectedKey === "" ? "" : " team-filter-chip-off"}`}
+            className={`team-chip team-filter-chip${(selectedKeys?.includes("") ?? false) ? "" : " team-filter-chip-off"}`}
           >
             <button
               type="button"
               className="team-chip-toggle"
-              onClick={() => toggle("")}
-              aria-pressed={selectedKey === ""}
+              onClick={(e) => handleClick("", e.shiftKey)}
+              aria-pressed={selectedKeys?.includes("") ?? false}
               title="Cards with no team"
             >
               <span className="team-chip-name team-col-unassigned">No team</span>

--- a/web/src/stages.ts
+++ b/web/src/stages.ts
@@ -20,6 +20,17 @@ export const STAGE_ORDER: StageKey[] = ["locked", "review", "done"];
 /** Progress bar colour for a stage; the default (no stage) bar is green. */
 export const DEFAULT_BAR_COLOR = "#3fb950";
 
+/** isInProgress reports the implicit "In Progress" status: a card with no stored
+ *  stage whose progress sits in [10, 90] inclusive. It is deliberately NOT a
+ *  StageKey — there is no stored option for it. */
+export function isInProgress(card: {
+  stage?: StageKey;
+  progress?: number;
+}): boolean {
+  const p = card.progress ?? 0;
+  return !card.stage && p >= 10 && p <= 90;
+}
+
 /** stageFromName maps a Stage single-select option name onto a StageKey. */
 export function stageFromName(name?: string): StageKey | undefined {
   switch (name?.trim().toLowerCase()) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1090,30 +1090,36 @@ button.card-age {
   outline-offset: -1px;
 }
 
-/* Linked review counterpart: the reviewer on an original, the implementer on a
-   review card. */
-.card-counterpart {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  flex: none;
-  margin-right: 4px;
-  padding: 1px 3px;
-  border-radius: 11px;
-}
-.card-counterpart-review {
-  background: #d4a72c22;
-}
-.card-counterpart-impl {
-  background: #3b82f622;
-}
-.card-counterpart-icon {
-  font-size: 11px;
-  line-height: 1;
+/* Linked review counterpart: a small avatar of the counterpart card's assignee
+   (reviewer on an original, implementer on a review card) half-overlapping the
+   team circle from above; clicking it opens the same team/person assign menu. */
+.card-counterpart-avatar-btn {
+  position: absolute;
+  top: -7px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  line-height: 0;
+  z-index: 1;
 }
 .card-counterpart-avatar {
-  width: 16px;
-  height: 16px;
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1.5px solid var(--bg);
+  background: var(--line);
+}
+.card-counterpart-head {
+  padding: 4px 8px;
+  font-size: 11px;
+  color: var(--faint);
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
 }
 
 .card-bar {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1095,9 +1095,9 @@ button.card-age {
    team circle from above; clicking it opens the same team/person assign menu. */
 .card-counterpart-avatar-btn {
   position: absolute;
-  top: -7px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 50%;
+  right: -7px;
+  transform: translateY(-50%);
   padding: 0;
   border: none;
   background: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1090,6 +1090,32 @@ button.card-age {
   outline-offset: -1px;
 }
 
+/* Linked review counterpart: the reviewer on an original, the implementer on a
+   review card. */
+.card-counterpart {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
+  margin-right: 4px;
+  padding: 1px 3px;
+  border-radius: 11px;
+}
+.card-counterpart-review {
+  background: #d4a72c22;
+}
+.card-counterpart-impl {
+  background: #3b82f622;
+}
+.card-counterpart-icon {
+  font-size: 11px;
+  line-height: 1;
+}
+.card-counterpart-avatar {
+  width: 16px;
+  height: 16px;
+}
+
 .card-bar {
   position: absolute;
   left: 6px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1095,9 +1095,8 @@ button.card-age {
    team circle from above; clicking it opens the same team/person assign menu. */
 .card-counterpart-avatar-btn {
   position: absolute;
-  top: 50%;
+  top: -7px;
   right: -7px;
-  transform: translateY(-50%);
   padding: 0;
   border: none;
   background: none;


### PR DESCRIPTION
Three Team / Me board UI improvements.

## Linked review counterpart on a card

The reviewer is managed from the assign menu's **Reviewer** column, which appears once the card is on the **Review** status (the separate "Send to review" action is removed): picking a person creates the linked review card (or reassigns an existing one); **Remove reviewer** deletes it. A card under review shows its reviewer as a small avatar at the team circle's top-right corner (and a review card shows its implementer); clicking it opens the same assign menu, which shows the counterpart's name at the top.

## Multi-select team filter (Shift-click)

The Team-mode team filter becomes multi-select: a plain click selects a single team (clearing it if it was the only one), **Shift-click adds/removes** a team. `teamFilter` is now `string[] | null` (null = all). Carry over / Carry over week act directly only when exactly one team is selected, otherwise they offer the team-picker menu; AddCard forces a team only for a single selection. Persisted to localStorage as JSON (legacy single-value filters still load).

## Card statuses

The status menu (the ⚑) is now **In Progress · Locked · Review · Done** — the "Clear" item is gone. **In Progress** is the implicit state: no stored status with progress in [10, 90]. Picking it clears any status and brings progress into that band (under 10 → 10, a done/full card → 90). Slider rules: a **Review** or **Locked** card never drops below 10%; any other card can reach 0% to clear its status, and dragging a **Done** card below 100% un-dones it.

## Full card title on hover

A long card title is truncated with an ellipsis; hovering it now reveals the full text (a `title` attribute on the title span).

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein
