### PR TITLE
feat(boards): lock without a comment; ask the team in Me for 0/2+ filtered

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchConfig, type AppConfig } from "./api/client";
 import { getProvider } from "./providers";
-import type { Board, Card as CardModel, Note } from "./providers/types";
+import type { Board, Card as CardModel } from "./providers/types";
 import { MeBoard } from "./components/MeBoard";
 import { TeamBoard } from "./components/TeamBoard";
 import { CardDetail } from "./components/CardDetail";
-import { LockDialog } from "./components/LockDialog";
 import { Logo } from "./components/Logo";
 import { fetchUsers, type GhUser } from "./users";
 
@@ -65,7 +64,6 @@ export function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [detailCard, setDetailCard] = useState<CardModel | null>(null);
-  const [lockCard, setLockCard] = useState<CardModel | null>(null);
 
   // Team roster + filter, persisted in localStorage. The roster is the union of
   // the teams found on the board and any teams the user has added by hand; the
@@ -336,38 +334,6 @@ export function App() {
     [patchCard, provider],
   );
 
-  // Locking posts a note (the reason) to the card so it shows in the day's log.
-  const handleLock = useCallback(
-    (card: CardModel, note: string) => {
-      if (!board) {
-        return;
-      }
-      const prevStage = card.stage;
-      const optimisticNote: Note = {
-        id: `tmp-${new Date().toISOString()}`,
-        body: note,
-        createdAt: new Date().toISOString(),
-        author: config?.login || undefined,
-        source: card.isDraft ? "draft" : "comment",
-      };
-      patchCard(card.itemId, {
-        stage: "locked",
-        notes: [...(card.notes ?? []), optimisticNote],
-      });
-      void (async () => {
-        try {
-          await provider.setStage(board, card, "locked");
-          await provider.addNote(board, card, note);
-        } catch (err: unknown) {
-          patchCard(card.itemId, { stage: prevStage });
-          setError(errMessage(err));
-          reload();
-        }
-      })();
-    },
-    [board, config?.login, patchCard, provider, reload],
-  );
-
   const showTokenWarning =
     config !== null && !config.tokenAvailable && !tokenWarningDismissed;
 
@@ -534,7 +500,6 @@ export function App() {
             reload={reload}
             onError={onError}
             onOpen={(c) => setDetailCard(c)}
-            onRequestLock={(c) => setLockCard(c)}
           />
         )}
         {board && view === "team" && (
@@ -557,7 +522,6 @@ export function App() {
             reload={reload}
             onError={onError}
             onOpen={(c) => setDetailCard(c)}
-            onRequestLock={(c) => setLockCard(c)}
           />
         )}
       </main>
@@ -573,13 +537,6 @@ export function App() {
         />
       )}
 
-      {board && lockCard && (
-        <LockDialog
-          card={board.cards.find((c) => c.itemId === lockCard.itemId) ?? lockCard}
-          onClose={() => setLockCard(null)}
-          onSubmit={handleLock}
-        />
-      )}
     </div>
   );
 }

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -96,11 +96,11 @@ export function Card({
   dimAvatar,
 }: CardProps) {
   const rawValue = card.stage === "done" ? 100 : card.progress ?? 0;
-  // Locked / on-review cards show at least one segment, so the stage colour is
-  // visible even before any progress has been set.
+  // Locked / on-review cards are clamped to a 10–90% band, so they always show
+  // the stage colour and never read as complete.
   const value =
-    rawValue === 0 && (card.stage === "locked" || card.stage === "review")
-      ? 10
+    card.stage === "locked" || card.stage === "review"
+      ? Math.min(90, Math.max(10, rawValue))
       : rawValue;
   const fill = barColor(card.stage);
   const ref = ticket(card);
@@ -141,10 +141,11 @@ export function Card({
     }
     const rect = barRef.current.getBoundingClientRect();
     const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0;
-    // review/locked keep at least one filled segment; other cards can reach 0%
-    // (which clears the status).
-    const min = card.stage === "review" || card.stage === "locked" ? 10 : 0;
-    const snapped = Math.min(100, Math.max(min, Math.round(frac * 10) * 10));
+    // review/locked are clamped to 10–90%; other cards span 0–100% (0% clears).
+    const locked = card.stage === "review" || card.stage === "locked";
+    const min = locked ? 10 : 0;
+    const max = locked ? 90 : 100;
+    const snapped = Math.min(max, Math.max(min, Math.round(frac * 10) * 10));
     if (snapped !== dragValue) {
       setDragValue(snapped);
     }

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -28,8 +28,6 @@ interface CardProps {
   onInProgress: (card: CardModel) => void;
   onRename: (card: CardModel, title: string) => void;
   onOpen: (card: CardModel) => void;
-  /** Locking requires a reason, gathered in a modal lifted to App. */
-  onRequestLock: (card: CardModel) => void;
   /** Reassign the card's team / person from the avatar menu (when provided). */
   teams?: string[];
   people?: string[];
@@ -83,7 +81,6 @@ export function Card({
   onInProgress,
   onRename,
   onOpen,
-  onRequestLock,
   teams,
   people,
   users,
@@ -188,13 +185,6 @@ export function Card({
     e.stopPropagation();
     setMenuOpen(false);
     onInProgress(card);
-  };
-
-  // Locking opens a modal (lifted to App) to gather the reason note.
-  const requestLock = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    setMenuOpen(false);
-    onRequestLock(card);
   };
 
   const pickAssignTeam = (team: string | null) => {
@@ -353,9 +343,7 @@ export function Card({
                   key={stage}
                   type="button"
                   className={`card-stage-item${card.stage === stage ? " card-stage-item-active" : ""}`}
-                  onClick={(e) =>
-                    stage === "locked" ? requestLock(e) : pickStage(e, stage)
-                  }
+                  onClick={(e) => pickStage(e, stage)}
                 >
                   <span
                     className="card-stage-dot"

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -41,7 +41,6 @@ interface MeBoardProps {
   reload: () => void;
   onError: (message: string) => void;
   onOpen: (card: CardModel) => void;
-  onRequestLock: (card: CardModel) => void;
 }
 
 /** Per-group metadata for the Me board: just the destination zone. */
@@ -71,7 +70,6 @@ export function MeBoard({
   reload,
   onError,
   onOpen,
-  onRequestLock,
 }: MeBoardProps) {
   const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -729,7 +727,6 @@ export function MeBoard({
                   onInProgress={handleInProgress}
                   onRename={handleRename}
                   onOpen={onOpen}
-                  onRequestLock={onRequestLock}
                   teams={teams}
                   people={people}
                   users={users}
@@ -754,7 +751,6 @@ export function MeBoard({
                   onInProgress={() => {}}
                   onRename={() => {}}
                   onOpen={() => {}}
-                  onRequestLock={() => {}}
                 />
               )}
               renderGroup={(group, body, { isOver, dropRef }) => {
@@ -773,8 +769,11 @@ export function MeBoard({
                       {body}
                       <AddCard
                         forcedTeam={
-                          teamFilter?.length === 1 ? teamFilter[0] || null : null
+                          teamFilter?.length === 1
+                            ? teamFilter[0] || null
+                            : undefined
                         }
+                        teams={teams}
                         onCreate={(title, team) =>
                           handleCreate(group.meta.zone, title, team)
                         }

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -218,10 +218,10 @@ export function MeBoard({
   };
 
   const handleProgress = (card: CardModel, raw: number) => {
-    // review/locked cards never drop below the one-segment minimum (10%).
+    // review/locked cards are clamped to a 10–90% band (never 0% or 100%).
     const value =
-      (card.stage === "review" || card.stage === "locked") && raw < 10
-        ? 10
+      card.stage === "review" || card.stage === "locked"
+        ? Math.min(90, Math.max(10, raw))
         : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -49,7 +49,6 @@ interface TeamBoardProps {
   reload: () => void;
   onError: (message: string) => void;
   onOpen: (card: CardModel) => void;
-  onRequestLock: (card: CardModel) => void;
 }
 
 /** Per-group metadata for the Team board: the destination engineer + zone. */
@@ -82,7 +81,6 @@ export function TeamBoard({
   reload,
   onError,
   onOpen,
-  onRequestLock,
 }: TeamBoardProps) {
   const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -1297,7 +1295,6 @@ export function TeamBoard({
               onInProgress={handleInProgress}
               onRename={handleRename}
               onOpen={onOpen}
-              onRequestLock={onRequestLock}
               teams={roster}
               people={people}
               users={users}
@@ -1323,7 +1320,6 @@ export function TeamBoard({
               onInProgress={handleInProgress}
               onRename={handleRename}
               onOpen={onOpen}
-              onRequestLock={onRequestLock}
               teams={roster}
               people={people}
               users={users}
@@ -1349,7 +1345,6 @@ export function TeamBoard({
               onInProgress={() => {}}
               onRename={() => {}}
               onOpen={() => {}}
-              onRequestLock={() => {}}
             />
           )}
           renderGroup={(group, body, { isOver, dropRef }) => {

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -671,10 +671,10 @@ export function TeamBoard({
   };
 
   const handleProgress = (card: CardModel, raw: number) => {
-    // review/locked cards never drop below the one-segment minimum (10%).
+    // review/locked cards are clamped to a 10–90% band (never 0% or 100%).
     const value =
-      (card.stage === "review" || card.stage === "locked") && raw < 10
-        ? 10
+      card.stage === "review" || card.stage === "locked"
+        ? Math.min(90, Math.max(10, raw))
         : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };


### PR DESCRIPTION
Two small board fixes.

## Lock without a reason comment

Locking a card no longer pops a modal asking for a reason note. The **Locked** status is set directly from the stage menu, and the whole LockDialog flow is removed (App, both boards, the Card).

## Me board: pick the team when 0 or 2+ teams are filtered

Creating a task in the Me board while **no team — or two or more teams —** is selected now shows the team picker, so you choose which team it goes to. A single filtered team is still used directly.

## Review / Locked progress is capped at 90%

A Review or Locked card is clamped to a 10–90% band: the slider can't reach 100% and the value is clamped, mirroring the existing 10% floor. (Setting Review/Locked on a full card already dropped it to 90%.)

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein
