### PR TITLE
feat(api,mcp): board-logic core over a swappable backend; hosted MCP with OAuth

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -15,10 +15,11 @@ Code that implements these rules:
 A card carries **two independent dates**:
 
 - **Sprint Start** (`sprintStart`) — the **sprint** the card belongs to (the
-  sprint's start date). Carry Over moves this; the Team board groups by it.
+  sprint's start date). Carry Over moves this; the Team board groups a materialized
+  card by it.
 - **Start** (`startDate`) — the card's **scheduled day**: the day it starts
-  showing and "materializes" into its sprint. Set to the day the card was created
-  (the viewed day); send-to-next-day moves it forward.
+  showing and "materializes" into its sprint. Set to the viewed day (`selectedDate`)
+  the card was created on; send-to-next-day moves it forward.
 
 Also:
 - **Day** (`day`, date) — set on create, not used by any filter.
@@ -46,17 +47,21 @@ its sprint, or deferred with send-to-next-day.
 ### Create
 - `sprintStart = currentSprint(team)` — the card joins the team's **current
   sprint** (which may be an earlier day than today).
-- `startDate = today` (the viewed day) — its scheduled day is now.
-- First sprint: if the team has none yet, creating records today as its first
-  sprint on the sprint-state card.
+- `startDate = selectedDate` (the viewed day) — its scheduled day is the day in
+  view.
+- First sprint: if the team has none yet, creating records the viewed day as its
+  first sprint on the sprint-state card.
 
-### Team view — a sprint's day (`selectedDate`)
-- A card shows on **its sprint's day** and only once it has materialized:
-  `sprintStart === selectedDate` **AND** `startDate <= today`.
-- The team lead navigates to a sprint's start date to see **all** that sprint's
-  cards, including ones created on later days of the sprint.
-- A card **deferred to the future** (`startDate > today`) is hidden until its day
-  arrives — it is not yet within the sprint's realized dates.
+### Team view — a card's effective day (`selectedDate`)
+- A card shows on its **effective day**: its sprint (`sprintStart`) once it has
+  materialized (`startDate <= today`), but its scheduled day (`startDate`) while
+  that is still in the future. Show iff `effectiveDay === selectedDate`.
+- A **materialized** card therefore sits on its sprint's start date, so the team
+  lead navigates there to see **all** that sprint's cards, including ones created
+  on later days of the sprint.
+- A card **deferred to the future** (`startDate > today`) shows on its own future
+  day instead of the sprint day, and rejoins the sprint day once today catches up
+  to its `startDate`.
 
 ### Me view — a personal day (`selectedDate`)
 - A card (assigned to the viewer) shows when its scheduled day has arrived and it
@@ -88,7 +93,7 @@ its sprint, or deferred with send-to-next-day.
    one-field "single-day" model is dropped.)
 2. **Me by the active sprint on the viewed day** (current, or previous when
    scrolled back), gated by `startDate <= selectedDate`.
-3. **Team by `sprintStart === selectedDate` and `startDate <= today`** — strictly
-   the sprint's day, hiding future-deferred cards.
+3. **Team by a card's effective day** — `sprintStart` once materialized, else the
+   future `startDate`; a deferred card shows on its own day, not the sprint day.
 4. **Send-to-next-day moves `startDate`** (not the sprint).
 5. The existing telemetry card is left as-is (the owner will move it).

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -1,0 +1,110 @@
+# Board dates, sprints, and card visibility
+
+This is the source of truth for how aeman places cards on days, what a "sprint"
+is, and the visibility rules for the Team / Me / Weekly views, plus create,
+Carry Over, and send-to-next-day. The date logic is subtle — **keep this file in
+sync with the code** whenever the rules change.
+
+Code that implements these rules:
+- Frontend: `web/src/components/{TeamBoard,MeBoard,Card}.tsx`, `web/src/date.ts`,
+  `web/src/sprint.ts`.
+- Go: `internal/board/{filters,date,sprint}.go`, `internal/boardservice/service.go`.
+
+## Fields
+
+GitHub Project fields on a card:
+
+- **Sprint Start** (`sprintStart`, date) — the sprint the card belongs to. Carry
+  Over moves this and groups by it.
+- **Start** (`startDate`, date) — the card's display day (the day it appears on
+  the day board). *Naming is historical; see Open question 1.*
+- **Day** (`day`, date) — set on create, currently not used by any filter.
+- **Week** (`week`, date) — weekly-plan only (Monday of the plan week).
+
+The hidden per-team **`aeman:sprint-state`** card carries the team's sprint
+pointer: its `Sprint Start` = the team's **current** sprint date, its `Start` =
+the team's **previous** sprint date. Read via `currentSprint(team)` /
+`previousSprint(team)`.
+
+## Concepts
+
+- A **sprint** is a team's batch of work anchored to a start date. Each team's
+  current and previous sprint live on its sprint-state card.
+- **Carry Over** (button) advances the team's sprint to today (current →
+  previous), and pulls its **unfinished** cards forward to today. **Done cards
+  are left on their day** (they do not crawl to the new sprint). After it runs,
+  the board jumps the viewed day to today.
+
+## Rules (current intent)
+
+### Create
+- A new card **joins the team's current sprint**: `sprintStart = currentSprint(team)`
+  — which may be an earlier day (e.g. the sprint is "yesterday" and you add a
+  card today).
+- Its **display date = today** (the viewed day): `startDate = today`.
+- So a card created today while the team's sprint is yesterday belongs to
+  yesterday's sprint but is shown on today.
+- First sprint: if the team has no sprint yet, creating records today as its
+  first sprint on the sprint-state card.
+
+### Team view — one day at a time (`selectedDate`)
+- A card shows **only on its display day**: `startDate === selectedDate`.
+- It does not appear on earlier or later days. A card sent to a future day does
+  not show today; a card on a past day is not pulled onto today (Carry Over does
+  that).
+
+### Me view — one day at a time (`selectedDate`)
+- A card (assigned to the viewer) shows from the moment its day arrives, and
+  keeps showing **until it is completed *and* a new sprint has started**.
+- ⇒ visible while `previousSprint(team) <= sprintStart <= selectedDate`: a done
+  card from the just-ended sprint stays visible until the **next** sprint starts;
+  an unfinished card is carried forward by Carry Over and keeps showing.
+- The team-focus "eye" toggle further narrows to the selected teams (not
+  persisted, off by default).
+
+### Carry Over
+- No-op if the team's sprint is already today.
+- Otherwise: sets sprint-state to (current = today, previous = old current), and
+  for every **unfinished** card with `sprintStart < today`, sets `sprintStart =
+  today` (sweeps in-between and externally-created cards too). Future-dated cards
+  and **done** cards stay put.
+
+### Send to next day
+- The per-card "+1 day" / "-1 day" control shifts the card forward / back by a
+  day, relative to the day you are viewing.
+- **Which field it moves is Open question 4.**
+
+## Open questions (need a decision)
+
+> These are the points where the rules above are under-specified or where earlier
+> statements conflict. Resolve each, then the doc and code get finalized.
+
+1. **One date or two?**
+   - The "single-day" model (confirmed earlier, and implemented but **not
+     deployed**): a card lives on exactly one day = `sprintStart`; its sprint
+     membership *is* its display day — one field.
+   - The latest create rule ("join yesterday's sprint, but end date is today")
+     needs the sprint membership (yesterday) and the display day (today) to
+     **differ** — two fields (`sprintStart` = sprint, `startDate` = display day).
+   - **Decide:** one field (day = sprint) or two fields (sprint + display day)?
+     The "Rules" above are written for the two-field reading.
+
+2. **Me lower bound: current or previous sprint?**
+   - Earlier: "completed cards drop from Me when a new sprint starts" → `currentSprint`.
+   - Latest (telemetry should stay visible; "show until completed *and* new
+     sprint") → `previousSprint`.
+   - **Proposed:** `previousSprint` (recent done work lingers one sprint, then
+     drops). The "Rules" above assume this. Confirm.
+
+3. **Team "its day".** With two fields, Team filters by the **display day**
+   (`startDate === selectedDate`). Confirm Team is strictly one day (not a span).
+
+4. **Send to next day moves which field?** The display day (`startDate`), the
+   sprint (`sprintStart`), or both? (Moving only the display day keeps the card
+   in its sprint but shifts where it shows; moving the sprint re-buckets it.)
+
+5. **Existing telemetry card.** It is done with `sprintStart = startDate =
+   2026-06-26` (marketing's previous sprint), so it landed on the 26th from the
+   old "create joins the sprint day" behavior. Once the rules above ship it shows
+   in Me again (previous-sprint bound). Want it left as-is, or its dates bumped
+   to today?

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -1,110 +1,94 @@
 # Board dates, sprints, and card visibility
 
-This is the source of truth for how aeman places cards on days, what a "sprint"
-is, and the visibility rules for the Team / Me / Weekly views, plus create,
-Carry Over, and send-to-next-day. The date logic is subtle — **keep this file in
-sync with the code** whenever the rules change.
+Source of truth for how aeman places cards on days, what a "sprint" is, and the
+visibility rules for the Team / Me / Weekly views, plus create, Carry Over, and
+send-to-next-day. The date logic is subtle — **keep this file in sync with the
+code** whenever the rules change.
 
 Code that implements these rules:
 - Frontend: `web/src/components/{TeamBoard,MeBoard,Card}.tsx`, `web/src/date.ts`,
   `web/src/sprint.ts`.
 - Go: `internal/board/{filters,date,sprint}.go`, `internal/boardservice/service.go`.
 
-## Fields
+## Two dates per card
 
-GitHub Project fields on a card:
+A card carries **two independent dates**:
 
-- **Sprint Start** (`sprintStart`, date) — the sprint the card belongs to. Carry
-  Over moves this and groups by it.
-- **Start** (`startDate`, date) — the card's display day (the day it appears on
-  the day board). *Naming is historical; see Open question 1.*
-- **Day** (`day`, date) — set on create, currently not used by any filter.
+- **Sprint Start** (`sprintStart`) — the **sprint** the card belongs to (the
+  sprint's start date). Carry Over moves this; the Team board groups by it.
+- **Start** (`startDate`) — the card's **scheduled day**: the day it starts
+  showing and "materializes" into its sprint. Set to the day the card was created
+  (the viewed day); send-to-next-day moves it forward.
+
+Also:
+- **Day** (`day`, date) — set on create, not used by any filter.
 - **Week** (`week`, date) — weekly-plan only (Monday of the plan week).
+- Hidden per-team **`aeman:sprint-state`** card: `Sprint Start` = the team's
+  **current** sprint date, `Start` = its **previous** sprint date. Read via
+  `currentSprint(team)` / `previousSprint(team)`.
 
-The hidden per-team **`aeman:sprint-state`** card carries the team's sprint
-pointer: its `Sprint Start` = the team's **current** sprint date, its `Start` =
-the team's **previous** sprint date. Read via `currentSprint(team)` /
-`previousSprint(team)`.
+`startDate` and `sprintStart` differ whenever a card is created on a later day of
+its sprint, or deferred with send-to-next-day.
 
 ## Concepts
 
-- A **sprint** is a team's batch of work anchored to a start date. Each team's
-  current and previous sprint live on its sprint-state card.
-- **Carry Over** (button) advances the team's sprint to today (current →
-  previous), and pulls its **unfinished** cards forward to today. **Done cards
-  are left on their day** (they do not crawl to the new sprint). After it runs,
-  the board jumps the viewed day to today.
+- A **sprint** is a team's batch of work anchored to a start date; a team's
+  current/previous sprint live on its sprint-state card.
+- **`activeSprint(team, day)`** = which sprint was current on a given day:
+  `current` if `day >= current`, else `previous` if `day >= previous`, else none
+  (we only track the last two sprints).
+- **Carry Over** advances the team's sprint to today (current → previous) and
+  pulls its **unfinished** cards forward (sets their `sprintStart = today`). Done
+  cards stay on their sprint. After it runs, the board jumps the viewed day to today.
 
-## Rules (current intent)
+## Rules
 
 ### Create
-- A new card **joins the team's current sprint**: `sprintStart = currentSprint(team)`
-  — which may be an earlier day (e.g. the sprint is "yesterday" and you add a
-  card today).
-- Its **display date = today** (the viewed day): `startDate = today`.
-- So a card created today while the team's sprint is yesterday belongs to
-  yesterday's sprint but is shown on today.
-- First sprint: if the team has no sprint yet, creating records today as its
-  first sprint on the sprint-state card.
+- `sprintStart = currentSprint(team)` — the card joins the team's **current
+  sprint** (which may be an earlier day than today).
+- `startDate = today` (the viewed day) — its scheduled day is now.
+- First sprint: if the team has none yet, creating records today as its first
+  sprint on the sprint-state card.
 
-### Team view — one day at a time (`selectedDate`)
-- A card shows **only on its display day**: `startDate === selectedDate`.
-- It does not appear on earlier or later days. A card sent to a future day does
-  not show today; a card on a past day is not pulled onto today (Carry Over does
-  that).
+### Team view — a sprint's day (`selectedDate`)
+- A card shows on **its sprint's day** and only once it has materialized:
+  `sprintStart === selectedDate` **AND** `startDate <= today`.
+- The team lead navigates to a sprint's start date to see **all** that sprint's
+  cards, including ones created on later days of the sprint.
+- A card **deferred to the future** (`startDate > today`) is hidden until its day
+  arrives — it is not yet within the sprint's realized dates.
 
-### Me view — one day at a time (`selectedDate`)
-- A card (assigned to the viewer) shows from the moment its day arrives, and
-  keeps showing **until it is completed *and* a new sprint has started**.
-- ⇒ visible while `previousSprint(team) <= sprintStart <= selectedDate`: a done
-  card from the just-ended sprint stays visible until the **next** sprint starts;
-  an unfinished card is carried forward by Carry Over and keeps showing.
+### Me view — a personal day (`selectedDate`)
+- A card (assigned to the viewer) shows when its scheduled day has arrived and it
+  belongs to the sprint that was current on the viewed day:
+  `startDate <= selectedDate` **AND** `sprintStart === activeSprint(team, selectedDate)`.
+- So **today** shows the current sprint's cards (everything from the sprint's
+  start up to today). Rolling **back** into the previous sprint's days shows that
+  sprint's cards — e.g. a card you completed in the previous sprint reappears when
+  you scroll to a day that fell inside it.
+- A deferred card (`startDate` in the future) is not shown until that day.
 - The team-focus "eye" toggle further narrows to the selected teams (not
   persisted, off by default).
 
 ### Carry Over
 - No-op if the team's sprint is already today.
-- Otherwise: sets sprint-state to (current = today, previous = old current), and
-  for every **unfinished** card with `sprintStart < today`, sets `sprintStart =
-  today` (sweeps in-between and externally-created cards too). Future-dated cards
-  and **done** cards stay put.
+- Else: sets sprint-state to (current = today, previous = old current), and for
+  every **unfinished** card with `sprintStart < today`, sets `sprintStart = today`.
+  Future-dated and **done** cards stay put. Then the view jumps to today.
 
 ### Send to next day
-- The per-card "+1 day" / "-1 day" control shifts the card forward / back by a
-  day, relative to the day you are viewing.
-- **Which field it moves is Open question 4.**
+- The per-card "+1 day" / "-1 day" control moves **`startDate`** by a day
+  (the card stays in its sprint, `sprintStart` unchanged). The card disappears
+  from Me/Team until its new `startDate` arrives (deferring into the future hides
+  it; it reappears when that day comes).
 
-## Open questions (need a decision)
+## Resolved open questions
 
-> These are the points where the rules above are under-specified or where earlier
-> statements conflict. Resolve each, then the doc and code get finalized.
-
-1. **One date or two?**
-   - The "single-day" model (confirmed earlier, and implemented but **not
-     deployed**): a card lives on exactly one day = `sprintStart`; its sprint
-     membership *is* its display day — one field.
-   - The latest create rule ("join yesterday's sprint, but end date is today")
-     needs the sprint membership (yesterday) and the display day (today) to
-     **differ** — two fields (`sprintStart` = sprint, `startDate` = display day).
-   - **Decide:** one field (day = sprint) or two fields (sprint + display day)?
-     The "Rules" above are written for the two-field reading.
-
-2. **Me lower bound: current or previous sprint?**
-   - Earlier: "completed cards drop from Me when a new sprint starts" → `currentSprint`.
-   - Latest (telemetry should stay visible; "show until completed *and* new
-     sprint") → `previousSprint`.
-   - **Proposed:** `previousSprint` (recent done work lingers one sprint, then
-     drops). The "Rules" above assume this. Confirm.
-
-3. **Team "its day".** With two fields, Team filters by the **display day**
-   (`startDate === selectedDate`). Confirm Team is strictly one day (not a span).
-
-4. **Send to next day moves which field?** The display day (`startDate`), the
-   sprint (`sprintStart`), or both? (Moving only the display day keeps the card
-   in its sprint but shifts where it shows; moving the sprint re-buckets it.)
-
-5. **Existing telemetry card.** It is done with `sprintStart = startDate =
-   2026-06-26` (marketing's previous sprint), so it landed on the 26th from the
-   old "create joins the sprint day" behavior. Once the rules above ship it shows
-   in Me again (previous-sprint bound). Want it left as-is, or its dates bumped
-   to today?
+1. **Two fields.** `sprintStart` = sprint, `startDate` = scheduled day. (The
+   one-field "single-day" model is dropped.)
+2. **Me by the active sprint on the viewed day** (current, or previous when
+   scrolled back), gated by `startDate <= selectedDate`.
+3. **Team by `sprintStart === selectedDate` and `startDate <= today`** — strictly
+   the sprint's day, hiding future-deferred cards.
+4. **Send-to-next-day moves `startDate`** (not the sprint).
+5. The existing telemetry card is left as-is (the owner will move it).

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -1,0 +1,125 @@
+// Package board holds aeman's pure board logic, ported from the web frontend:
+// date helpers, the stage model, per-team sprint pointers, the three board views
+// (Team grid, Me, Weekly plan) and the status/progress transition rules. Every
+// function works on an in-memory Board snapshot with no network access, so the
+// HTTP API and the MCP server can later expose the same views and actions.
+package board
+
+// SprintStateTitle marks the hidden per-team card that stores a team's sprint
+// pointer (current/previous start dates). It mirrors SPRINT_STATE_TITLE in
+// web/src/providers/github/githubProvider.ts; such cards never render on a board.
+const SprintStateTitle = "aeman:sprint-state"
+
+// ZoneKey is the colour zone a card belongs to, in the Ford sense. It mirrors
+// the ZoneKey union in web/src/providers/types.ts ("" means no zone).
+type ZoneKey string
+
+// The four Ford zones, mirroring web/src/zones.ts. ZoneNone ("") is no zone.
+const (
+	ZoneNone   ZoneKey = ""
+	ZoneGray   ZoneKey = "gray"
+	ZoneGreen  ZoneKey = "green"
+	ZoneYellow ZoneKey = "yellow"
+	ZoneRed    ZoneKey = "red"
+)
+
+// PlanBand is a card's weekly-plan band. It mirrors the `plan?: "wed" | "fri"`
+// field in web/src/providers/types.ts; PlanNone ("") means the card is not a
+// weekly-plan card.
+type PlanBand string
+
+// The weekly-plan bands. PlanNone ("") means the card is not in the weekly plan.
+const (
+	PlanNone PlanBand = ""
+	PlanWed  PlanBand = "wed"
+	PlanFri  PlanBand = "fri"
+)
+
+// SingleSelectOption is one choice of a single-select project field. It mirrors
+// the SingleSelectOption interface in web/src/providers/types.ts.
+type SingleSelectOption struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// ProjectField is a column/field defined on a project board. It mirrors the
+// ProjectField interface in web/src/providers/types.ts.
+type ProjectField struct {
+	ID       string               `json:"id"`
+	Name     string               `json:"name"`
+	DataType string               `json:"dataType"`
+	Options  []SingleSelectOption `json:"options,omitempty"`
+}
+
+// Card is a single project item with the well-known field values the boards
+// orient by. It mirrors the Card interface in web/src/providers/types.ts (kept
+// distinct from ghprojects.Card, which has no typed Stage/Plan/Week/ReviewOf and
+// stores them only in a generic map).
+type Card struct {
+	ItemID    string   `json:"itemId"`
+	Title     string   `json:"title"`
+	Assignees []string `json:"assignees"`
+	// Team is the card's team label ("" = the no-team group).
+	Team string  `json:"team,omitempty"`
+	Zone ZoneKey `json:"zone,omitempty"`
+	// Progress is the readiness percentage (0..100); 0 also stands for unset,
+	// matching the frontend's `progress ?? 0`.
+	Progress int      `json:"progress"`
+	Stage    StageKey `json:"stage,omitempty"`
+	// StartDate is the day the card starts on; SprintStart is the start day of the
+	// sprint it belongs to (what the day boards orient by).
+	StartDate   string `json:"startDate,omitempty"`
+	SprintStart string `json:"sprintStart,omitempty"`
+	// Plan/Week place the card in the founders' weekly plan (Week is a Monday).
+	Plan PlanBand `json:"plan,omitempty"`
+	Week string   `json:"week,omitempty"`
+	// ReviewOf, on a review card, is the itemId of the original card it reviews.
+	ReviewOf  string `json:"reviewOf,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+// SprintState is a team's explicit sprint pointer, read from its hidden
+// sprint-state card: the current and previous sprint start dates (and the card's
+// item id). It mirrors the SprintState interface in web/src/providers/types.ts;
+// "" means the team has no such sprint yet.
+type SprintState struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous"`
+	ItemID   string `json:"itemId"`
+}
+
+// Board is an in-memory snapshot of a project board: its fields, the visible
+// cards (sprint-state cards excluded) and the per-team sprint pointers. It
+// mirrors the Board interface in web/src/providers/types.ts.
+type Board struct {
+	Fields []ProjectField `json:"fields"`
+	Cards  []Card         `json:"cards"`
+	// SprintStates maps each team key ("" = the no-team group) to its pointer.
+	SprintStates map[string]SprintState `json:"sprintStates"`
+}
+
+// NewBoard builds a Board snapshot from a board's fields and full card list,
+// splitting the hidden sprint-state cards out of Cards into SprintStates (keyed
+// by team, "" = the no-team group). It mirrors mapProject's split: a sprint-state
+// card's Team is its key, its SprintStart is the team's current sprint and its
+// StartDate (the "Start" field) is the previous sprint.
+func NewBoard(fields []ProjectField, cards []Card) Board {
+	b := Board{
+		Fields:       fields,
+		Cards:        make([]Card, 0, len(cards)),
+		SprintStates: map[string]SprintState{},
+	}
+	for _, c := range cards {
+		if c.Title == SprintStateTitle {
+			b.SprintStates[c.Team] = SprintState{
+				Current:  c.SprintStart,
+				Previous: c.StartDate,
+				ItemID:   c.ItemID,
+			}
+			continue
+		}
+		b.Cards = append(b.Cards, c)
+	}
+	return b
+}

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -57,7 +57,13 @@ type ProjectField struct {
 // distinct from ghprojects.Card, which has no typed Stage/Plan/Week/ReviewOf and
 // stores them only in a generic map).
 type Card struct {
-	ItemID    string   `json:"itemId"`
+	ItemID string `json:"itemId"`
+	// ContentID is the node id of the underlying issue/PR/draft and IsDraft marks
+	// a draft-issue card. They mirror the contentId/isDraft fields on the frontend
+	// Card; a backend needs them to rename, reassign or note on the card (the pure
+	// views never read them).
+	ContentID string   `json:"contentId,omitempty"`
+	IsDraft   bool     `json:"isDraft,omitempty"`
 	Title     string   `json:"title"`
 	Assignees []string `json:"assignees"`
 	// Team is the card's team label ("" = the no-team group).
@@ -79,6 +85,23 @@ type Card struct {
 	CreatedAt string `json:"createdAt,omitempty"`
 }
 
+// CreateInput is the payload for creating a card on a board: the fields a create
+// can set. It mirrors NewCardInput in web/src/providers/types.ts. It lives in the
+// board package (not boardservice) so a backend can implement the create method
+// without importing boardservice. An empty field is left unset.
+type CreateInput struct {
+	Title       string   `json:"title"`
+	Zone        ZoneKey  `json:"zone,omitempty"`
+	Day         string   `json:"day,omitempty"`
+	Start       string   `json:"start,omitempty"`
+	SprintStart string   `json:"sprintStart,omitempty"`
+	Assignee    string   `json:"assignee,omitempty"`
+	Team        string   `json:"team,omitempty"`
+	ReviewOf    string   `json:"reviewOf,omitempty"`
+	Plan        PlanBand `json:"plan,omitempty"`
+	Week        string   `json:"week,omitempty"`
+}
+
 // SprintState is a team's explicit sprint pointer, read from its hidden
 // sprint-state card: the current and previous sprint start dates (and the card's
 // item id). It mirrors the SprintState interface in web/src/providers/types.ts;
@@ -93,6 +116,12 @@ type SprintState struct {
 // cards (sprint-state cards excluded) and the per-team sprint pointers. It
 // mirrors the Board interface in web/src/providers/types.ts.
 type Board struct {
+	// ID/Number/Owner identify the project this snapshot came from, so a backend
+	// can apply mutations against it. They mirror the id/number/owner fields on the
+	// frontend Board and are empty on hand-built snapshots that never get persisted.
+	ID     string         `json:"id,omitempty"`
+	Number int            `json:"number,omitempty"`
+	Owner  string         `json:"owner,omitempty"`
 	Fields []ProjectField `json:"fields"`
 	Cards  []Card         `json:"cards"`
 	// SprintStates maps each team key ("" = the no-team group) to its pointer.

--- a/internal/board/date.go
+++ b/internal/board/date.go
@@ -31,12 +31,14 @@ func ActiveOnDay(start, finish, day string) bool {
 	if from == "" {
 		from = finish
 	}
-	to := finish
-	if to == "" {
-		to = start
-	}
-	if from == "" || to == "" {
+	if from == "" {
 		return false
+	}
+	// The span runs from `start` to the later of start/finish, so a card whose
+	// start day is past its sprint (added on a later day) still shows on its day.
+	to := from
+	if finish > from {
+		to = finish
 	}
 	return from <= day && day <= to
 }

--- a/internal/board/date.go
+++ b/internal/board/date.go
@@ -1,0 +1,107 @@
+package board
+
+import "time"
+
+// isoLayout is the yyyy-mm-dd date layout the boards orient by.
+const isoLayout = "2006-01-02"
+
+// TodayIso returns today's date as a local yyyy-mm-dd string. It mirrors todayIso
+// in web/src/date.ts.
+func TodayIso() string {
+	return time.Now().Format(isoLayout)
+}
+
+// LocalDateIso returns the local yyyy-mm-dd date for an ISO timestamp, or "" when
+// the timestamp cannot be parsed. It mirrors localDateIso in web/src/date.ts.
+func LocalDateIso(iso string) string {
+	t, ok := parseTimestamp(iso)
+	if !ok {
+		return ""
+	}
+	return t.In(time.Local).Format(isoLayout)
+}
+
+// ActiveOnDay reports whether `day` falls within a card's [start, finish] range.
+// A missing bound collapses to the other date, so a card with a single date is
+// active only on that day and a card with neither date is never on the day board.
+// It mirrors activeOnDay in web/src/date.ts (from = start||finish,
+// to = finish||start, from <= day <= to).
+func ActiveOnDay(start, finish, day string) bool {
+	from := start
+	if from == "" {
+		from = finish
+	}
+	to := finish
+	if to == "" {
+		to = start
+	}
+	if from == "" || to == "" {
+		return false
+	}
+	return from <= day && day <= to
+}
+
+// DaysSince returns the whole days between an ISO timestamp's local date and the
+// `asOf` day (a yyyy-mm-dd string; "" means today). It never goes negative. It
+// mirrors daysSince in web/src/date.ts.
+func DaysSince(iso, asOf string) int {
+	if iso == "" {
+		return 0
+	}
+	then := LocalDateIso(iso)
+	if then == "" {
+		return 0
+	}
+	if asOf == "" {
+		asOf = TodayIso()
+	}
+	t1, err1 := time.Parse(isoLayout, then)
+	t2, err2 := time.Parse(isoLayout, asOf)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+	days := int(t2.Sub(t1) / (24 * time.Hour))
+	if days < 0 {
+		return 0
+	}
+	return days
+}
+
+// MondayOf returns the yyyy-mm-dd Monday of the week containing `iso`, or `iso`
+// unchanged when it is not a parseable date. It mirrors mondayOf in
+// web/src/date.ts.
+func MondayOf(iso string) string {
+	t, err := time.Parse(isoLayout, iso)
+	if err != nil {
+		return iso
+	}
+	// time.Weekday and JS getDay both run Sunday=0..Saturday=6, so (wd+6)%7 is the
+	// number of days back to Monday.
+	offset := (int(t.Weekday()) + 6) % 7
+	return t.AddDate(0, 0, -offset).Format(isoLayout)
+}
+
+// AddDays shifts a yyyy-mm-dd date by delta days, returning yyyy-mm-dd, or `iso`
+// unchanged when it is not a parseable date. It mirrors addDays in
+// web/src/date.ts.
+func AddDays(iso string, delta int) string {
+	t, err := time.Parse(isoLayout, iso)
+	if err != nil {
+		return iso
+	}
+	return t.AddDate(0, 0, delta).Format(isoLayout)
+}
+
+// parseTimestamp parses an ISO timestamp the way the frontend's `new Date(iso)`
+// does for the inputs aeman sees: an RFC 3339 timestamp or a bare yyyy-mm-dd.
+func parseTimestamp(iso string) (time.Time, bool) {
+	if iso == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05", isoLayout} {
+		if t, err := time.Parse(layout, iso); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/board/date_test.go
+++ b/internal/board/date_test.go
@@ -1,0 +1,120 @@
+package board
+
+import (
+	"testing"
+	"time"
+)
+
+func TestActiveOnDay(t *testing.T) {
+	cases := []struct {
+		name          string
+		start, finish string
+		day           string
+		want          bool
+	}{
+		{"neither bound", "", "", "2026-06-15", false},
+		{"start only, on day", "2026-06-10", "", "2026-06-10", true},
+		{"start only, before", "2026-06-10", "", "2026-06-09", false},
+		{"start only, after", "2026-06-10", "", "2026-06-11", false},
+		{"finish only, on day", "", "2026-06-10", "2026-06-10", true},
+		{"finish only, before", "", "2026-06-10", "2026-06-09", false},
+		{"range, on start", "2026-06-10", "2026-06-20", "2026-06-10", true},
+		{"range, in middle", "2026-06-10", "2026-06-20", "2026-06-15", true},
+		{"range, on finish", "2026-06-10", "2026-06-20", "2026-06-20", true},
+		{"range, before", "2026-06-10", "2026-06-20", "2026-06-09", false},
+		{"range, after", "2026-06-10", "2026-06-20", "2026-06-21", false},
+		{"inverted bounds never active", "2026-06-20", "2026-06-10", "2026-06-15", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ActiveOnDay(c.start, c.finish, c.day); got != c.want {
+				t.Errorf("ActiveOnDay(%q,%q,%q) = %v, want %v", c.start, c.finish, c.day, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMondayOf(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"2026-06-15", "2026-06-15"}, // Monday → itself
+		{"2026-06-17", "2026-06-15"}, // Wednesday
+		{"2026-06-21", "2026-06-15"}, // Sunday (end of week)
+		{"2026-06-22", "2026-06-22"}, // next Monday
+		{"2026-07-01", "2026-06-29"}, // Wednesday, Monday is in the prior month
+		{"garbage", "garbage"},       // unparseable → unchanged
+	}
+	for _, c := range cases {
+		if got := MondayOf(c.in); got != c.want {
+			t.Errorf("MondayOf(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAddDays(t *testing.T) {
+	cases := []struct {
+		in    string
+		delta int
+		want  string
+	}{
+		{"2026-06-15", 0, "2026-06-15"},
+		{"2026-06-30", 1, "2026-07-01"},  // month boundary
+		{"2026-06-01", -1, "2026-05-31"}, // month boundary back
+		{"2026-12-31", 1, "2027-01-01"},  // year boundary
+		{"2026-03-01", -1, "2026-02-28"}, // non-leap February
+		{"2026-06-15", 7, "2026-06-22"},  // a week ahead
+		{"garbage", 3, "garbage"},        // unparseable → unchanged
+	}
+	for _, c := range cases {
+		if got := AddDays(c.in, c.delta); got != c.want {
+			t.Errorf("AddDays(%q,%d) = %q, want %q", c.in, c.delta, got, c.want)
+		}
+	}
+}
+
+func TestDaysSince(t *testing.T) {
+	// Build the timestamp from local noon so converting to a local date never
+	// crosses a day boundary, keeping the test timezone-independent.
+	noon := time.Date(2026, 6, 25, 12, 0, 0, 0, time.Local).Format(time.RFC3339)
+
+	cases := []struct {
+		name      string
+		iso, asOf string
+		want      int
+	}{
+		{"empty iso", "", "2026-06-30", 0},
+		{"unparseable iso", "garbage", "2026-06-30", 0},
+		{"five days", noon, "2026-06-30", 5},
+		{"same day", noon, "2026-06-25", 0},
+		{"asOf before never negative", noon, "2026-06-20", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DaysSince(c.iso, c.asOf); got != c.want {
+				t.Errorf("DaysSince(%q,%q) = %d, want %d", c.iso, c.asOf, got, c.want)
+			}
+		})
+	}
+}
+
+func TestLocalDateIso(t *testing.T) {
+	if got := LocalDateIso("garbage"); got != "" {
+		t.Errorf("LocalDateIso(garbage) = %q, want empty", got)
+	}
+	if got := LocalDateIso(""); got != "" {
+		t.Errorf("LocalDateIso(empty) = %q, want empty", got)
+	}
+	// Local noon stays on the same local date in every timezone.
+	tm := time.Date(2026, 6, 25, 12, 0, 0, 0, time.Local)
+	if got := LocalDateIso(tm.Format(time.RFC3339)); got != "2026-06-25" {
+		t.Errorf("LocalDateIso(local noon) = %q, want 2026-06-25", got)
+	}
+}
+
+func TestTodayIso(t *testing.T) {
+	got := TodayIso()
+	if _, err := time.Parse(isoLayout, got); err != nil {
+		t.Errorf("TodayIso() = %q, not a yyyy-mm-dd date: %v", got, err)
+	}
+}

--- a/internal/board/date_test.go
+++ b/internal/board/date_test.go
@@ -23,7 +23,11 @@ func TestActiveOnDay(t *testing.T) {
 		{"range, on finish", "2026-06-10", "2026-06-20", "2026-06-20", true},
 		{"range, before", "2026-06-10", "2026-06-20", "2026-06-09", false},
 		{"range, after", "2026-06-10", "2026-06-20", "2026-06-21", false},
-		{"inverted bounds never active", "2026-06-20", "2026-06-10", "2026-06-15", false},
+		// start later than finish (a card added on a day past its sprint): the
+		// span collapses to its start day rather than vanishing.
+		{"start past finish, off its day", "2026-06-20", "2026-06-10", "2026-06-15", false},
+		{"start past finish, on its day", "2026-06-20", "2026-06-10", "2026-06-20", true},
+		{"start past finish, after its day", "2026-06-20", "2026-06-10", "2026-06-21", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/board/filters.go
+++ b/internal/board/filters.go
@@ -4,16 +4,24 @@ import "slices"
 
 // TeamGrid returns the cards shown on the Team board's people×zones grid for a
 // single team on a given day: cards matching the team filter ("" = the no-team
-// group) whose day — their sprintStart — is the viewed day. A card lives on
-// exactly one day; Carry Over moves that day forward, it does not widen a span.
-// It mirrors filteredCards/passesFilter in TeamBoard.tsx.
+// group) whose effective day is the viewed day. A card's effective day is its
+// sprint (sprintStart) once it has materialized, but its scheduled day (startDate)
+// while that is still in the future — so a materialized card sits on its sprint's
+// start date (including ones created on later days), and a deferred card shows on
+// its own future day instead, rejoining the sprint day once today catches up. It
+// mirrors filteredCards in TeamBoard.tsx.
 func TeamGrid(b Board, team, day string) []Card {
+	today := TodayIso()
 	out := []Card{}
 	for _, c := range b.Cards {
 		if c.Team != team {
 			continue
 		}
-		if c.SprintStart == day {
+		eff := c.SprintStart
+		if c.StartDate != "" && c.StartDate > today {
+			eff = c.StartDate
+		}
+		if eff == day {
 			out = append(out, c)
 		}
 	}
@@ -21,22 +29,20 @@ func TeamGrid(b Board, team, day string) []Card {
 }
 
 // MeView returns the cards on the personal day board for a user on a given day:
-// the user's cards (user = "" means everyone) whose day (sprintStart) sits at or
-// after their team's current sprint and at or before the viewed day. The lower
-// bound drops done/old cards from past sprints; the upper bound hides
-// future-dated cards until their day arrives. A card with no team sprint or no
-// sprintStart never shows. It mirrors mine/myCards in MeBoard.tsx.
+// the user's cards (user = "" means everyone) that belong to the sprint that was
+// active on the viewed day (activeSprint) and whose scheduled day has arrived
+// (startDate empty or on or before the viewed day). Today shows the current
+// sprint; rolling back into the previous sprint's days shows that sprint's cards.
+// A card whose team had no active sprint on the day, or that is deferred to the
+// future, never shows. It mirrors myCards in MeBoard.tsx.
 func MeView(b Board, user, day string) []Card {
 	out := []Card{}
 	for _, c := range b.Cards {
 		if user != "" && !slices.Contains(c.Assignees, user) {
 			continue
 		}
-		cur := CurrentSprint(b, c.Team)
-		if cur == "" || c.SprintStart == "" {
-			continue
-		}
-		if cur <= c.SprintStart && c.SprintStart <= day {
+		as := ActiveSprint(b, c.Team, day)
+		if as != "" && c.SprintStart == as && (c.StartDate == "" || c.StartDate <= day) {
 			out = append(out, c)
 		}
 	}

--- a/internal/board/filters.go
+++ b/internal/board/filters.go
@@ -4,17 +4,16 @@ import "slices"
 
 // TeamGrid returns the cards shown on the Team board's people×zones grid for a
 // single team on a given day: cards matching the team filter ("" = the no-team
-// group) that are active on the day across their [startDate, sprintStart] span.
-// A card carried into a later sprint (sprintStart advanced past startDate) shows
-// on every day of that widened span, so it appears in both its original sprint
-// and the new one. It mirrors filteredCards/passesFilter in TeamBoard.tsx.
+// group) whose day — their sprintStart — is the viewed day. A card lives on
+// exactly one day; Carry Over moves that day forward, it does not widen a span.
+// It mirrors filteredCards/passesFilter in TeamBoard.tsx.
 func TeamGrid(b Board, team, day string) []Card {
 	out := []Card{}
 	for _, c := range b.Cards {
 		if c.Team != team {
 			continue
 		}
-		if ActiveOnDay(c.StartDate, c.SprintStart, day) {
+		if c.SprintStart == day {
 			out = append(out, c)
 		}
 	}
@@ -22,26 +21,22 @@ func TeamGrid(b Board, team, day string) []Card {
 }
 
 // MeView returns the cards on the personal day board for a user on a given day:
-// the user's cards (user = "" means everyone) whose start (startDate, or
-// sprintStart when absent) and sprintStart are both set, where the day is on or
-// after the start, and the day is on or before the sprint — or that sprint is
-// still the team's current one, so a card stays visible until a new sprint is
-// started. It mirrors mine/myCards in MeBoard.tsx.
+// the user's cards (user = "" means everyone) whose day (sprintStart) sits at or
+// after their team's current sprint and at or before the viewed day. The lower
+// bound drops done/old cards from past sprints; the upper bound hides
+// future-dated cards until their day arrives. A card with no team sprint or no
+// sprintStart never shows. It mirrors mine/myCards in MeBoard.tsx.
 func MeView(b Board, user, day string) []Card {
 	out := []Card{}
 	for _, c := range b.Cards {
 		if user != "" && !slices.Contains(c.Assignees, user) {
 			continue
 		}
-		start := c.StartDate
-		if start == "" {
-			start = c.SprintStart
-		}
-		sprint := c.SprintStart
-		if start == "" || sprint == "" || day < start {
+		cur := CurrentSprint(b, c.Team)
+		if cur == "" || c.SprintStart == "" {
 			continue
 		}
-		if day <= sprint || CurrentSprint(b, c.Team) == sprint {
+		if cur <= c.SprintStart && c.SprintStart <= day {
 			out = append(out, c)
 		}
 	}

--- a/internal/board/filters.go
+++ b/internal/board/filters.go
@@ -1,0 +1,76 @@
+package board
+
+import "slices"
+
+// TeamGrid returns the cards shown on the Team board's people×zones grid for a
+// single team on a given day: cards matching the team filter ("" = the no-team
+// group) that are active on the day across their [startDate, sprintStart] span.
+// A card carried into a later sprint (sprintStart advanced past startDate) shows
+// on every day of that widened span, so it appears in both its original sprint
+// and the new one. It mirrors filteredCards/passesFilter in TeamBoard.tsx.
+func TeamGrid(b Board, team, day string) []Card {
+	out := []Card{}
+	for _, c := range b.Cards {
+		if c.Team != team {
+			continue
+		}
+		if ActiveOnDay(c.StartDate, c.SprintStart, day) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// MeView returns the cards on the personal day board for a user on a given day:
+// the user's cards (user = "" means everyone) whose start (startDate, or
+// sprintStart when absent) and sprintStart are both set, where the day is on or
+// after the start, and the day is on or before the sprint — or that sprint is
+// still the team's current one, so a card stays visible until a new sprint is
+// started. It mirrors mine/myCards in MeBoard.tsx.
+func MeView(b Board, user, day string) []Card {
+	out := []Card{}
+	for _, c := range b.Cards {
+		if user != "" && !slices.Contains(c.Assignees, user) {
+			continue
+		}
+		start := c.StartDate
+		if start == "" {
+			start = c.SprintStart
+		}
+		sprint := c.SprintStart
+		if start == "" || sprint == "" || day < start {
+			continue
+		}
+		if day <= sprint || CurrentSprint(b, c.Team) == sprint {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// WeeklyBands holds a week's plan cards split into the two deadline bands. It
+// mirrors the { wed, fri } shape of the `weekly` memo in TeamBoard.tsx.
+type WeeklyBands struct {
+	Wed []Card `json:"wed"`
+	Fri []Card `json:"fri"`
+}
+
+// WeeklyPlan returns a single team's weekly-plan cards for a given week (a Monday
+// from MondayOf), split into the Wed/Fri bands. A card qualifies when it has a
+// plan band, its week equals `week`, and it matches the team ("" = the no-team
+// group). Only the Fri band collects cards explicitly marked PlanFri; every other
+// plan card falls into Wed. It mirrors the `weekly` memo in TeamBoard.tsx.
+func WeeklyPlan(b Board, team, week string) WeeklyBands {
+	bands := WeeklyBands{Wed: []Card{}, Fri: []Card{}}
+	for _, c := range b.Cards {
+		if c.Plan == PlanNone || c.Week != week || c.Team != team {
+			continue
+		}
+		if c.Plan == PlanFri {
+			bands.Fri = append(bands.Fri, c)
+		} else {
+			bands.Wed = append(bands.Wed, c)
+		}
+	}
+	return bands
+}

--- a/internal/board/filters_test.go
+++ b/internal/board/filters_test.go
@@ -15,9 +15,10 @@ func ids(cards []Card) []string {
 
 func gridBoard() Board {
 	return NewBoard(nil, []Card{
-		// Team A: a fresh card (one sprint day) and one carried into a later sprint.
+		// Team A: a card on its day and one moved (carried) to a later day. The
+		// origin (StartDate) is left behind; only the day (SprintStart) places it.
 		{ItemID: "A1", Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
-		{ItemID: "Acarry", Team: "A", StartDate: "2026-06-15", SprintStart: "2026-06-22"},
+		{ItemID: "Amoved", Team: "A", StartDate: "2026-06-20", SprintStart: "2026-06-26"},
 		{ItemID: "B1", Team: "B", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
 		{ItemID: "N1", Team: "", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
 	})
@@ -30,10 +31,10 @@ func TestTeamGrid(t *testing.T) {
 		team, day string
 		want      []string
 	}{
-		{"new sprint day shows both A cards", "A", "2026-06-22", []string{"A1", "Acarry"}},
-		{"original sprint day shows only the carried card", "A", "2026-06-15", []string{"Acarry"}},
-		{"a mid span day shows the carried card", "A", "2026-06-18", []string{"Acarry"}},
-		{"day past the span is empty", "A", "2026-06-23", []string{}},
+		{"a card shows on its day", "A", "2026-06-22", []string{"A1"}},
+		{"the moved card shows only on its new day", "A", "2026-06-26", []string{"Amoved"}},
+		{"the moved card's origin day no longer shows it", "A", "2026-06-20", []string{}},
+		{"a day with no card is empty", "A", "2026-06-23", []string{}},
 		{"other team is isolated", "B", "2026-06-22", []string{"B1"}},
 		{"no-team group", "", "2026-06-20", []string{"N1"}},
 	}
@@ -48,17 +49,18 @@ func TestTeamGrid(t *testing.T) {
 
 func meBoard() Board {
 	return NewBoard(nil, []Card{
-		// Sprint pointers: A's current sprint is 06-22; B has moved on to 06-25.
-		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-22"},
-		{ItemID: "ss-b", Title: SprintStateTitle, Team: "B", SprintStart: "2026-06-25"},
-		// u's current-sprint card for team A.
-		{ItemID: "u1", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
-		// u's card on a sprint team B has already left behind (no longer current).
-		{ItemID: "u2", Assignees: []string{"u"}, Team: "B", StartDate: "2026-06-10", SprintStart: "2026-06-12"},
+		// Team A's current sprint is 06-26 (previously 06-20).
+		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-26", StartDate: "2026-06-20"},
+		// u's card in the current sprint (a carried card: sprintStart == current).
+		{ItemID: "u1", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-26", SprintStart: "2026-06-26"},
+		// u's future-dated card: hidden until its day (06-28) arrives.
+		{ItemID: "ufuture", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-28", SprintStart: "2026-06-28"},
+		// u's done/old card from a past sprint (sprintStart < current) — never shows.
+		{ItemID: "uold", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
 		// Assigned to u but never placed in a sprint — must never show.
 		{ItemID: "u3", Assignees: []string{"u"}, Team: "A"},
-		// Someone else's card.
-		{ItemID: "u4", Assignees: []string{"v"}, Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
+		// Someone else's current-sprint card.
+		{ItemID: "u4", Assignees: []string{"v"}, Team: "A", StartDate: "2026-06-26", SprintStart: "2026-06-26"},
 	})
 }
 
@@ -69,11 +71,11 @@ func TestMeView(t *testing.T) {
 		user, day string
 		want      []string
 	}{
-		{"on the sprint day", "u", "2026-06-22", []string{"u1"}},
-		{"carried: stays while still the team's current sprint", "u", "2026-06-23", []string{"u1"}},
-		{"a non-current carried sprint only shows within its range", "u", "2026-06-12", []string{"u2"}},
-		{"before start and past a non-current sprint is empty", "u", "2026-06-21", []string{}},
-		{"empty user sees everyone with a sprint", "", "2026-06-22", []string{"u1", "u4"}},
+		{"current-sprint card shows on its day", "u", "2026-06-26", []string{"u1"}},
+		{"current-sprint card still shows on a later day", "u", "2026-06-27", []string{"u1"}},
+		{"future-dated card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture"}},
+		{"before the current sprint nothing shows", "u", "2026-06-25", []string{}},
+		{"empty user sees everyone in the current sprint", "", "2026-06-26", []string{"u1", "u4"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/board/filters_test.go
+++ b/internal/board/filters_test.go
@@ -14,13 +14,20 @@ func ids(cards []Card) []string {
 }
 
 func gridBoard() Board {
+	// TeamGrid places a card on its effective day: sprintStart once materialized
+	// (startDate <= TodayIso()), else the future startDate. To stay independent of
+	// the wall clock, materialized cards carry a startDate far in the past (always
+	// <= today) and the deferred card one far in the future (always > today).
 	return NewBoard(nil, []Card{
-		// Team A: a card on its day and one moved (carried) to a later day. The
-		// origin (StartDate) is left behind; only the day (SprintStart) places it.
-		{ItemID: "A1", Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
-		{ItemID: "Amoved", Team: "A", StartDate: "2026-06-20", SprintStart: "2026-06-26"},
-		{ItemID: "B1", Team: "B", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
-		{ItemID: "N1", Team: "", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
+		// Team A: a materialized card — effective day is its sprint, 06-22.
+		{ItemID: "A1", Team: "A", StartDate: "2000-01-01", SprintStart: "2026-06-22"},
+		// Team A: a deferred card sharing the same sprint — its effective day is the
+		// future startDate (2999-12-31), not the sprint day.
+		{ItemID: "Afuture", Team: "A", StartDate: "2999-12-31", SprintStart: "2026-06-22"},
+		// Team A: a materialized card on a different sprint day.
+		{ItemID: "Aother", Team: "A", StartDate: "2000-01-01", SprintStart: "2026-06-26"},
+		{ItemID: "B1", Team: "B", StartDate: "2000-01-01", SprintStart: "2026-06-22"},
+		{ItemID: "N1", Team: "", StartDate: "2000-01-01", SprintStart: "2026-06-20"},
 	})
 }
 
@@ -31,9 +38,9 @@ func TestTeamGrid(t *testing.T) {
 		team, day string
 		want      []string
 	}{
-		{"a card shows on its day", "A", "2026-06-22", []string{"A1"}},
-		{"the moved card shows only on its new day", "A", "2026-06-26", []string{"Amoved"}},
-		{"the moved card's origin day no longer shows it", "A", "2026-06-20", []string{}},
+		{"materialized card shows on its sprint day; deferred one is not", "A", "2026-06-22", []string{"A1"}},
+		{"deferred card shows on its own future day", "A", "2999-12-31", []string{"Afuture"}},
+		{"another sprint day shows its own card", "A", "2026-06-26", []string{"Aother"}},
 		{"a day with no card is empty", "A", "2026-06-23", []string{}},
 		{"other team is isolated", "B", "2026-06-22", []string{"B1"}},
 		{"no-team group", "", "2026-06-20", []string{"N1"}},
@@ -48,15 +55,19 @@ func TestTeamGrid(t *testing.T) {
 }
 
 func meBoard() Board {
+	// MeView groups a day's cards by activeSprint(team, day) and gates on
+	// startDate <= day — both deterministic in the viewed day, so these cases do
+	// not depend on the wall clock. Team A's current sprint is 06-26, previous 06-20.
 	return NewBoard(nil, []Card{
-		// Team A's current sprint is 06-26 (previously 06-20).
 		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-26", StartDate: "2026-06-20"},
-		// u's card in the current sprint (a carried card: sprintStart == current).
+		// u's card in the current sprint, scheduled on its sprint day.
 		{ItemID: "u1", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-26", SprintStart: "2026-06-26"},
-		// u's future-dated card: hidden until its day (06-28) arrives.
-		{ItemID: "ufuture", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-28", SprintStart: "2026-06-28"},
-		// u's done/old card from a past sprint (sprintStart < current) — never shows.
-		{ItemID: "uold", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
+		// u's current-sprint card deferred to 06-28: hidden until that day arrives.
+		{ItemID: "ufuture", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-28", SprintStart: "2026-06-26"},
+		// u's card in the previous sprint: shows only on days inside [06-20, 06-26).
+		{ItemID: "uprev", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
+		// u's card from before the previous sprint: no active sprint matches it.
+		{ItemID: "uold", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-10", SprintStart: "2026-06-10"},
 		// Assigned to u but never placed in a sprint — must never show.
 		{ItemID: "u3", Assignees: []string{"u"}, Team: "A"},
 		// Someone else's current-sprint card.
@@ -71,11 +82,11 @@ func TestMeView(t *testing.T) {
 		user, day string
 		want      []string
 	}{
-		{"current-sprint card shows on its day", "u", "2026-06-26", []string{"u1"}},
-		{"current-sprint card still shows on a later day", "u", "2026-06-27", []string{"u1"}},
-		{"future-dated card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture"}},
-		{"before the current sprint nothing shows", "u", "2026-06-25", []string{}},
-		{"empty user sees everyone in the current sprint", "", "2026-06-26", []string{"u1", "u4"}},
+		{"current-sprint card shows on its sprint day", "u", "2026-06-26", []string{"u1"}},
+		{"deferred current-sprint card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture"}},
+		{"rolling back shows the previous sprint, hides the current", "u", "2026-06-22", []string{"uprev"}},
+		{"before the previous sprint nothing shows", "u", "2026-06-19", []string{}},
+		{"empty user sees everyone in the active sprint", "", "2026-06-26", []string{"u1", "u4"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/board/filters_test.go
+++ b/internal/board/filters_test.go
@@ -1,0 +1,122 @@
+package board
+
+import (
+	"reflect"
+	"testing"
+)
+
+func ids(cards []Card) []string {
+	out := []string{}
+	for _, c := range cards {
+		out = append(out, c.ItemID)
+	}
+	return out
+}
+
+func gridBoard() Board {
+	return NewBoard(nil, []Card{
+		// Team A: a fresh card (one sprint day) and one carried into a later sprint.
+		{ItemID: "A1", Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
+		{ItemID: "Acarry", Team: "A", StartDate: "2026-06-15", SprintStart: "2026-06-22"},
+		{ItemID: "B1", Team: "B", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
+		{ItemID: "N1", Team: "", StartDate: "2026-06-20", SprintStart: "2026-06-20"},
+	})
+}
+
+func TestTeamGrid(t *testing.T) {
+	b := gridBoard()
+	cases := []struct {
+		name      string
+		team, day string
+		want      []string
+	}{
+		{"new sprint day shows both A cards", "A", "2026-06-22", []string{"A1", "Acarry"}},
+		{"original sprint day shows only the carried card", "A", "2026-06-15", []string{"Acarry"}},
+		{"a mid span day shows the carried card", "A", "2026-06-18", []string{"Acarry"}},
+		{"day past the span is empty", "A", "2026-06-23", []string{}},
+		{"other team is isolated", "B", "2026-06-22", []string{"B1"}},
+		{"no-team group", "", "2026-06-20", []string{"N1"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ids(TeamGrid(b, c.team, c.day)); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("TeamGrid(%q,%q) = %v, want %v", c.team, c.day, got, c.want)
+			}
+		})
+	}
+}
+
+func meBoard() Board {
+	return NewBoard(nil, []Card{
+		// Sprint pointers: A's current sprint is 06-22; B has moved on to 06-25.
+		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-22"},
+		{ItemID: "ss-b", Title: SprintStateTitle, Team: "B", SprintStart: "2026-06-25"},
+		// u's current-sprint card for team A.
+		{ItemID: "u1", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
+		// u's card on a sprint team B has already left behind (no longer current).
+		{ItemID: "u2", Assignees: []string{"u"}, Team: "B", StartDate: "2026-06-10", SprintStart: "2026-06-12"},
+		// Assigned to u but never placed in a sprint — must never show.
+		{ItemID: "u3", Assignees: []string{"u"}, Team: "A"},
+		// Someone else's card.
+		{ItemID: "u4", Assignees: []string{"v"}, Team: "A", StartDate: "2026-06-22", SprintStart: "2026-06-22"},
+	})
+}
+
+func TestMeView(t *testing.T) {
+	b := meBoard()
+	cases := []struct {
+		name      string
+		user, day string
+		want      []string
+	}{
+		{"on the sprint day", "u", "2026-06-22", []string{"u1"}},
+		{"carried: stays while still the team's current sprint", "u", "2026-06-23", []string{"u1"}},
+		{"a non-current carried sprint only shows within its range", "u", "2026-06-12", []string{"u2"}},
+		{"before start and past a non-current sprint is empty", "u", "2026-06-21", []string{}},
+		{"empty user sees everyone with a sprint", "", "2026-06-22", []string{"u1", "u4"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ids(MeView(b, c.user, c.day)); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("MeView(%q,%q) = %v, want %v", c.user, c.day, got, c.want)
+			}
+		})
+	}
+}
+
+func planBoard() Board {
+	return NewBoard(nil, []Card{
+		{ItemID: "p1", Team: "A", Plan: PlanWed, Week: "2026-06-15"},
+		{ItemID: "p2", Team: "A", Plan: PlanFri, Week: "2026-06-15"},
+		{ItemID: "p3", Team: "A", Plan: PlanWed, Week: "2026-06-22"},  // other week
+		{ItemID: "p4", Team: "B", Plan: PlanWed, Week: "2026-06-15"},  // other team
+		{ItemID: "p5", Team: "A", Plan: PlanNone, Week: "2026-06-15"}, // not a plan card
+		{ItemID: "p6", Team: "", Plan: PlanFri, Week: "2026-06-15"},   // no-team group
+	})
+}
+
+func TestWeeklyPlan(t *testing.T) {
+	b := planBoard()
+	cases := []struct {
+		name    string
+		team    string
+		week    string
+		wantWed []string
+		wantFri []string
+	}{
+		{"team A, current week, split by band", "A", "2026-06-15", []string{"p1"}, []string{"p2"}},
+		{"no-team group", "", "2026-06-15", []string{}, []string{"p6"}},
+		{"other week keeps only its card", "A", "2026-06-22", []string{"p3"}, []string{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bands := WeeklyPlan(b, c.team, c.week)
+			if got := ids(bands.Wed); !reflect.DeepEqual(got, c.wantWed) {
+				t.Errorf("WeeklyPlan(%q,%q).Wed = %v, want %v", c.team, c.week, got, c.wantWed)
+			}
+			if got := ids(bands.Fri); !reflect.DeepEqual(got, c.wantFri) {
+				t.Errorf("WeeklyPlan(%q,%q).Fri = %v, want %v", c.team, c.week, got, c.wantFri)
+			}
+		})
+	}
+}

--- a/internal/board/sprint.go
+++ b/internal/board/sprint.go
@@ -13,3 +13,20 @@ func CurrentSprint(b Board, team string) string {
 func PreviousSprint(b Board, team string) string {
 	return b.SprintStates[team].Previous
 }
+
+// ActiveSprint returns which sprint was current for a team on a given day: the
+// team's current sprint when day is on or after it, else the previous sprint when
+// day is on or after that, else "" (only the last two sprints are tracked). The
+// Me view groups a day's cards by this. It mirrors activeSprint in
+// web/src/sprint.ts. team = "" is the no-team group.
+func ActiveSprint(b Board, team, day string) string {
+	cur := CurrentSprint(b, team)
+	prev := PreviousSprint(b, team)
+	if cur != "" && day >= cur {
+		return cur
+	}
+	if prev != "" && day >= prev {
+		return prev
+	}
+	return ""
+}

--- a/internal/board/sprint.go
+++ b/internal/board/sprint.go
@@ -1,0 +1,15 @@
+package board
+
+// CurrentSprint returns a team's current sprint start from its sprint-state card,
+// or "" when the team has no sprint yet. team = "" is the no-team group. It
+// mirrors currentSprint in web/src/sprint.ts.
+func CurrentSprint(b Board, team string) string {
+	return b.SprintStates[team].Current
+}
+
+// PreviousSprint returns a team's previous sprint start from its sprint-state
+// card, or "" when the team has no prior sprint. team = "" is the no-team group.
+// It mirrors previousSprint in web/src/sprint.ts.
+func PreviousSprint(b Board, team string) string {
+	return b.SprintStates[team].Previous
+}

--- a/internal/board/sprint_test.go
+++ b/internal/board/sprint_test.go
@@ -63,3 +63,33 @@ func TestCurrentAndPreviousSprint(t *testing.T) {
 		}
 	}
 }
+
+func TestActiveSprint(t *testing.T) {
+	b := NewBoard(nil, []Card{
+		// Team A: current 06-26, previous 06-20 (both tracked).
+		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-26", StartDate: "2026-06-20"},
+		// Team B: only a current sprint, no previous.
+		{ItemID: "ss-b", Title: SprintStateTitle, Team: "B", SprintStart: "2026-06-26", StartDate: ""},
+	})
+	cases := []struct {
+		name      string
+		team, day string
+		want      string
+	}{
+		{"day after current returns current", "A", "2026-06-27", "2026-06-26"},
+		{"day equal current returns current", "A", "2026-06-26", "2026-06-26"},
+		{"day in [previous,current) returns previous", "A", "2026-06-22", "2026-06-20"},
+		{"day equal previous returns previous", "A", "2026-06-20", "2026-06-20"},
+		{"day before previous returns empty", "A", "2026-06-19", ""},
+		{"only-current team before current returns empty", "B", "2026-06-22", ""},
+		{"only-current team at current returns current", "B", "2026-06-26", "2026-06-26"},
+		{"team with no state (empty pointers) returns empty", "missing", "2026-06-30", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ActiveSprint(b, c.team, c.day); got != c.want {
+				t.Errorf("ActiveSprint(%q,%q) = %q, want %q", c.team, c.day, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/board/sprint_test.go
+++ b/internal/board/sprint_test.go
@@ -1,0 +1,65 @@
+package board
+
+import "testing"
+
+// stateBoard builds a snapshot with two hidden sprint-state cards (team "A" and
+// the no-team group) plus a few ordinary cards, exercising the mapProject split.
+func stateBoard() Board {
+	return NewBoard(nil, []Card{
+		{ItemID: "ss-a", Title: SprintStateTitle, Team: "A", SprintStart: "2026-06-22", StartDate: "2026-06-15"},
+		{ItemID: "ss-none", Title: SprintStateTitle, Team: "", SprintStart: "2026-06-20", StartDate: "2026-06-13"},
+		{ItemID: "1", Title: "real card", Team: "A", SprintStart: "2026-06-22", StartDate: "2026-06-22"},
+		{ItemID: "2", Title: "no team card", Team: "", SprintStart: "2026-06-20", StartDate: "2026-06-20"},
+	})
+}
+
+func TestNewBoardSplitsSprintState(t *testing.T) {
+	b := stateBoard()
+
+	if len(b.Cards) != 2 {
+		t.Fatalf("Cards = %d, want 2 (state cards excluded)", len(b.Cards))
+	}
+	for _, c := range b.Cards {
+		if c.Title == SprintStateTitle {
+			t.Errorf("sprint-state card %q leaked into Cards", c.ItemID)
+		}
+	}
+
+	a, ok := b.SprintStates["A"]
+	if !ok {
+		t.Fatalf("SprintStates missing team A")
+	}
+	if a.Current != "2026-06-22" || a.Previous != "2026-06-15" || a.ItemID != "ss-a" {
+		t.Errorf("team A state = %+v, want current 06-22 / previous 06-15 / itemId ss-a", a)
+	}
+
+	none, ok := b.SprintStates[""]
+	if !ok {
+		t.Fatalf("SprintStates missing the no-team group")
+	}
+	if none.Current != "2026-06-20" || none.Previous != "2026-06-13" {
+		t.Errorf("no-team state = %+v, want current 06-20 / previous 06-13", none)
+	}
+}
+
+func TestCurrentAndPreviousSprint(t *testing.T) {
+	b := stateBoard()
+
+	cases := []struct {
+		team         string
+		wantCurrent  string
+		wantPrevious string
+	}{
+		{"A", "2026-06-22", "2026-06-15"},
+		{"", "2026-06-20", "2026-06-13"}, // the no-team group
+		{"missing", "", ""},              // a team with no state card
+	}
+	for _, c := range cases {
+		if got := CurrentSprint(b, c.team); got != c.wantCurrent {
+			t.Errorf("CurrentSprint(%q) = %q, want %q", c.team, got, c.wantCurrent)
+		}
+		if got := PreviousSprint(b, c.team); got != c.wantPrevious {
+			t.Errorf("PreviousSprint(%q) = %q, want %q", c.team, got, c.wantPrevious)
+		}
+	}
+}

--- a/internal/board/stages.go
+++ b/internal/board/stages.go
@@ -1,0 +1,61 @@
+package board
+
+import "strings"
+
+// StageKey is an explicit per-card status that recolours the progress bar. It
+// mirrors the StageKey union in web/src/providers/types.ts and the stage model in
+// web/src/stages.ts. StageNone ("") means the card carries no stored stage.
+type StageKey string
+
+// The explicit stages a card can carry, mirroring web/src/stages.ts. StageNone
+// ("") is the absence of a stage (the implicit In Progress / not-started state).
+const (
+	StageNone   StageKey = ""
+	StageLocked StageKey = "locked"
+	StageReview StageKey = "review"
+	StageDone   StageKey = "done"
+)
+
+// StageOrder is the canonical stage ordering, mirroring STAGE_ORDER.
+var StageOrder = []StageKey{StageLocked, StageReview, StageDone}
+
+// DefaultBarColor is the progress-bar colour for a card with no stage, mirroring
+// DEFAULT_BAR_COLOR.
+const DefaultBarColor = "#3fb950"
+
+// StageDef describes a stage's label and progress-bar colour, mirroring StageDef.
+type StageDef struct {
+	Key   StageKey `json:"key"`
+	Label string   `json:"label"`
+	Color string   `json:"color"`
+}
+
+// Stages maps each stage to its label and bar colour, mirroring STAGES.
+var Stages = map[StageKey]StageDef{
+	StageLocked: {Key: StageLocked, Label: "Locked", Color: "#cf222e"},
+	StageReview: {Key: StageReview, Label: "Review", Color: "#d4a72c"},
+	StageDone:   {Key: StageDone, Label: "Done", Color: "#1f883d"},
+}
+
+// StageFromName maps a Stage single-select option name onto a StageKey, mirroring
+// stageFromName. An unknown (or empty) name yields StageNone.
+func StageFromName(name string) StageKey {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "locked":
+		return StageLocked
+	case "review":
+		return StageReview
+	case "done":
+		return StageDone
+	default:
+		return StageNone
+	}
+}
+
+// IsInProgress reports the implicit "In Progress" status: a card with no stored
+// stage whose progress sits in [10, 90] inclusive. It mirrors isInProgress in
+// web/src/stages.ts and is deliberately not a StageKey (there is no stored option
+// for it).
+func IsInProgress(c Card) bool {
+	return c.Stage == StageNone && c.Progress >= 10 && c.Progress <= 90
+}

--- a/internal/board/stages_test.go
+++ b/internal/board/stages_test.go
@@ -1,0 +1,62 @@
+package board
+
+import "testing"
+
+func TestIsInProgress(t *testing.T) {
+	cases := []struct {
+		name string
+		card Card
+		want bool
+	}{
+		{"no stage, zero progress", Card{Stage: StageNone, Progress: 0}, false},
+		{"no stage, at lower bound", Card{Stage: StageNone, Progress: 10}, true},
+		{"no stage, mid", Card{Stage: StageNone, Progress: 50}, true},
+		{"no stage, at upper bound", Card{Stage: StageNone, Progress: 90}, true},
+		{"no stage, just under", Card{Stage: StageNone, Progress: 9}, false},
+		{"no stage, just over", Card{Stage: StageNone, Progress: 91}, false},
+		{"no stage, full", Card{Stage: StageNone, Progress: 100}, false},
+		{"review stage in band", Card{Stage: StageReview, Progress: 50}, false},
+		{"locked stage in band", Card{Stage: StageLocked, Progress: 50}, false},
+		{"done stage in band", Card{Stage: StageDone, Progress: 50}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsInProgress(c.card); got != c.want {
+				t.Errorf("IsInProgress(%+v) = %v, want %v", c.card, got, c.want)
+			}
+		})
+	}
+}
+
+func TestStageFromName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want StageKey
+	}{
+		{"Locked", StageLocked},
+		{"  review ", StageReview},
+		{"DONE", StageDone},
+		{"unknown", StageNone},
+		{"", StageNone},
+	}
+	for _, c := range cases {
+		if got := StageFromName(c.in); got != c.want {
+			t.Errorf("StageFromName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStageOrderAndDefs(t *testing.T) {
+	want := []StageKey{StageLocked, StageReview, StageDone}
+	if len(StageOrder) != len(want) {
+		t.Fatalf("StageOrder = %v, want %v", StageOrder, want)
+	}
+	for i, s := range want {
+		if StageOrder[i] != s {
+			t.Errorf("StageOrder[%d] = %q, want %q", i, StageOrder[i], s)
+		}
+		if def, ok := Stages[s]; !ok || def.Key != s || def.Label == "" {
+			t.Errorf("Stages[%q] = %+v, want a labelled def", s, def)
+		}
+	}
+}

--- a/internal/board/status.go
+++ b/internal/board/status.go
@@ -1,0 +1,67 @@
+package board
+
+// ClampProgress clamps a raw progress value for a card in the given stage. A
+// review or locked card is held within the 10–90% band (never 0% or 100%); any
+// other stage, including StageNone, keeps the value unchanged. It mirrors the
+// slider clamp shared by handleProgress and the Card component.
+func ClampProgress(stage StageKey, value int) int {
+	if stage == StageReview || stage == StageLocked {
+		if value < 10 {
+			return 10
+		}
+		if value > 90 {
+			return 90
+		}
+	}
+	return value
+}
+
+// ApplyProgress computes the (stage, progress) resulting from setting a card's
+// progress to raw. The value is first clamped for the current stage, then the
+// done auto-link runs: reaching 100% with no stage moves the card to done, and
+// dropping below 100% clears a done stage. review/locked stages are left as-is.
+// It mirrors handleProgress (the done-link assumes the board has a Stage field,
+// the `if (roles.stage)` guard there; aeman boards always do).
+func ApplyProgress(stage StageKey, raw int) (StageKey, int) {
+	value := ClampProgress(stage, raw)
+	switch {
+	case value == 100 && stage == StageNone:
+		return StageDone, value
+	case value < 100 && stage == StageDone:
+		return StageNone, value
+	default:
+		return stage, value
+	}
+}
+
+// ApplyStage computes the (stage, progress) resulting from moving a card to the
+// given stage. Choosing done fills progress to 100%; choosing review or locked
+// knocks a full (100%) card down to 90%, since those stages can never sit at
+// full. Clearing the stage (StageNone) or any other case keeps progress. It
+// mirrors handleStage.
+func ApplyStage(stage StageKey, currentProgress int) (StageKey, int) {
+	progress := currentProgress
+	switch {
+	case stage == StageDone:
+		progress = 100
+	case (stage == StageReview || stage == StageLocked) && currentProgress == 100:
+		progress = 90
+	}
+	return stage, progress
+}
+
+// ApplyInProgress computes the (stage, progress) for moving a card to the
+// implicit In Progress status: the stage is cleared and progress is nudged into
+// the [10, 90] band only at its edges — under 10 becomes 10, a done or full
+// (>=100) card drops to 90, otherwise the value is kept as-is (so a 91–99 value
+// is left untouched, matching the frontend). It mirrors handleInProgress.
+func ApplyInProgress(stage StageKey, progress int) (StageKey, int) {
+	value := progress
+	switch {
+	case progress < 10:
+		value = 10
+	case stage == StageDone || progress >= 100:
+		value = 90
+	}
+	return StageNone, value
+}

--- a/internal/board/status_test.go
+++ b/internal/board/status_test.go
@@ -1,0 +1,109 @@
+package board
+
+import "testing"
+
+func TestClampProgress(t *testing.T) {
+	cases := []struct {
+		name  string
+		stage StageKey
+		value int
+		want  int
+	}{
+		{"review under band", StageReview, 5, 10},
+		{"review over band", StageReview, 95, 90},
+		{"review in band", StageReview, 50, 50},
+		{"review at lower edge", StageReview, 10, 10},
+		{"review at upper edge", StageReview, 90, 90},
+		{"locked under band", StageLocked, 0, 10},
+		{"locked over band", StageLocked, 100, 90},
+		{"none passes through low", StageNone, 0, 0},
+		{"none passes through full", StageNone, 100, 100},
+		{"done passes through full", StageDone, 100, 100},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClampProgress(c.stage, c.value); got != c.want {
+				t.Errorf("ClampProgress(%q,%d) = %d, want %d", c.stage, c.value, got, c.want)
+			}
+		})
+	}
+}
+
+func TestApplyProgress(t *testing.T) {
+	cases := []struct {
+		name      string
+		stage     StageKey
+		raw       int
+		wantStage StageKey
+		wantValue int
+	}{
+		{"full with no stage links done", StageNone, 100, StageDone, 100},
+		{"below full clears done", StageDone, 50, StageNone, 50},
+		{"mid with no stage unchanged", StageNone, 50, StageNone, 50},
+		{"review clamps full to 90, no link", StageReview, 100, StageReview, 90},
+		{"locked clamps under to 10", StageLocked, 5, StageLocked, 10},
+		{"done at full stays done", StageDone, 100, StageDone, 100},
+		{"review mid unchanged", StageReview, 50, StageReview, 50},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotStage, gotValue := ApplyProgress(c.stage, c.raw)
+			if gotStage != c.wantStage || gotValue != c.wantValue {
+				t.Errorf("ApplyProgress(%q,%d) = (%q,%d), want (%q,%d)",
+					c.stage, c.raw, gotStage, gotValue, c.wantStage, c.wantValue)
+			}
+		})
+	}
+}
+
+func TestApplyStage(t *testing.T) {
+	cases := []struct {
+		name      string
+		stage     StageKey
+		progress  int
+		wantStage StageKey
+		wantValue int
+	}{
+		{"done fills to full", StageDone, 50, StageDone, 100},
+		{"review drops full to 90", StageReview, 100, StageReview, 90},
+		{"locked drops full to 90", StageLocked, 100, StageLocked, 90},
+		{"review below full kept", StageReview, 50, StageReview, 50},
+		{"locked below full kept", StageLocked, 50, StageLocked, 50},
+		{"clearing keeps progress", StageNone, 100, StageNone, 100},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotStage, gotValue := ApplyStage(c.stage, c.progress)
+			if gotStage != c.wantStage || gotValue != c.wantValue {
+				t.Errorf("ApplyStage(%q,%d) = (%q,%d), want (%q,%d)",
+					c.stage, c.progress, gotStage, gotValue, c.wantStage, c.wantValue)
+			}
+		})
+	}
+}
+
+func TestApplyInProgress(t *testing.T) {
+	cases := []struct {
+		name      string
+		stage     StageKey
+		progress  int
+		wantValue int
+	}{
+		{"under band raised to 10", StageNone, 5, 10},
+		{"zero raised to 10", StageNone, 0, 10},
+		{"done dropped to 90", StageDone, 100, 90},
+		{"full review dropped to 90", StageReview, 100, 90},
+		{"mid kept", StageNone, 50, 50},
+		{"review mid kept, stage cleared", StageReview, 50, 50},
+		{"91-99 left untouched (quirk)", StageNone, 95, 95},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotStage, gotValue := ApplyInProgress(c.stage, c.progress)
+			if gotStage != StageNone || gotValue != c.wantValue {
+				t.Errorf("ApplyInProgress(%q,%d) = (%q,%d), want (%q,%d)",
+					c.stage, c.progress, gotStage, gotValue, StageNone, c.wantValue)
+			}
+		})
+	}
+}

--- a/internal/boardservice/backend.go
+++ b/internal/boardservice/backend.go
@@ -1,0 +1,53 @@
+// Package boardservice is the single entry point for aeman's board actions. It
+// ports the action logic that lives in the web frontend's board components
+// (TeamBoard.tsx, MeBoard.tsx) onto the pure domain in internal/board, applying
+// each change through a Backend. The HTTP API and the MCP server call this
+// service in Phase 3 instead of re-implementing the handlers.
+package boardservice
+
+import (
+	"context"
+
+	"github.com/aenix-org/aeman/internal/board"
+)
+
+// Backend abstracts the storage backend a board lives in (GitHub Projects v2
+// today, a git backend later). It mirrors the frontend Provider in
+// web/src/providers/types.ts, expressed in the domain types from internal/board.
+// *ghprojects.Client satisfies it structurally. Setter zero values clear the
+// field (an empty ZoneKey/StageKey/PlanBand/date), matching the frontend's
+// `null` argument; team = "" is the no-team group.
+type Backend interface {
+	// LoadBoard fetches a project and returns the parsed domain snapshot (cards +
+	// fields, with the hidden per-team sprint-state cards split into SprintStates).
+	LoadBoard(ctx context.Context, owner string, project int) (board.Board, error)
+
+	// CreateCard creates a card on the board and returns it.
+	CreateCard(ctx context.Context, b board.Board, in board.CreateInput) (board.Card, error)
+	// DeleteCard removes a card from the board.
+	DeleteCard(ctx context.Context, b board.Board, card board.Card) error
+	// MoveCard reorders card to sit after afterID ("" = move to the top).
+	MoveCard(ctx context.Context, b board.Board, card board.Card, afterID string) error
+	// AddNote appends a work note to a card.
+	AddNote(ctx context.Context, b board.Board, card board.Card, text string) error
+	// RenameCard changes a card's title.
+	RenameCard(ctx context.Context, b board.Board, card board.Card, title string) error
+
+	// Field setters mirroring the Provider. A zero value clears the field.
+	SetStage(ctx context.Context, b board.Board, card board.Card, stage board.StageKey) error
+	SetProgress(ctx context.Context, b board.Board, card board.Card, progress int) error
+	SetZone(ctx context.Context, b board.Board, card board.Card, zone board.ZoneKey) error
+	SetDay(ctx context.Context, b board.Board, card board.Card, day string) error
+	SetStart(ctx context.Context, b board.Board, card board.Card, date string) error
+	SetSprintStart(ctx context.Context, b board.Board, card board.Card, date string) error
+	SetPlan(ctx context.Context, b board.Board, card board.Card, plan board.PlanBand) error
+	SetWeek(ctx context.Context, b board.Board, card board.Card, week string) error
+	SetTeam(ctx context.Context, b board.Board, card board.Card, team string) error
+	SetAssignee(ctx context.Context, b board.Board, card board.Card, login string) error
+	SetReviewOf(ctx context.Context, b board.Board, card board.Card, reviewOf string) error
+
+	// SetSprintState creates or updates a team's hidden sprint-state card.
+	// current/previous are the team's current and previous sprint start dates
+	// ("" clears them); team = "" is the no-team group.
+	SetSprintState(ctx context.Context, b board.Board, team, current, previous string) error
+}

--- a/internal/boardservice/boardservicetest/fake.go
+++ b/internal/boardservice/boardservicetest/fake.go
@@ -1,0 +1,247 @@
+// Package boardservicetest provides an in-memory boardservice.Backend for tests
+// of the HTTP API and the MCP server, so they exercise the real boardservice
+// logic over a seeded board without touching GitHub.
+package boardservicetest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/boardservice"
+)
+
+// Backend is an in-memory boardservice.Backend. It logs every call and mutates
+// its board so the service's views reflect the result of an action.
+type Backend struct {
+	board   board.Board
+	log     []string
+	creates []board.CreateInput
+	nextID  int
+}
+
+// New builds a Backend seeded with cards and per-team sprint states.
+func New(cards []board.Card, states map[string]board.SprintState) *Backend {
+	if states == nil {
+		states = map[string]board.SprintState{}
+	}
+	return &Backend{board: board.Board{ID: "B1", Number: 1, Owner: "acme", Cards: cards, SprintStates: states}}
+}
+
+func (f *Backend) rec(format string, a ...any) { f.log = append(f.log, fmt.Sprintf(format, a...)) }
+
+// Saw reports whether the call log contains an exact entry.
+func (f *Backend) Saw(s string) bool {
+	for _, e := range f.log {
+		if e == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Count returns how many logged calls start with prefix.
+func (f *Backend) Count(prefix string) int {
+	n := 0
+	for _, e := range f.log {
+		if strings.HasPrefix(e, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// Card returns a pointer to the seeded card with the given item id, or nil.
+func (f *Backend) Card(itemID string) *board.Card {
+	for i := range f.board.Cards {
+		if f.board.Cards[i].ItemID == itemID {
+			return &f.board.Cards[i]
+		}
+	}
+	return nil
+}
+
+// Creates returns the create inputs the service issued, in order.
+func (f *Backend) Creates() []board.CreateInput { return f.creates }
+
+// LoadBoard returns a copy of the seeded board snapshot.
+func (f *Backend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	f.rec("LoadBoard")
+	cards := make([]board.Card, len(f.board.Cards))
+	copy(cards, f.board.Cards)
+	states := map[string]board.SprintState{}
+	for k, v := range f.board.SprintStates {
+		states[k] = v
+	}
+	return board.Board{ID: f.board.ID, Number: f.board.Number, Owner: f.board.Owner, Cards: cards, SprintStates: states}, nil
+}
+
+// CreateCard appends a new card and records the create input.
+func (f *Backend) CreateCard(_ context.Context, _ board.Board, in board.CreateInput) (board.Card, error) {
+	f.nextID++
+	card := board.Card{
+		ItemID: fmt.Sprintf("new%d", f.nextID), Title: in.Title, IsDraft: true,
+		Zone: in.Zone, StartDate: in.Start, SprintStart: in.SprintStart,
+		Plan: in.Plan, Week: in.Week, Team: in.Team, ReviewOf: in.ReviewOf,
+		Assignees: []string{},
+	}
+	if in.Assignee != "" {
+		card.Assignees = []string{in.Assignee}
+	}
+	f.board.Cards = append(f.board.Cards, card)
+	f.creates = append(f.creates, in)
+	f.rec("CreateCard %s", card.ItemID)
+	return card, nil
+}
+
+// DeleteCard removes a card from the board.
+func (f *Backend) DeleteCard(_ context.Context, _ board.Board, card board.Card) error {
+	f.rec("DeleteCard %s", card.ItemID)
+	out := f.board.Cards[:0]
+	for _, c := range f.board.Cards {
+		if c.ItemID != card.ItemID {
+			out = append(out, c)
+		}
+	}
+	f.board.Cards = out
+	return nil
+}
+
+// MoveCard records a reorder (the in-memory order is left unchanged).
+func (f *Backend) MoveCard(_ context.Context, _ board.Board, card board.Card, afterID string) error {
+	f.rec("MoveCard %s after=%s", card.ItemID, afterID)
+	return nil
+}
+
+// AddNote records a note on a card.
+func (f *Backend) AddNote(_ context.Context, _ board.Board, card board.Card, text string) error {
+	f.rec("AddNote %s %s", card.ItemID, text)
+	return nil
+}
+
+// RenameCard changes a card's title.
+func (f *Backend) RenameCard(_ context.Context, _ board.Board, card board.Card, title string) error {
+	f.rec("RenameCard %s", card.ItemID)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Title = title
+	}
+	return nil
+}
+
+// SetStage sets a card's stage.
+func (f *Backend) SetStage(_ context.Context, _ board.Board, card board.Card, stage board.StageKey) error {
+	f.rec("SetStage %s %s", card.ItemID, stage)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Stage = stage
+	}
+	return nil
+}
+
+// SetProgress sets a card's progress.
+func (f *Backend) SetProgress(_ context.Context, _ board.Board, card board.Card, progress int) error {
+	f.rec("SetProgress %s %d", card.ItemID, progress)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Progress = progress
+	}
+	return nil
+}
+
+// SetZone sets a card's zone.
+func (f *Backend) SetZone(_ context.Context, _ board.Board, card board.Card, zone board.ZoneKey) error {
+	f.rec("SetZone %s %s", card.ItemID, zone)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Zone = zone
+	}
+	return nil
+}
+
+// SetDay records a day change.
+func (f *Backend) SetDay(_ context.Context, _ board.Board, card board.Card, day string) error {
+	f.rec("SetDay %s %s", card.ItemID, day)
+	return nil
+}
+
+// SetStart sets a card's start date.
+func (f *Backend) SetStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.rec("SetStart %s %s", card.ItemID, date)
+	if c := f.Card(card.ItemID); c != nil {
+		c.StartDate = date
+	}
+	return nil
+}
+
+// SetSprintStart sets a card's sprint-start date.
+func (f *Backend) SetSprintStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.rec("SetSprintStart %s %s", card.ItemID, date)
+	if c := f.Card(card.ItemID); c != nil {
+		c.SprintStart = date
+	}
+	return nil
+}
+
+// SetPlan sets a card's weekly-plan band.
+func (f *Backend) SetPlan(_ context.Context, _ board.Board, card board.Card, plan board.PlanBand) error {
+	f.rec("SetPlan %s %s", card.ItemID, plan)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Plan = plan
+	}
+	return nil
+}
+
+// SetWeek sets a card's plan week.
+func (f *Backend) SetWeek(_ context.Context, _ board.Board, card board.Card, week string) error {
+	f.rec("SetWeek %s %s", card.ItemID, week)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Week = week
+	}
+	return nil
+}
+
+// SetTeam sets a card's team.
+func (f *Backend) SetTeam(_ context.Context, _ board.Board, card board.Card, team string) error {
+	f.rec("SetTeam %s %s", card.ItemID, team)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Team = team
+	}
+	return nil
+}
+
+// SetAssignee replaces a card's assignee.
+func (f *Backend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
+	f.rec("SetAssignee %s %s", card.ItemID, login)
+	if c := f.Card(card.ItemID); c != nil {
+		if login == "" {
+			c.Assignees = []string{}
+		} else {
+			c.Assignees = []string{login}
+		}
+	}
+	return nil
+}
+
+// SetReviewOf sets a card's review-of link.
+func (f *Backend) SetReviewOf(_ context.Context, _ board.Board, card board.Card, reviewOf string) error {
+	f.rec("SetReviewOf %s %s", card.ItemID, reviewOf)
+	if c := f.Card(card.ItemID); c != nil {
+		c.ReviewOf = reviewOf
+	}
+	return nil
+}
+
+// SetSprintState creates or updates a team's sprint pointer.
+func (f *Backend) SetSprintState(_ context.Context, _ board.Board, team, current, previous string) error {
+	f.rec("SetSprintState %s cur=%s prev=%s", team, current, previous)
+	st := f.board.SprintStates[team]
+	st.Current = current
+	st.Previous = previous
+	if st.ItemID == "" {
+		f.nextID++
+		st.ItemID = fmt.Sprintf("state%d", f.nextID)
+	}
+	f.board.SprintStates[team] = st
+	return nil
+}
+
+// Backend must satisfy boardservice.Backend.
+var _ boardservice.Backend = (*Backend)(nil)

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -119,9 +119,9 @@ func (s *Service) WeeklyPlan(ctx context.Context, owner string, project int, tea
 // --- Create / sprints ------------------------------------------------------
 
 // CreateCardArgs are the inputs to CreateCard. Day defaults to today.
-// StartNewSprint forces the sprint choice: nil = auto (join the team's current
-// sprint, or start one when the team has none), true = always start a new sprint
-// today, false = always join the current sprint (start one only if there is none).
+// StartNewSprint forces the team's sprint pointer: nil = auto (record the day as
+// the team's first sprint only when it has none), true = always (re)start the
+// pointer on the day, false = same as auto (start one only when there is none).
 type CreateCardArgs struct {
 	Team           string
 	Zone           board.ZoneKey
@@ -131,11 +131,11 @@ type CreateCardArgs struct {
 	StartNewSprint *bool
 }
 
-// CreateCard creates a card that joins (or starts) its team's sprint. It mirrors
-// handleCreate in TeamBoard.tsx: a team with no current sprint starts its first
-// one off this card (recorded on the team's sprint-state card), otherwise the
-// card joins the current sprint. Start and Sprint Start both equal the sprint;
-// Day is the create day.
+// CreateCard creates a card on a single day: its Start (origin) and SprintStart
+// (the day it lives on) both equal the viewed day. A team with no sprint yet
+// records its first one off this card on its sprint-state card, so the Me view's
+// lower bound has an anchor; force-new (re)starts the pointer on the day. It
+// mirrors handleCreate in TeamBoard.tsx.
 func (s *Service) CreateCard(ctx context.Context, owner string, project int, args CreateCardArgs) (board.Card, error) {
 	b, err := s.backend.LoadBoard(ctx, owner, project)
 	if err != nil {
@@ -146,18 +146,11 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		day = board.TodayIso()
 	}
 	cur := board.CurrentSprint(b, args.Team)
-	sprint := cur
-	startNew := false
-	switch {
-	case args.StartNewSprint != nil && *args.StartNewSprint:
-		startNew = true
-	case args.StartNewSprint != nil && !*args.StartNewSprint:
-		startNew = cur == ""
-	default:
-		startNew = cur == ""
+	startNew := cur == ""
+	if args.StartNewSprint != nil {
+		startNew = *args.StartNewSprint || cur == ""
 	}
 	if startNew {
-		sprint = day
 		// Record the new sprint on the team's state card (previous = the old
 		// current, which is "" when the team had no sprint yet — matching the
 		// frontend's setSprintState(team, day, null)).
@@ -165,14 +158,14 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 			return board.Card{}, err
 		}
 	}
-	// Start = the viewed day (where the card sits); SprintStart = the current
-	// sprint (so Carry Over carries it). They differ when creating on a later day.
+	// A card lives on exactly one day: Start (origin) and SprintStart (its day)
+	// both equal the viewed day.
 	return s.backend.CreateCard(ctx, b, board.CreateInput{
 		Title:       args.Title,
 		Zone:        args.Zone,
 		Day:         day,
 		Start:       day,
-		SprintStart: sprint,
+		SprintStart: day,
 		Assignee:    args.Assignee,
 		Team:        args.Team,
 	})

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -1,0 +1,545 @@
+package boardservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aenix-org/aeman/internal/board"
+)
+
+// ErrCardNotFound is returned when an item id is not on the loaded board.
+var ErrCardNotFound = errors.New("card not found")
+
+// Service performs aeman's board actions. It is stateless: every method loads
+// the board through the backend, computes the change with internal/board logic,
+// then applies it through the backend setters.
+type Service struct {
+	backend Backend
+}
+
+// New builds a Service over a backend.
+func New(backend Backend) *Service {
+	return &Service{backend: backend}
+}
+
+// findCard returns the card with the given item id, or ok = false.
+func findCard(b board.Board, itemID string) (board.Card, bool) {
+	for _, c := range b.Cards {
+		if c.ItemID == itemID {
+			return c, true
+		}
+	}
+	return board.Card{}, false
+}
+
+// findReviewCard returns the review card linked to an original (its ReviewOf is
+// the original's item id), or ok = false.
+func findReviewCard(b board.Board, originalItemID string) (board.Card, bool) {
+	for _, c := range b.Cards {
+		if c.ReviewOf == originalItemID {
+			return c, true
+		}
+	}
+	return board.Card{}, false
+}
+
+// loadCard loads the board and resolves a card by item id.
+func (s *Service) loadCard(ctx context.Context, owner string, project int, itemID string) (board.Board, board.Card, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return board.Board{}, board.Card{}, err
+	}
+	card, ok := findCard(b, itemID)
+	if !ok {
+		return b, board.Card{}, fmt.Errorf("%w: %s", ErrCardNotFound, itemID)
+	}
+	return b, card, nil
+}
+
+// --- Views -----------------------------------------------------------------
+
+// TeamView returns the Team board's grid cards for a team on a day (day = "" is
+// today). It mirrors filteredCards/passesFilter in TeamBoard.tsx via board.TeamGrid.
+func (s *Service) TeamView(ctx context.Context, owner string, project int, team, day string) ([]board.Card, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return nil, err
+	}
+	if day == "" {
+		day = board.TodayIso()
+	}
+	return board.TeamGrid(b, team, day), nil
+}
+
+// MeView returns the personal day board for a user on a day (user = "" is
+// everyone, day = "" is today). It mirrors myCards in MeBoard.tsx via board.MeView.
+func (s *Service) MeView(ctx context.Context, owner string, project int, user, day string) ([]board.Card, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return nil, err
+	}
+	if day == "" {
+		day = board.TodayIso()
+	}
+	return board.MeView(b, user, day), nil
+}
+
+// WeeklyPlan returns a team's weekly-plan cards for a week (week = "" is the
+// Monday of the current week), split into the Wed/Fri bands. It mirrors the
+// `weekly` memo in TeamBoard.tsx via board.WeeklyPlan.
+func (s *Service) WeeklyPlan(ctx context.Context, owner string, project int, team, week string) (board.WeeklyBands, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return board.WeeklyBands{}, err
+	}
+	if week == "" {
+		week = board.MondayOf(board.TodayIso())
+	}
+	return board.WeeklyPlan(b, team, week), nil
+}
+
+// --- Create / sprints ------------------------------------------------------
+
+// CreateCardArgs are the inputs to CreateCard. Day defaults to today.
+// StartNewSprint forces the sprint choice: nil = auto (join the team's current
+// sprint, or start one when the team has none), true = always start a new sprint
+// today, false = always join the current sprint (start one only if there is none).
+type CreateCardArgs struct {
+	Team           string
+	Zone           board.ZoneKey
+	Title          string
+	Assignee       string
+	Day            string
+	StartNewSprint *bool
+}
+
+// CreateCard creates a card that joins (or starts) its team's sprint. It mirrors
+// handleCreate in TeamBoard.tsx: a team with no current sprint starts its first
+// one off this card (recorded on the team's sprint-state card), otherwise the
+// card joins the current sprint. Start and Sprint Start both equal the sprint;
+// Day is the create day.
+func (s *Service) CreateCard(ctx context.Context, owner string, project int, args CreateCardArgs) (board.Card, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return board.Card{}, err
+	}
+	day := args.Day
+	if day == "" {
+		day = board.TodayIso()
+	}
+	cur := board.CurrentSprint(b, args.Team)
+	sprint := cur
+	startNew := false
+	switch {
+	case args.StartNewSprint != nil && *args.StartNewSprint:
+		startNew = true
+	case args.StartNewSprint != nil && !*args.StartNewSprint:
+		startNew = cur == ""
+	default:
+		startNew = cur == ""
+	}
+	if startNew {
+		sprint = day
+		// Record the new sprint on the team's state card (previous = the old
+		// current, which is "" when the team had no sprint yet — matching the
+		// frontend's setSprintState(team, day, null)).
+		if err := s.backend.SetSprintState(ctx, b, args.Team, day, cur); err != nil {
+			return board.Card{}, err
+		}
+	}
+	return s.backend.CreateCard(ctx, b, board.CreateInput{
+		Title:       args.Title,
+		Zone:        args.Zone,
+		Day:         day,
+		Start:       sprint,
+		SprintStart: sprint,
+		Assignee:    args.Assignee,
+		Team:        args.Team,
+	})
+}
+
+// CarryOver advances a team's sprint to today (the old current becomes previous)
+// and pulls its unfinished cards forward. It mirrors startSprint in TeamBoard.tsx:
+// idempotent (a no-op when the sprint is already today's), and it always advances
+// even with nothing to carry. team = "" is the no-team group.
+func (s *Service) CarryOver(ctx context.Context, owner string, project int, team string) error {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return err
+	}
+	old := board.CurrentSprint(b, team)
+	today := board.TodayIso()
+	if old == today {
+		// Already on today's sprint: re-advancing would overwrite previous.
+		return nil
+	}
+	if err := s.backend.SetSprintState(ctx, b, team, today, old); err != nil {
+		return err
+	}
+	for _, c := range b.Cards {
+		if c.Team != team || c.SprintStart != old || c.Stage == board.StageDone {
+			continue
+		}
+		if err := s.backend.SetSprintStart(ctx, b, c, today); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CarryWeek pulls a team's unfinished plan cards from earlier weeks into the
+// target week (week = "" is the current week's Monday), returning the cards it
+// moved. It mirrors handleCarryWeek in TeamBoard.tsx (nothing to carry yields an
+// empty result, not an error). team = "" is the no-team group.
+func (s *Service) CarryWeek(ctx context.Context, owner string, project int, team, week string) ([]board.Card, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return nil, err
+	}
+	if week == "" {
+		week = board.MondayOf(board.TodayIso())
+	}
+	var carried []board.Card
+	for _, c := range b.Cards {
+		if c.Plan == board.PlanNone || c.Week == "" || c.Week >= week {
+			continue
+		}
+		if c.Stage == board.StageDone || c.Team != team {
+			continue
+		}
+		if err := s.backend.SetWeek(ctx, b, c, week); err != nil {
+			return carried, err
+		}
+		c.Week = week
+		carried = append(carried, c)
+	}
+	return carried, nil
+}
+
+// --- Stage / progress ------------------------------------------------------
+
+// SetStage moves a card to a stage (stage = "" clears it). It mirrors handleStage
+// in TeamBoard.tsx: board.ApplyStage computes the resulting (stage, progress) and
+// both are persisted (done fills 100%, review/locked knock a full card to 90%).
+func (s *Service) SetStage(ctx context.Context, owner string, project int, itemID string, stage board.StageKey) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.applyStage(ctx, b, card, stage)
+}
+
+// applyStage persists a stage change and any coupled progress change.
+func (s *Service) applyStage(ctx context.Context, b board.Board, card board.Card, stage board.StageKey) error {
+	newStage, newProgress := board.ApplyStage(stage, card.Progress)
+	if err := s.backend.SetStage(ctx, b, card, newStage); err != nil {
+		return err
+	}
+	if newProgress != card.Progress {
+		if err := s.backend.SetProgress(ctx, b, card, newProgress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetProgress sets a card's progress. It mirrors handleProgress in TeamBoard.tsx:
+// board.ApplyProgress clamps the value and runs the done auto-link, both are
+// persisted, and a review card's progress drives its original's review stage.
+func (s *Service) SetProgress(ctx context.Context, owner string, project int, itemID string, raw int) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	newStage, newProgress := board.ApplyProgress(card.Stage, raw)
+	if err := s.backend.SetProgress(ctx, b, card, newProgress); err != nil {
+		return err
+	}
+	if newStage != card.Stage {
+		if err := s.backend.SetStage(ctx, b, card, newStage); err != nil {
+			return err
+		}
+	}
+	return s.syncReviewLink(ctx, b, card, newProgress)
+}
+
+// SetInProgress moves a card to the implicit "In Progress" status (no stage,
+// progress nudged into [10, 90]). It mirrors handleInProgress in TeamBoard.tsx
+// via board.ApplyInProgress, keeping a review card's review-link in sync.
+func (s *Service) SetInProgress(ctx context.Context, owner string, project int, itemID string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	newStage, newProgress := board.ApplyInProgress(card.Stage, card.Progress)
+	if err := s.backend.SetStage(ctx, b, card, newStage); err != nil {
+		return err
+	}
+	if newProgress == card.Progress {
+		return nil
+	}
+	if err := s.backend.SetProgress(ctx, b, card, newProgress); err != nil {
+		return err
+	}
+	return s.syncReviewLink(ctx, b, card, newProgress)
+}
+
+// syncReviewLink, when card is a review card, drives its original's review stage
+// from the review card's progress. It mirrors syncOriginalReview.
+func (s *Service) syncReviewLink(ctx context.Context, b board.Board, card board.Card, reviewProgress int) error {
+	if card.ReviewOf == "" {
+		return nil
+	}
+	original, ok := findCard(b, card.ReviewOf)
+	if !ok {
+		return nil
+	}
+	var next board.StageKey
+	switch {
+	case reviewProgress == 100 && original.Stage == board.StageReview:
+		next = board.StageNone
+	case reviewProgress < 100 && original.Stage != board.StageReview:
+		next = board.StageReview
+	default:
+		return nil
+	}
+	return s.backend.SetStage(ctx, b, original, next)
+}
+
+// --- Review linkage --------------------------------------------------------
+
+// SendToReview creates a linked review card for a reviewer (in the original's
+// zone/team) and puts the original on the review stage, returning the review
+// card. day = "" is today. It mirrors handleSendToReview in TeamBoard.tsx.
+func (s *Service) SendToReview(ctx context.Context, owner string, project int, itemID, reviewer, day string) (board.Card, error) {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return board.Card{}, err
+	}
+	return s.sendToReview(ctx, b, card, reviewer, day)
+}
+
+// sendToReview is the create-review-card half of SendToReview over a loaded board.
+func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Card, reviewer, day string) (board.Card, error) {
+	if day == "" {
+		day = board.TodayIso()
+	}
+	zone := card.Zone
+	if zone == "" {
+		zone = board.ZoneGray
+	}
+	sprintStart := board.CurrentSprint(b, card.Team)
+	if sprintStart == "" {
+		sprintStart = day
+	}
+	created, err := s.backend.CreateCard(ctx, b, board.CreateInput{
+		Title:       "review: " + card.Title,
+		Zone:        zone,
+		Day:         day,
+		Start:       day,
+		SprintStart: sprintStart,
+		Assignee:    reviewer,
+		Team:        card.Team,
+		ReviewOf:    card.ItemID,
+	})
+	if err != nil {
+		return board.Card{}, err
+	}
+	// Put the original on review (ApplyStage also drops a 100% card to 90%).
+	if err := s.applyStage(ctx, b, card, board.StageReview); err != nil {
+		return created, err
+	}
+	return created, nil
+}
+
+// ReassignReviewer points a card's linked review card at another reviewer, or
+// sends the card to review when it has none yet (day = "" is today). It mirrors
+// handleSetReviewAssignee (non-null login) in TeamBoard.tsx.
+func (s *Service) ReassignReviewer(ctx context.Context, owner string, project int, itemID, reviewer, day string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	reviewCard, ok := findReviewCard(b, card.ItemID)
+	if !ok {
+		_, err := s.sendToReview(ctx, b, card, reviewer, day)
+		return err
+	}
+	return s.backend.SetAssignee(ctx, b, reviewCard, reviewer)
+}
+
+// RemoveReviewer deletes a card's linked review card (a no-op when there is
+// none). It mirrors handleSetReviewAssignee(null) in TeamBoard.tsx.
+func (s *Service) RemoveReviewer(ctx context.Context, owner string, project int, itemID string) error {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return err
+	}
+	reviewCard, ok := findReviewCard(b, itemID)
+	if !ok {
+		return nil
+	}
+	return s.backend.DeleteCard(ctx, b, reviewCard)
+}
+
+// --- Card field actions ----------------------------------------------------
+
+// SetAssignee replaces a card's assignee (login = "" unassigns). It mirrors
+// handleSetAssignee in TeamBoard.tsx.
+func (s *Service) SetAssignee(ctx context.Context, owner string, project int, itemID, login string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.backend.SetAssignee(ctx, b, card, login)
+}
+
+// SetTeam moves a card to a team and joins that team's current sprint (team = ""
+// is the no-team group, day = "" is today). It mirrors handleSetTeam in
+// TeamBoard.tsx.
+func (s *Service) SetTeam(ctx context.Context, owner string, project int, itemID, team, day string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	if day == "" {
+		day = board.TodayIso()
+	}
+	sprintStart := board.CurrentSprint(b, team)
+	if sprintStart == "" {
+		sprintStart = day
+	}
+	if err := s.backend.SetTeam(ctx, b, card, team); err != nil {
+		return err
+	}
+	if sprintStart != card.SprintStart {
+		return s.backend.SetSprintStart(ctx, b, card, sprintStart)
+	}
+	return nil
+}
+
+// Rename changes a card's title. It mirrors handleRename in TeamBoard.tsx.
+func (s *Service) Rename(ctx context.Context, owner string, project int, itemID, title string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.backend.RenameCard(ctx, b, card, title)
+}
+
+// AddNote appends a work note to a card.
+func (s *Service) AddNote(ctx context.Context, owner string, project int, itemID, text string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.backend.AddNote(ctx, b, card, text)
+}
+
+// MoveCard reorders a card to sit after afterID ("" = top of the board). It
+// mirrors the moveCard calls behind drag-and-drop in TeamBoard.tsx.
+func (s *Service) MoveCard(ctx context.Context, owner string, project int, itemID, afterID string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.backend.MoveCard(ctx, b, card, afterID)
+}
+
+// DeleteCard deletes a card, cascading to its linked review card. It mirrors
+// handleDelete in TeamBoard.tsx (deleting a reviewed card removes both).
+func (s *Service) DeleteCard(ctx context.Context, owner string, project int, itemID string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.deleteWithCascade(ctx, b, card)
+}
+
+// deleteWithCascade deletes a card and any review card linked to it.
+func (s *Service) deleteWithCascade(ctx context.Context, b board.Board, card board.Card) error {
+	if reviewCard, ok := findReviewCard(b, card.ItemID); ok {
+		if err := s.backend.DeleteCard(ctx, b, reviewCard); err != nil {
+			return err
+		}
+	}
+	return s.backend.DeleteCard(ctx, b, card)
+}
+
+// --- Weekly plan -----------------------------------------------------------
+
+// TakeIntoPlan takes a weekly-plan card into work: it assigns the card to an
+// engineer (engineer = "" unassigns), sets its zone (zone = "" keeps the card's
+// own zone, defaulting to gray) and joins the card's team's current sprint
+// (day = "" is today). It mirrors takePlanCard in TeamBoard.tsx.
+func (s *Service) TakeIntoPlan(ctx context.Context, owner string, project int, itemID, engineer string, zone board.ZoneKey, day string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	if day == "" {
+		day = board.TodayIso()
+	}
+	if zone == "" {
+		zone = card.Zone
+		if zone == "" {
+			zone = board.ZoneGray
+		}
+	}
+	sprintStart := board.CurrentSprint(b, card.Team)
+	if sprintStart == "" {
+		sprintStart = day
+	}
+	if err := s.backend.SetAssignee(ctx, b, card, engineer); err != nil {
+		return err
+	}
+	if zone != card.Zone {
+		if err := s.backend.SetZone(ctx, b, card, zone); err != nil {
+			return err
+		}
+	}
+	return s.backend.SetSprintStart(ctx, b, card, sprintStart)
+}
+
+// ReleaseFromPlan removes a card from the weekly plan. It mirrors removeFromPlan
+// in TeamBoard.tsx: a taken-into-work card (it has an assignee) just loses its
+// Plan + Week markers; a pure plan card is demoted to its previous plan week, or
+// deleted (cascading to a linked review card) when there is none.
+func (s *Service) ReleaseFromPlan(ctx context.Context, owner string, project int, itemID string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	if len(card.Assignees) == 0 {
+		if prevWeek := previousWeekFor(b, card); prevWeek != "" {
+			return s.backend.SetWeek(ctx, b, card, prevWeek)
+		}
+		return s.deleteWithCascade(ctx, b, card)
+	}
+	if err := s.backend.SetPlan(ctx, b, card, board.PlanNone); err != nil {
+		return err
+	}
+	return s.backend.SetWeek(ctx, b, card, "")
+}
+
+// previousWeekFor returns the latest plan week before a card's week among the
+// same team's cards, or "". It mirrors previousWeekFor in TeamBoard.tsx.
+func previousWeekFor(b board.Board, card board.Card) string {
+	if card.Week == "" {
+		return ""
+	}
+	prev := ""
+	for _, c := range b.Cards {
+		if c.ItemID == card.ItemID || c.Team != card.Team {
+			continue
+		}
+		if c.Week == "" || c.Week >= card.Week {
+			continue
+		}
+		if prev == "" || c.Week > prev {
+			prev = c.Week
+		}
+	}
+	return prev
+}

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -131,11 +131,13 @@ type CreateCardArgs struct {
 	StartNewSprint *bool
 }
 
-// CreateCard creates a card on a single day: its Start (origin) and SprintStart
-// (the day it lives on) both equal the viewed day. A team with no sprint yet
-// records its first one off this card on its sprint-state card, so the Me view's
-// lower bound has an anchor; force-new (re)starts the pointer on the day. It
-// mirrors handleCreate in TeamBoard.tsx.
+// CreateCard creates a card with two dates: StartDate (its scheduled day) is the
+// requested day (today by default), and SprintStart (the sprint it joins) is the
+// team's current sprint — so a card created on a later day of the sprint keeps the
+// sprint's start. A team with no sprint yet records its first one off this card on
+// its sprint-state card, anchoring the Me view; force-new (re)starts the pointer on
+// the day and the card joins that fresh sprint. It mirrors handleCreate in
+// TeamBoard.tsx / MeBoard.tsx.
 func (s *Service) CreateCard(ctx context.Context, owner string, project int, args CreateCardArgs) (board.Card, error) {
 	b, err := s.backend.LoadBoard(ctx, owner, project)
 	if err != nil {
@@ -146,26 +148,27 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		day = board.TodayIso()
 	}
 	cur := board.CurrentSprint(b, args.Team)
+	sprint := cur
 	startNew := cur == ""
 	if args.StartNewSprint != nil {
 		startNew = *args.StartNewSprint || cur == ""
 	}
 	if startNew {
-		// Record the new sprint on the team's state card (previous = the old
-		// current, which is "" when the team had no sprint yet — matching the
+		// Record the new sprint on the day and have the card join it (previous = the
+		// old current, which is "" when the team had no sprint yet — matching the
 		// frontend's setSprintState(team, day, null)).
+		sprint = day
 		if err := s.backend.SetSprintState(ctx, b, args.Team, day, cur); err != nil {
 			return board.Card{}, err
 		}
 	}
-	// A card lives on exactly one day: Start (origin) and SprintStart (its day)
-	// both equal the viewed day.
+	// Start is the scheduled day; SprintStart is the sprint the card belongs to.
 	return s.backend.CreateCard(ctx, b, board.CreateInput{
 		Title:       args.Title,
 		Zone:        args.Zone,
 		Day:         day,
 		Start:       day,
-		SprintStart: day,
+		SprintStart: sprint,
 		Assignee:    args.Assignee,
 		Team:        args.Team,
 	})

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -164,6 +164,10 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		if err := s.backend.SetSprintState(ctx, b, args.Team, day, cur); err != nil {
 			return board.Card{}, err
 		}
+	} else if day > sprint {
+		// Creating on a day past the current sprint keeps the card on that day
+		// instead of back-dating it into the (earlier) current sprint.
+		sprint = day
 	}
 	return s.backend.CreateCard(ctx, b, board.CreateInput{
 		Title:       args.Title,

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -164,16 +164,14 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		if err := s.backend.SetSprintState(ctx, b, args.Team, day, cur); err != nil {
 			return board.Card{}, err
 		}
-	} else if day > sprint {
-		// Creating on a day past the current sprint keeps the card on that day
-		// instead of back-dating it into the (earlier) current sprint.
-		sprint = day
 	}
+	// Start = the viewed day (where the card sits); SprintStart = the current
+	// sprint (so Carry Over carries it). They differ when creating on a later day.
 	return s.backend.CreateCard(ctx, b, board.CreateInput{
 		Title:       args.Title,
 		Zone:        args.Zone,
 		Day:         day,
-		Start:       sprint,
+		Start:       day,
 		SprintStart: sprint,
 		Assignee:    args.Assignee,
 		Team:        args.Team,
@@ -199,7 +197,10 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		return err
 	}
 	for _, c := range b.Cards {
-		if c.Team != team || c.SprintStart != old || c.Stage == board.StageDone {
+		// Carry every unfinished card whose sprint is before the new day — not
+		// just the previous sprint — so cards added on an in-between day (or made
+		// directly on the backend) are picked up too. Future-dated cards stay.
+		if c.Team != team || c.SprintStart == "" || c.SprintStart >= today || c.Stage == board.StageDone {
 			continue
 		}
 		if err := s.backend.SetSprintStart(ctx, b, c, today); err != nil {

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -57,6 +57,23 @@ func (s *Service) loadCard(ctx context.Context, owner string, project int, itemI
 	return b, card, nil
 }
 
+// --- Snapshot --------------------------------------------------------------
+
+// Board returns the full board snapshot: identity, fields, the visible cards and
+// the per-team sprint pointers. The API/MCP board endpoint builds its meta
+// response (fields + sprint states) from it.
+func (s *Service) Board(ctx context.Context, owner string, project int) (board.Board, error) {
+	return s.backend.LoadBoard(ctx, owner, project)
+}
+
+// Card loads the board and returns a single card by item id (ErrCardNotFound
+// when absent). The API/MCP layer uses it to return the card resulting from an
+// action, mirroring the way the UI re-renders the card it just changed.
+func (s *Service) Card(ctx context.Context, owner string, project int, itemID string) (board.Card, error) {
+	_, card, err := s.loadCard(ctx, owner, project, itemID)
+	return card, err
+}
+
 // --- Views -----------------------------------------------------------------
 
 // TeamView returns the Team board's grid cards for a team on a day (day = "" is

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -1,0 +1,686 @@
+package boardservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/ghprojects"
+)
+
+// *ghprojects.Client must satisfy Backend structurally (no boardservice import in
+// ghprojects). This line is the compile-time proof.
+var _ Backend = (*ghprojects.Client)(nil)
+
+// fakeBackend implements Backend over an in-memory board, logging every call and
+// mutating its board so the service's views reflect the result.
+type fakeBackend struct {
+	b       board.Board
+	log     []string
+	creates []board.CreateInput
+	nextID  int
+}
+
+func newFake(cards []board.Card, states map[string]board.SprintState) *fakeBackend {
+	if states == nil {
+		states = map[string]board.SprintState{}
+	}
+	return &fakeBackend{b: board.Board{ID: "B1", Number: 1, Owner: "acme", Cards: cards, SprintStates: states}}
+}
+
+func (f *fakeBackend) rec(format string, a ...any) { f.log = append(f.log, fmt.Sprintf(format, a...)) }
+
+func (f *fakeBackend) saw(s string) bool {
+	for _, e := range f.log {
+		if e == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeBackend) count(prefix string) int {
+	n := 0
+	for _, e := range f.log {
+		if strings.HasPrefix(e, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeBackend) get(itemID string) *board.Card {
+	for i := range f.b.Cards {
+		if f.b.Cards[i].ItemID == itemID {
+			return &f.b.Cards[i]
+		}
+	}
+	return nil
+}
+
+func (f *fakeBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	f.rec("LoadBoard")
+	cards := make([]board.Card, len(f.b.Cards))
+	copy(cards, f.b.Cards)
+	states := map[string]board.SprintState{}
+	for k, v := range f.b.SprintStates {
+		states[k] = v
+	}
+	return board.Board{ID: f.b.ID, Number: f.b.Number, Owner: f.b.Owner, Cards: cards, SprintStates: states}, nil
+}
+
+func (f *fakeBackend) CreateCard(_ context.Context, _ board.Board, in board.CreateInput) (board.Card, error) {
+	f.nextID++
+	card := board.Card{
+		ItemID: fmt.Sprintf("new%d", f.nextID), Title: in.Title, IsDraft: true,
+		Zone: in.Zone, StartDate: in.Start, SprintStart: in.SprintStart,
+		Plan: in.Plan, Week: in.Week, Team: in.Team, ReviewOf: in.ReviewOf,
+		Assignees: []string{},
+	}
+	if in.Assignee != "" {
+		card.Assignees = []string{in.Assignee}
+	}
+	f.b.Cards = append(f.b.Cards, card)
+	f.creates = append(f.creates, in)
+	f.rec("CreateCard %s", card.ItemID)
+	return card, nil
+}
+
+func (f *fakeBackend) DeleteCard(_ context.Context, _ board.Board, card board.Card) error {
+	f.rec("DeleteCard %s", card.ItemID)
+	out := f.b.Cards[:0]
+	for _, c := range f.b.Cards {
+		if c.ItemID != card.ItemID {
+			out = append(out, c)
+		}
+	}
+	f.b.Cards = out
+	return nil
+}
+
+func (f *fakeBackend) MoveCard(_ context.Context, _ board.Board, card board.Card, afterID string) error {
+	f.rec("MoveCard %s after=%s", card.ItemID, afterID)
+	return nil
+}
+
+func (f *fakeBackend) AddNote(_ context.Context, _ board.Board, card board.Card, text string) error {
+	f.rec("AddNote %s %s", card.ItemID, text)
+	return nil
+}
+
+func (f *fakeBackend) RenameCard(_ context.Context, _ board.Board, card board.Card, title string) error {
+	f.rec("RenameCard %s", card.ItemID)
+	if c := f.get(card.ItemID); c != nil {
+		c.Title = title
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetStage(_ context.Context, _ board.Board, card board.Card, stage board.StageKey) error {
+	f.rec("SetStage %s %s", card.ItemID, stage)
+	if c := f.get(card.ItemID); c != nil {
+		c.Stage = stage
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetProgress(_ context.Context, _ board.Board, card board.Card, progress int) error {
+	f.rec("SetProgress %s %d", card.ItemID, progress)
+	if c := f.get(card.ItemID); c != nil {
+		c.Progress = progress
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetZone(_ context.Context, _ board.Board, card board.Card, zone board.ZoneKey) error {
+	f.rec("SetZone %s %s", card.ItemID, zone)
+	if c := f.get(card.ItemID); c != nil {
+		c.Zone = zone
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetDay(_ context.Context, _ board.Board, card board.Card, day string) error {
+	f.rec("SetDay %s %s", card.ItemID, day)
+	return nil
+}
+
+func (f *fakeBackend) SetStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.rec("SetStart %s %s", card.ItemID, date)
+	if c := f.get(card.ItemID); c != nil {
+		c.StartDate = date
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetSprintStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.rec("SetSprintStart %s %s", card.ItemID, date)
+	if c := f.get(card.ItemID); c != nil {
+		c.SprintStart = date
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetPlan(_ context.Context, _ board.Board, card board.Card, plan board.PlanBand) error {
+	f.rec("SetPlan %s %s", card.ItemID, plan)
+	if c := f.get(card.ItemID); c != nil {
+		c.Plan = plan
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetWeek(_ context.Context, _ board.Board, card board.Card, week string) error {
+	f.rec("SetWeek %s %s", card.ItemID, week)
+	if c := f.get(card.ItemID); c != nil {
+		c.Week = week
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetTeam(_ context.Context, _ board.Board, card board.Card, team string) error {
+	f.rec("SetTeam %s %s", card.ItemID, team)
+	if c := f.get(card.ItemID); c != nil {
+		c.Team = team
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
+	f.rec("SetAssignee %s %s", card.ItemID, login)
+	if c := f.get(card.ItemID); c != nil {
+		if login == "" {
+			c.Assignees = []string{}
+		} else {
+			c.Assignees = []string{login}
+		}
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetReviewOf(_ context.Context, _ board.Board, card board.Card, reviewOf string) error {
+	f.rec("SetReviewOf %s %s", card.ItemID, reviewOf)
+	if c := f.get(card.ItemID); c != nil {
+		c.ReviewOf = reviewOf
+	}
+	return nil
+}
+
+func (f *fakeBackend) SetSprintState(_ context.Context, _ board.Board, team, current, previous string) error {
+	f.rec("SetSprintState %s cur=%s prev=%s", team, current, previous)
+	st := f.b.SprintStates[team]
+	st.Current = current
+	st.Previous = previous
+	if st.ItemID == "" {
+		f.nextID++
+		st.ItemID = fmt.Sprintf("state%d", f.nextID)
+	}
+	f.b.SprintStates[team] = st
+	return nil
+}
+
+// ctx is a shared test context.
+var ctx = context.Background()
+
+// --- CreateCard ------------------------------------------------------------
+
+func TestCreateCardStartsNewSprintForTeamWithNone(t *testing.T) {
+	f := newFake(nil, nil)
+	today := board.TodayIso()
+	card, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Zone: board.ZoneGray, Title: "task", Assignee: "bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw(fmt.Sprintf("SetSprintState alpha cur=%s prev=", today)) {
+		t.Fatalf("expected new sprint recorded; log=%v", f.log)
+	}
+	if len(f.creates) != 1 || f.creates[0].Start != today || f.creates[0].SprintStart != today {
+		t.Fatalf("create input = %+v", f.creates)
+	}
+	if card.Team != "alpha" || card.SprintStart != today {
+		t.Fatalf("card = %+v", card)
+	}
+}
+
+func TestCreateCardJoinsRunningSprint(t *testing.T) {
+	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task"}); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 0 {
+		t.Fatalf("should not touch sprint state; log=%v", f.log)
+	}
+	if f.creates[0].SprintStart != "2026-06-20" || f.creates[0].Start != "2026-06-20" {
+		t.Fatalf("create input = %+v", f.creates[0])
+	}
+}
+
+func TestCreateCardForceNewSprintDemotesCurrent(t *testing.T) {
+	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	today := board.TodayIso()
+	yes := true
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", StartNewSprint: &yes}); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw(fmt.Sprintf("SetSprintState alpha cur=%s prev=2026-06-20", today)) {
+		t.Fatalf("force-new should demote current to previous; log=%v", f.log)
+	}
+	if f.creates[0].SprintStart != today {
+		t.Fatalf("create input = %+v", f.creates[0])
+	}
+}
+
+// --- CarryOver -------------------------------------------------------------
+
+func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
+	old := "2026-01-01"
+	f := newFake([]board.Card{
+		{ItemID: "c1", Team: "alpha", SprintStart: old, Stage: board.StageNone},
+		{ItemID: "c2", Team: "alpha", SprintStart: old, Stage: board.StageDone},
+		{ItemID: "c3", Team: "alpha", SprintStart: "2026-02-01"},
+		{ItemID: "c4", Team: "beta", SprintStart: old},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	today := board.TodayIso()
+	if err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw(fmt.Sprintf("SetSprintState alpha cur=%s prev=%s", today, old)) {
+		t.Fatalf("expected advance; log=%v", f.log)
+	}
+	if f.count("SetSprintStart") != 1 || !f.saw(fmt.Sprintf("SetSprintStart c1 %s", today)) {
+		t.Fatalf("only the unfinished c1 should carry; log=%v", f.log)
+	}
+	if f.get("c1").SprintStart != today {
+		t.Fatalf("c1 not carried: %+v", f.get("c1"))
+	}
+}
+
+func TestCarryOverIdempotentWhenAlreadyToday(t *testing.T) {
+	today := board.TodayIso()
+	f := newFake([]board.Card{{ItemID: "c1", Team: "alpha", SprintStart: today}},
+		map[string]board.SprintState{"alpha": {Current: today}})
+	if err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 0 || f.count("SetSprintStart") != 0 {
+		t.Fatalf("idempotent carry should do nothing; log=%v", f.log)
+	}
+}
+
+func TestCarryOverWithNothingToCarryStillAdvances(t *testing.T) {
+	old := "2026-01-01"
+	f := newFake([]board.Card{{ItemID: "c1", Team: "alpha", SprintStart: old, Stage: board.StageDone}},
+		map[string]board.SprintState{"alpha": {Current: old}})
+	if err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 1 {
+		t.Fatalf("expected the sprint to advance; log=%v", f.log)
+	}
+	if f.count("SetSprintStart") != 0 {
+		t.Fatalf("nothing unfinished to carry; log=%v", f.log)
+	}
+}
+
+// --- Stage / progress ------------------------------------------------------
+
+func TestSetStageDoneFillsProgress(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Progress: 50}}, nil)
+	if err := f2svc(f).SetStage(ctx, "acme", 1, "c1", board.StageDone); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Stage != board.StageDone || f.get("c1").Progress != 100 {
+		t.Fatalf("card = %+v", f.get("c1"))
+	}
+}
+
+func TestSetStageReviewKnocksFullCardTo90(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Progress: 100}}, nil)
+	if err := f2svc(f).SetStage(ctx, "acme", 1, "c1", board.StageReview); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Stage != board.StageReview || f.get("c1").Progress != 90 {
+		t.Fatalf("card = %+v", f.get("c1"))
+	}
+}
+
+func TestSetProgressDoneLink(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Progress: 50}}, nil)
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 100); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Progress != 100 || f.get("c1").Stage != board.StageDone {
+		t.Fatalf("100%% should auto-set done: %+v", f.get("c1"))
+	}
+	// Dropping below 100 clears done.
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 80); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Progress != 80 || f.get("c1").Stage != board.StageNone {
+		t.Fatalf("below 100 should clear done: %+v", f.get("c1"))
+	}
+}
+
+func TestSetProgressClampsReviewCard(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Progress: 50, Stage: board.StageReview}}, nil)
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 5); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Progress != 10 {
+		t.Fatalf("review progress clamps up to 10: %+v", f.get("c1"))
+	}
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 95); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Progress != 90 || f.get("c1").Stage != board.StageReview {
+		t.Fatalf("review progress clamps down to 90: %+v", f.get("c1"))
+	}
+}
+
+func TestSetInProgressClampsDoneCard(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Progress: 100, Stage: board.StageDone}}, nil)
+	if err := f2svc(f).SetInProgress(ctx, "acme", 1, "c1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Stage != board.StageNone || f.get("c1").Progress != 90 {
+		t.Fatalf("in progress should clear done and drop to 90: %+v", f.get("c1"))
+	}
+}
+
+func TestSetProgressReviewLinkClearsOriginal(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Stage: board.StageReview},
+		{ItemID: "rev", ReviewOf: "orig", Stage: board.StageNone, Progress: 50},
+	}, nil)
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "rev", 100); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("orig").Stage != board.StageNone {
+		t.Fatalf("review at 100%% should take the original out of review: %+v", f.get("orig"))
+	}
+}
+
+func TestSetProgressReviewLinkReopensOriginal(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Stage: board.StageNone},
+		{ItemID: "rev", ReviewOf: "orig", Stage: board.StageNone, Progress: 50},
+	}, nil)
+	if err := f2svc(f).SetProgress(ctx, "acme", 1, "rev", 40); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("orig").Stage != board.StageReview {
+		t.Fatalf("review below 100%% should put the original on review: %+v", f.get("orig"))
+	}
+}
+
+// --- Review linkage --------------------------------------------------------
+
+func TestSendToReviewCreatesLinkedCardAndStagesOriginal(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "orig", Title: "ship it", Team: "alpha", Zone: board.ZoneRed, Progress: 100}},
+		map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	day := "2026-06-25"
+	rev, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "carol", day)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := f.creates[0]
+	if in.Title != "review: ship it" || in.Assignee != "carol" || in.ReviewOf != "orig" {
+		t.Fatalf("review create input = %+v", in)
+	}
+	if in.Zone != board.ZoneRed || in.Team != "alpha" || in.Start != day || in.SprintStart != "2026-06-20" {
+		t.Fatalf("review create input = %+v", in)
+	}
+	if rev.ReviewOf != "orig" {
+		t.Fatalf("returned review card = %+v", rev)
+	}
+	// Original goes to review; a full card is knocked to 90.
+	if f.get("orig").Stage != board.StageReview || f.get("orig").Progress != 90 {
+		t.Fatalf("original = %+v", f.get("orig"))
+	}
+}
+
+func TestReassignReviewerOnExistingReview(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Title: "x"},
+		{ItemID: "rev", ReviewOf: "orig", Assignees: []string{"carol"}},
+	}, nil)
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", ""); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("CreateCard") != 0 {
+		t.Fatalf("reassign should not create a new review card; log=%v", f.log)
+	}
+	if got := f.get("rev").Assignees; len(got) != 1 || got[0] != "dave" {
+		t.Fatalf("review assignee = %v", got)
+	}
+}
+
+func TestReassignReviewerWithoutReviewSendsToReview(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "orig", Title: "x", Team: "alpha"}}, nil)
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", "2026-06-25"); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("CreateCard") != 1 || f.creates[0].Assignee != "dave" || f.creates[0].ReviewOf != "orig" {
+		t.Fatalf("expected a review card to be created; creates=%+v", f.creates)
+	}
+}
+
+func TestRemoveReviewerDeletesReviewCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Title: "x"},
+		{ItemID: "rev", ReviewOf: "orig"},
+	}, nil)
+	if err := f2svc(f).RemoveReviewer(ctx, "acme", 1, "orig"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("DeleteCard rev") || f.get("rev") != nil {
+		t.Fatalf("review card should be deleted; log=%v", f.log)
+	}
+}
+
+// --- Delete cascade --------------------------------------------------------
+
+func TestDeleteCardCascadesToReview(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Title: "x"},
+		{ItemID: "rev", ReviewOf: "orig"},
+	}, nil)
+	if err := f2svc(f).DeleteCard(ctx, "acme", 1, "orig"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("orig") != nil || f.get("rev") != nil {
+		t.Fatalf("both cards should be gone; remaining=%+v", f.b.Cards)
+	}
+	if f.count("DeleteCard") != 2 {
+		t.Fatalf("expected two deletes; log=%v", f.log)
+	}
+}
+
+func TestDeleteCardUnknownItem(t *testing.T) {
+	f := newFake(nil, nil)
+	err := f2svc(f).DeleteCard(ctx, "acme", 1, "nope")
+	if err == nil || !strings.Contains(err.Error(), "card not found") {
+		t.Fatalf("err = %v, want card not found", err)
+	}
+}
+
+// --- SetTeam ---------------------------------------------------------------
+
+func TestSetTeamJoinsNewTeamSprint(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Team: "alpha", SprintStart: "2026-01-01"}},
+		map[string]board.SprintState{"beta": {Current: "2026-06-20"}})
+	if err := f2svc(f).SetTeam(ctx, "acme", 1, "c1", "beta", ""); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Team != "beta" || f.get("c1").SprintStart != "2026-06-20" {
+		t.Fatalf("card = %+v", f.get("c1"))
+	}
+}
+
+// --- Weekly plan -----------------------------------------------------------
+
+func TestTakeIntoPlanAssignsAndJoinsSprint(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "p1", Plan: board.PlanWed, Week: "2026-06-15", Zone: board.ZoneGray, Team: "alpha", Assignees: []string{}}},
+		map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	if err := f2svc(f).TakeIntoPlan(ctx, "acme", 1, "p1", "bob", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.get("p1").Assignees; len(got) != 1 || got[0] != "bob" {
+		t.Fatalf("assignee = %v", got)
+	}
+	if f.get("p1").SprintStart != "2026-06-20" {
+		t.Fatalf("sprint = %+v", f.get("p1"))
+	}
+	if f.count("SetZone") != 0 {
+		t.Fatalf("zone unchanged should not call SetZone; log=%v", f.log)
+	}
+}
+
+func TestTakeIntoPlanChangesZone(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "p1", Plan: board.PlanWed, Zone: board.ZoneGray, Team: "alpha", Assignees: []string{}}}, nil)
+	if err := f2svc(f).TakeIntoPlan(ctx, "acme", 1, "p1", "bob", board.ZoneRed, "2026-06-25"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("p1").Zone != board.ZoneRed {
+		t.Fatalf("zone = %+v", f.get("p1"))
+	}
+}
+
+func TestReleaseFromPlanClearsMarkersWhenAssigned(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Plan: board.PlanWed, Week: "2026-06-15", Assignees: []string{"bob"}}}, nil)
+	if err := f2svc(f).ReleaseFromPlan(ctx, "acme", 1, "c1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Plan != board.PlanNone || f.get("c1").Week != "" {
+		t.Fatalf("assigned card should keep but lose plan markers: %+v", f.get("c1"))
+	}
+	if f.count("DeleteCard") != 0 {
+		t.Fatalf("assigned card must not be deleted; log=%v", f.log)
+	}
+}
+
+func TestReleaseFromPlanDemotesPureCardToPreviousWeek(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "p1", Plan: board.PlanWed, Week: "2026-06-15", Team: "alpha", Assignees: []string{}},
+		{ItemID: "p2", Plan: board.PlanWed, Week: "2026-06-08", Team: "alpha", Assignees: []string{}},
+	}, nil)
+	if err := f2svc(f).ReleaseFromPlan(ctx, "acme", 1, "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("p1").Week != "2026-06-08" {
+		t.Fatalf("pure plan card should demote to previous week: %+v", f.get("p1"))
+	}
+	if f.count("DeleteCard") != 0 {
+		t.Fatalf("demote must not delete; log=%v", f.log)
+	}
+}
+
+func TestReleaseFromPlanDeletesPureCardWithNoPreviousWeek(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "p1", Plan: board.PlanWed, Week: "2026-06-15", Team: "alpha", Assignees: []string{}}}, nil)
+	if err := f2svc(f).ReleaseFromPlan(ctx, "acme", 1, "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("p1") != nil {
+		t.Fatalf("a pure plan card with no earlier week should be deleted: %+v", f.b.Cards)
+	}
+}
+
+func TestCarryWeekMovesUnfinishedEarlierCards(t *testing.T) {
+	week := "2026-06-22"
+	f := newFake([]board.Card{
+		{ItemID: "a1", Plan: board.PlanWed, Week: "2026-06-15", Team: "alpha"},
+		{ItemID: "a2", Plan: board.PlanFri, Week: "2026-06-15", Team: "alpha", Stage: board.StageDone},
+		{ItemID: "a3", Plan: board.PlanWed, Week: week, Team: "alpha"},
+		{ItemID: "a4", Plan: board.PlanWed, Week: "2026-06-15", Team: "beta"},
+	}, nil)
+	carried, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", week)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(carried) != 1 || carried[0].ItemID != "a1" || carried[0].Week != week {
+		t.Fatalf("carried = %+v", carried)
+	}
+	if f.get("a1").Week != week {
+		t.Fatalf("a1 not moved: %+v", f.get("a1"))
+	}
+	if f.count("SetWeek") != 1 {
+		t.Fatalf("only a1 should move; log=%v", f.log)
+	}
+}
+
+func TestCarryWeekNothingToCarry(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "a1", Plan: board.PlanWed, Week: "2026-06-22", Team: "alpha"}}, nil)
+	carried, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", "2026-06-22")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(carried) != 0 || f.count("SetWeek") != 0 {
+		t.Fatalf("nothing to carry; carried=%v log=%v", carried, f.log)
+	}
+}
+
+// --- Misc actions + views --------------------------------------------------
+
+func TestRenameAddNoteAndMove(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Title: "old"}, {ItemID: "c2"}}, nil)
+	svc := f2svc(f)
+	if err := svc.Rename(ctx, "acme", 1, "c1", "new"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Title != "new" {
+		t.Fatalf("rename failed: %+v", f.get("c1"))
+	}
+	if err := svc.AddNote(ctx, "acme", 1, "c1", "a note"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("AddNote c1 a note") {
+		t.Fatalf("note not recorded; log=%v", f.log)
+	}
+	if err := svc.MoveCard(ctx, "acme", 1, "c1", "c2"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("MoveCard c1 after=c2") {
+		t.Fatalf("move not recorded; log=%v", f.log)
+	}
+}
+
+func TestViewsReflectCreatedCard(t *testing.T) {
+	f := newFake(nil, nil)
+	today := board.TodayIso()
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Zone: board.ZoneGray, Title: "task", Assignee: "bob"}); err != nil {
+		t.Fatal(err)
+	}
+	me, err := f2svc(f).MeView(ctx, "acme", 1, "bob", today)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(me) != 1 || me[0].Title != "task" {
+		t.Fatalf("MeView should show the new card: %+v", me)
+	}
+	team, err := f2svc(f).TeamView(ctx, "acme", 1, "alpha", today)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(team) != 1 {
+		t.Fatalf("TeamView should show the new card: %+v", team)
+	}
+}
+
+func TestWeeklyPlanView(t *testing.T) {
+	week := "2026-06-22"
+	f := newFake([]board.Card{
+		{ItemID: "a1", Plan: board.PlanWed, Week: week, Team: "alpha"},
+		{ItemID: "a2", Plan: board.PlanFri, Week: week, Team: "alpha"},
+	}, nil)
+	bands, err := f2svc(f).WeeklyPlan(ctx, "acme", 1, "alpha", week)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bands.Wed) != 1 || len(bands.Fri) != 1 {
+		t.Fatalf("bands = %+v", bands)
+	}
+}
+
+// f2svc wraps a fake backend in a Service.
+func f2svc(f *fakeBackend) *Service { return New(f) }

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -243,10 +243,10 @@ func TestCreateCardStartsNewSprintForTeamWithNone(t *testing.T) {
 	}
 }
 
-func TestCreateCardWithExistingSprintStaysOnDay(t *testing.T) {
+func TestCreateCardOnTheSprintsOwnDay(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	// With an existing sprint, creating on a day puts the card on that day
-	// (Start == SprintStart) and leaves the sprint pointer untouched.
+	// Creating on the sprint's own day: Start (scheduled day) and SprintStart (the
+	// sprint) coincide, and the team's sprint pointer is left untouched.
 	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-20"}); err != nil {
 		t.Fatal(err)
 	}
@@ -258,18 +258,18 @@ func TestCreateCardWithExistingSprintStaysOnDay(t *testing.T) {
 	}
 }
 
-func TestCreateCardOnALaterDayUsesThatDay(t *testing.T) {
+func TestCreateCardJoinsCurrentSprintOnLaterDay(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	// A card lives on exactly one day: creating on a later day puts both Start and
-	// SprintStart on that day; the team's sprint pointer is left alone.
+	// Creating on a later day joins the running sprint: Start is the scheduled day
+	// while SprintStart stays the team's current sprint; the pointer is left alone.
 	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-30"}); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("SetSprintState") != 0 {
 		t.Fatalf("creating with an existing sprint should not touch it; log=%v", f.log)
 	}
-	if f.creates[0].Start != "2026-06-30" || f.creates[0].SprintStart != "2026-06-30" {
-		t.Fatalf("want Start == SprintStart == 2026-06-30; got %+v", f.creates[0])
+	if f.creates[0].Start != "2026-06-30" || f.creates[0].SprintStart != "2026-06-20" {
+		t.Fatalf("want Start 2026-06-30 / SprintStart 2026-06-20; got %+v", f.creates[0])
 	}
 }
 

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -243,9 +243,10 @@ func TestCreateCardStartsNewSprintForTeamWithNone(t *testing.T) {
 	}
 }
 
-func TestCreateCardJoinsRunningSprint(t *testing.T) {
+func TestCreateCardWithExistingSprintStaysOnDay(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	// Creating on a day within the current sprint joins it.
+	// With an existing sprint, creating on a day puts the card on that day
+	// (Start == SprintStart) and leaves the sprint pointer untouched.
 	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-20"}); err != nil {
 		t.Fatal(err)
 	}
@@ -257,19 +258,18 @@ func TestCreateCardJoinsRunningSprint(t *testing.T) {
 	}
 }
 
-func TestCreateCardPastSprintStaysOnDay(t *testing.T) {
+func TestCreateCardOnALaterDayUsesThatDay(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	// Creating on a day past the current sprint keeps the card on that day
-	// (Start) but joins the current sprint (SprintStart), so Carry Over carries
-	// it later; the team's sprint pointer is not advanced.
+	// A card lives on exactly one day: creating on a later day puts both Start and
+	// SprintStart on that day; the team's sprint pointer is left alone.
 	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-30"}); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("SetSprintState") != 0 {
-		t.Fatalf("creating past the sprint should not advance it; log=%v", f.log)
+		t.Fatalf("creating with an existing sprint should not touch it; log=%v", f.log)
 	}
-	if f.creates[0].Start != "2026-06-30" || f.creates[0].SprintStart != "2026-06-20" {
-		t.Fatalf("want Start=day 2026-06-30, SprintStart=sprint 2026-06-20; got %+v", f.creates[0])
+	if f.creates[0].Start != "2026-06-30" || f.creates[0].SprintStart != "2026-06-30" {
+		t.Fatalf("want Start == SprintStart == 2026-06-30; got %+v", f.creates[0])
 	}
 }
 

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -245,7 +245,8 @@ func TestCreateCardStartsNewSprintForTeamWithNone(t *testing.T) {
 
 func TestCreateCardJoinsRunningSprint(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task"}); err != nil {
+	// Creating on a day within the current sprint joins it.
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-20"}); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("SetSprintState") != 0 {
@@ -253,6 +254,21 @@ func TestCreateCardJoinsRunningSprint(t *testing.T) {
 	}
 	if f.creates[0].SprintStart != "2026-06-20" || f.creates[0].Start != "2026-06-20" {
 		t.Fatalf("create input = %+v", f.creates[0])
+	}
+}
+
+func TestCreateCardPastSprintStaysOnDay(t *testing.T) {
+	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	// Creating on a day past the current sprint keeps the card on that day and
+	// does not advance the team's sprint pointer.
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-30"}); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 0 {
+		t.Fatalf("creating past the sprint should not advance it; log=%v", f.log)
+	}
+	if f.creates[0].SprintStart != "2026-06-30" || f.creates[0].Start != "2026-06-30" {
+		t.Fatalf("card should stay on the viewed day; create input = %+v", f.creates[0])
 	}
 }
 

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -259,16 +259,17 @@ func TestCreateCardJoinsRunningSprint(t *testing.T) {
 
 func TestCreateCardPastSprintStaysOnDay(t *testing.T) {
 	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
-	// Creating on a day past the current sprint keeps the card on that day and
-	// does not advance the team's sprint pointer.
+	// Creating on a day past the current sprint keeps the card on that day
+	// (Start) but joins the current sprint (SprintStart), so Carry Over carries
+	// it later; the team's sprint pointer is not advanced.
 	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-30"}); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("SetSprintState") != 0 {
 		t.Fatalf("creating past the sprint should not advance it; log=%v", f.log)
 	}
-	if f.creates[0].SprintStart != "2026-06-30" || f.creates[0].Start != "2026-06-30" {
-		t.Fatalf("card should stay on the viewed day; create input = %+v", f.creates[0])
+	if f.creates[0].Start != "2026-06-30" || f.creates[0].SprintStart != "2026-06-20" {
+		t.Fatalf("want Start=day 2026-06-30, SprintStart=sprint 2026-06-20; got %+v", f.creates[0])
 	}
 }
 
@@ -296,6 +297,7 @@ func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
 		{ItemID: "c2", Team: "alpha", SprintStart: old, Stage: board.StageDone},
 		{ItemID: "c3", Team: "alpha", SprintStart: "2026-02-01"},
 		{ItemID: "c4", Team: "beta", SprintStart: old},
+		{ItemID: "c5", Team: "alpha", SprintStart: "2027-01-01"},
 	}, map[string]board.SprintState{"alpha": {Current: old}})
 	today := board.TodayIso()
 	if err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha"); err != nil {
@@ -304,11 +306,18 @@ func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
 	if !f.saw(fmt.Sprintf("SetSprintState alpha cur=%s prev=%s", today, old)) {
 		t.Fatalf("expected advance; log=%v", f.log)
 	}
-	if f.count("SetSprintStart") != 1 || !f.saw(fmt.Sprintf("SetSprintStart c1 %s", today)) {
-		t.Fatalf("only the unfinished c1 should carry; log=%v", f.log)
+	// c1 (previous sprint) and the in-between c3 both carry; c2 is done, c4 is
+	// another team, and c5 is future-dated — none of those move.
+	if f.count("SetSprintStart") != 2 ||
+		!f.saw(fmt.Sprintf("SetSprintStart c1 %s", today)) ||
+		!f.saw(fmt.Sprintf("SetSprintStart c3 %s", today)) {
+		t.Fatalf("c1 and the in-between c3 should carry; log=%v", f.log)
 	}
-	if f.get("c1").SprintStart != today {
-		t.Fatalf("c1 not carried: %+v", f.get("c1"))
+	if f.get("c1").SprintStart != today || f.get("c3").SprintStart != today {
+		t.Fatalf("c1/c3 not carried: %+v %+v", f.get("c1"), f.get("c3"))
+	}
+	if f.get("c5").SprintStart != "2027-01-01" {
+		t.Fatalf("future-dated c5 should not carry: %+v", f.get("c5"))
 	}
 }
 

--- a/internal/ghprojects/board.go
+++ b/internal/ghprojects/board.go
@@ -129,8 +129,10 @@ func (c *Client) ListBoards(ctx context.Context, owner string) ([]BoardSummary, 
 	return nil, nil
 }
 
-// LoadBoard loads a project board fully, mapping fields and cards.
-func (c *Client) LoadBoard(ctx context.Context, owner string, number int) (*Board, error) {
+// LoadProjectBoard loads a project board fully into the rich ghprojects.Board
+// (with notes, URLs and content ids). The domain-typed loader used by the board
+// service is the LoadBoard method in load.go.
+func (c *Client) LoadProjectBoard(ctx context.Context, owner string, number int) (*Board, error) {
 	raw, err := c.loadProject(ctx, owner, number)
 	if err != nil {
 		return nil, err

--- a/internal/ghprojects/board.go
+++ b/internal/ghprojects/board.go
@@ -85,8 +85,15 @@ type rawProject struct {
 		Nodes []rawField `json:"nodes"`
 	} `json:"fields"`
 	Items struct {
-		Nodes []rawItem `json:"nodes"`
+		PageInfo rawPageInfo `json:"pageInfo"`
+		Nodes    []rawItem   `json:"nodes"`
 	} `json:"items"`
+}
+
+// rawPageInfo is the items() connection cursor used to page a large board.
+type rawPageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
 }
 
 type projectResult struct {
@@ -149,13 +156,13 @@ func (c *Client) LoadProjectBoard(ctx context.Context, owner string, number int)
 // than falling through to the user query (which would error on an org login and
 // surface as a 502).
 func (c *Client) loadProject(ctx context.Context, owner string, number int) (*rawProject, error) {
-	vars := map[string]any{"owner": owner, "number": number}
+	vars := map[string]any{"owner": owner, "number": number, "after": nil}
 
 	var orgData projectResult
 	orgErr := c.graphql(ctx, orgProjectQuery, vars, &orgData)
 	if orgData.Organization != nil {
 		if orgData.Organization.ProjectV2 != nil {
-			return orgData.Organization.ProjectV2, nil
+			return c.pageProject(ctx, true, owner, number, orgData.Organization.ProjectV2)
 		}
 		return nil, fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
 	}
@@ -166,7 +173,7 @@ func (c *Client) loadProject(ctx context.Context, owner string, number int) (*ra
 	userErr := c.graphql(ctx, userProjectQuery, vars, &userData)
 	if userData.User != nil {
 		if userData.User.ProjectV2 != nil {
-			return userData.User.ProjectV2, nil
+			return c.pageProject(ctx, false, owner, number, userData.User.ProjectV2)
 		}
 		return nil, fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
 	}
@@ -184,6 +191,38 @@ func (c *Client) loadProject(ctx context.Context, owner string, number int) (*ra
 		return nil, orgErr
 	}
 	return nil, fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
+}
+
+// pageProject collects every remaining items() page for an already-resolved
+// project, appending them onto the first page's nodes. It mirrors the paging
+// loop in web/src/providers/github/githubProvider.ts: a board can hold more than
+// the 100-item GraphQL page size, and without paging the newest cards silently
+// fall off the load and "disappear" after a refresh.
+func (c *Client) pageProject(ctx context.Context, isOrg bool, owner string, number int, first *rawProject) (*rawProject, error) {
+	query := userProjectQuery
+	if isOrg {
+		query = orgProjectQuery
+	}
+	for first.Items.PageInfo.HasNextPage && first.Items.PageInfo.EndCursor != "" {
+		vars := map[string]any{"owner": owner, "number": number, "after": first.Items.PageInfo.EndCursor}
+		var data projectResult
+		if err := c.graphql(ctx, query, vars, &data); err != nil {
+			return nil, err
+		}
+		var next *rawProject
+		switch {
+		case isOrg && data.Organization != nil:
+			next = data.Organization.ProjectV2
+		case !isOrg && data.User != nil:
+			next = data.User.ProjectV2
+		}
+		if next == nil {
+			break
+		}
+		first.Items.Nodes = append(first.Items.Nodes, next.Items.Nodes...)
+		first.Items.PageInfo = next.Items.PageInfo
+	}
+	return first, nil
 }
 
 func mapProject(owner string, raw *rawProject) *Board {

--- a/internal/ghprojects/client.go
+++ b/internal/ghprojects/client.go
@@ -43,6 +43,10 @@ type Client struct {
 	httpClient Doer
 	userAgent  string
 	userCache  userIDCache
+	// fieldCache memoises fields the domain setters lazily create, keyed by
+	// project id + role, so two setters in one board operation never create the
+	// same field twice (see ensureDomainField).
+	fieldCache domainFieldCache
 }
 
 // Option customises a Client.

--- a/internal/ghprojects/client_test.go
+++ b/internal/ghprojects/client_test.go
@@ -93,7 +93,7 @@ func defaultRespond(query string, _ map[string]any) string {
 
 func TestLoadBoardMapsCards(t *testing.T) {
 	client, _ := newClientWithFake(t, defaultRespond)
-	board, err := client.LoadBoard(context.Background(), "acme", 7)
+	board, err := client.LoadProjectBoard(context.Background(), "acme", 7)
 	if err != nil {
 		t.Fatalf("LoadBoard: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestLoadBoardMapsCards(t *testing.T) {
 
 func TestUpdateCardSetsZoneProgressDay(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, err := client.LoadBoard(context.Background(), "acme", 7)
+	board, err := client.LoadProjectBoard(context.Background(), "acme", 7)
 	if err != nil {
 		t.Fatalf("LoadBoard: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestUpdateCardSetsZoneProgressDay(t *testing.T) {
 
 func TestUpdateCardClearsDayWithEmptyString(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
 	empty := ""
 	if err := client.UpdateCard(context.Background(), board, "I_DRAFT", UpdateCardInput{Day: &empty}); err != nil {
 		t.Fatalf("UpdateCard: %v", err)
@@ -190,7 +190,7 @@ func TestUpdateCardClearsDayWithEmptyString(t *testing.T) {
 
 func TestUpdateCardUnknownItem(t *testing.T) {
 	client, _ := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
 	title := "x"
 	err := client.UpdateCard(context.Background(), board, "NOPE", UpdateCardInput{Title: &title})
 	if err == nil || !strings.Contains(err.Error(), "card not found") {
@@ -200,8 +200,8 @@ func TestUpdateCardUnknownItem(t *testing.T) {
 
 func TestCreateCardAppliesZone(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
-	card, err := client.CreateCard(context.Background(), board, CreateCardInput{
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
+	card, err := client.CreateProjectCard(context.Background(), board, CreateCardInput{
 		Title:    "New work",
 		Zone:     ZoneRed,
 		Assignee: "octocat",
@@ -233,8 +233,8 @@ func TestCreateCardAppliesZone(t *testing.T) {
 
 func TestAddNoteOnIssueAddsComment(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
-	if err := client.AddNote(context.Background(), board, "I_ISSUE", "ship it"); err != nil {
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
+	if err := client.AddProjectNote(context.Background(), board, "I_ISSUE", "ship it"); err != nil {
 		t.Fatalf("AddNote: %v", err)
 	}
 	commented := false
@@ -250,8 +250,8 @@ func TestAddNoteOnIssueAddsComment(t *testing.T) {
 
 func TestAddNoteOnDraftAppendsBody(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
-	if err := client.AddNote(context.Background(), board, "I_DRAFT", "draft note"); err != nil {
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
+	if err := client.AddProjectNote(context.Background(), board, "I_DRAFT", "draft note"); err != nil {
 		t.Fatalf("AddNote: %v", err)
 	}
 	updated := false
@@ -269,12 +269,12 @@ func TestAddNoteOnDraftAppendsBody(t *testing.T) {
 
 func TestMoveAndDeleteCard(t *testing.T) {
 	client, fake := newClientWithFake(t, defaultRespond)
-	board, _ := client.LoadBoard(context.Background(), "acme", 7)
+	board, _ := client.LoadProjectBoard(context.Background(), "acme", 7)
 	after := "I_ISSUE"
-	if err := client.MoveCard(context.Background(), board, "I_DRAFT", &after); err != nil {
+	if err := client.MoveProjectCard(context.Background(), board, "I_DRAFT", &after); err != nil {
 		t.Fatalf("MoveCard: %v", err)
 	}
-	if err := client.DeleteCard(context.Background(), board, "I_DRAFT"); err != nil {
+	if err := client.DeleteProjectCard(context.Background(), board, "I_DRAFT"); err != nil {
 		t.Fatalf("DeleteCard: %v", err)
 	}
 	var moved, deleted bool
@@ -299,7 +299,7 @@ func TestLoadBoardNotFound(t *testing.T) {
 		}
 		return `{"user":null}`
 	})
-	_, err := client.LoadBoard(context.Background(), "ghost", 99)
+	_, err := client.LoadProjectBoard(context.Background(), "ghost", 99)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("err = %v, want not found", err)
 	}
@@ -327,7 +327,7 @@ func TestLoadBoardOrgMissingProject(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := New("test-token", WithEndpoint(srv.URL))
-	_, err := client.LoadBoard(context.Background(), "aenix-org", 999999)
+	_, err := client.LoadProjectBoard(context.Background(), "aenix-org", 999999)
 	if !errors.Is(err, ErrBoardNotFound) {
 		t.Fatalf("err = %v, want ErrBoardNotFound", err)
 	}
@@ -359,7 +359,7 @@ func TestLoadBoardMissingOwnerNotFound(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := New("test-token", WithEndpoint(srv.URL))
-	_, err := client.LoadBoard(context.Background(), "nobody-xyz", 1)
+	_, err := client.LoadProjectBoard(context.Background(), "nobody-xyz", 1)
 	if !errors.Is(err, ErrBoardNotFound) {
 		t.Fatalf("err = %v, want ErrBoardNotFound", err)
 	}
@@ -374,7 +374,7 @@ func TestLoadBoardSurfacesNonNotFoundError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := New("test-token", WithEndpoint(srv.URL))
-	_, err := client.LoadBoard(context.Background(), "acme", 7)
+	_, err := client.LoadProjectBoard(context.Background(), "acme", 7)
 	if err == nil || errors.Is(err, ErrBoardNotFound) {
 		t.Fatalf("err = %v, want a non-not-found error", err)
 	}

--- a/internal/ghprojects/client_test.go
+++ b/internal/ghprojects/client_test.go
@@ -382,3 +382,53 @@ func TestLoadBoardSurfacesNonNotFoundError(t *testing.T) {
 		t.Fatalf("err = %v, want it to surface the rate-limit message", err)
 	}
 }
+
+// TestLoadBoardPaginatesItems covers the items() pagination: a board larger than
+// one GraphQL page must be loaded in full, following pageInfo.endCursor, so the
+// newest cards do not silently fall off the load.
+func TestLoadBoardPaginatesItems(t *testing.T) {
+	page1 := `{"organization":{"projectV2":{
+	  "id":"PVT_1","number":7,"title":"Board","url":"u",
+	  "fields":{"nodes":[]},
+	  "items":{"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR1"},"nodes":[
+	    {"id":"I_P1","type":"DRAFT_ISSUE","content":{"__typename":"DraftIssue","id":"D1","title":"one","assignees":{"nodes":[]}},"fieldValues":{"nodes":[]}}
+	  ]}
+	}}}`
+	page2 := `{"organization":{"projectV2":{
+	  "id":"PVT_1","number":7,"title":"Board","url":"u",
+	  "fields":{"nodes":[]},
+	  "items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+	    {"id":"I_P2","type":"DRAFT_ISSUE","content":{"__typename":"DraftIssue","id":"D2","title":"two","assignees":{"nodes":[]}},"fieldValues":{"nodes":[]}}
+	  ]}
+	}}}`
+	client, fake := newClientWithFake(t, func(query string, vars map[string]any) string {
+		if strings.Contains(query, "organization(login:") && strings.Contains(query, "projectV2(number:") {
+			if vars["after"] == "CURSOR1" {
+				return page2
+			}
+			return page1
+		}
+		return "{}"
+	})
+
+	board, err := client.LoadProjectBoard(context.Background(), "acme", 7)
+	if err != nil {
+		t.Fatalf("LoadProjectBoard: %v", err)
+	}
+	if len(board.Cards) != 2 {
+		t.Fatalf("want 2 cards across 2 pages, got %d", len(board.Cards))
+	}
+	if board.cardByItemID("I_P1") == nil || board.cardByItemID("I_P2") == nil {
+		t.Fatalf("missing a paged card: %+v", board.Cards)
+	}
+
+	projectQueries := 0
+	for _, r := range fake.reqs {
+		if strings.Contains(r.query, "projectV2(number:") {
+			projectQueries++
+		}
+	}
+	if projectQueries != 2 {
+		t.Fatalf("want 2 project page queries (first + one follow-up), got %d", projectQueries)
+	}
+}

--- a/internal/ghprojects/load.go
+++ b/internal/ghprojects/load.go
@@ -1,0 +1,216 @@
+package ghprojects
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aenix-org/aeman/internal/board"
+)
+
+// LoadBoard loads a project board and maps it into the domain board.Board the
+// board service operates on (fields + cards, with the hidden sprint-state cards
+// split out by board.NewBoard). It mirrors githubProvider.mapProject. The rich
+// ghprojects.Board (notes, URLs, content ids) is loaded by LoadProjectBoard.
+func (c *Client) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
+	raw, err := c.loadProject(ctx, owner, project)
+	if err != nil {
+		return board.Board{}, err
+	}
+	return mapDomainBoard(owner, raw), nil
+}
+
+// mapDomainBoard maps a raw project onto the domain board.Board, calling
+// board.NewBoard so the per-team sprint-state cards are split out of Cards.
+func mapDomainBoard(owner string, raw *rawProject) board.Board {
+	fields := make([]board.ProjectField, 0, len(raw.Fields.Nodes))
+	for _, f := range raw.Fields.Nodes {
+		if f.ID == "" || f.Name == "" {
+			continue
+		}
+		field := board.ProjectField{ID: f.ID, Name: f.Name, DataType: f.DataType}
+		for _, o := range f.Options {
+			field.Options = append(field.Options, board.SingleSelectOption{ID: o.ID, Name: o.Name, Color: o.Color})
+		}
+		fields = append(fields, field)
+	}
+	roles := domainRoles(fields)
+	cards := make([]board.Card, 0, len(raw.Items.Nodes))
+	for i := range raw.Items.Nodes {
+		cards = append(cards, mapDomainItem(&raw.Items.Nodes[i], roles))
+	}
+	b := board.NewBoard(fields, cards)
+	b.ID = raw.ID
+	b.Number = raw.Number
+	b.Owner = owner
+	return b
+}
+
+// mapDomainItem maps one raw item onto a domain board.Card, reading the typed
+// roles aeman orients by. It mirrors githubProvider.mapItem (minus the
+// description/notes the pure card does not carry). The Day field has no place on
+// board.Card and is intentionally dropped.
+func mapDomainItem(item *rawItem, roles domainFieldRoles) board.Card {
+	content := item.Content
+	isDraft := item.Type == "DRAFT_ISSUE" || (content != nil && content.Typename == "DraftIssue")
+	card := board.Card{
+		ItemID:    item.ID,
+		Title:     "(untitled)",
+		IsDraft:   isDraft,
+		CreatedAt: item.CreatedAt,
+		Assignees: []string{},
+	}
+	if content != nil {
+		card.ContentID = content.ID
+		if content.Title != "" {
+			card.Title = content.Title
+		}
+		if content.Assignees != nil {
+			for _, a := range content.Assignees.Nodes {
+				card.Assignees = append(card.Assignees, a.Login)
+			}
+		}
+	}
+	for i := range item.FieldValues.Nodes {
+		applyDomainRole(&card, &item.FieldValues.Nodes[i], roles)
+	}
+	return card
+}
+
+// applyDomainRole records a single raw field value under the matching typed role,
+// mirroring the if/else-if chain in githubProvider.mapItem.
+func applyDomainRole(card *board.Card, v *rawFieldValue, roles domainFieldRoles) {
+	if v.Field == nil || v.Field.ID == "" {
+		return
+	}
+	id := v.Field.ID
+	switch {
+	case roles.Zone != nil && id == roles.Zone.ID && v.OptionID != "":
+		for _, o := range roles.Zone.Options {
+			if o.ID == v.OptionID {
+				card.Zone = board.ZoneKey(zoneFromColor(o.Color))
+			}
+		}
+	case roles.Stage != nil && id == roles.Stage.ID && v.Name != "":
+		card.Stage = board.StageFromName(v.Name)
+	case roles.Progress != nil && id == roles.Progress.ID && v.Number != nil:
+		card.Progress = int(*v.Number)
+	case roles.Start != nil && id == roles.Start.ID && v.Date != "":
+		card.StartDate = v.Date
+	case roles.SprintStart != nil && id == roles.SprintStart.ID && v.Date != "":
+		card.SprintStart = v.Date
+	case roles.Plan != nil && id == roles.Plan.ID && v.Name != "":
+		if strings.EqualFold(v.Name, "fri") {
+			card.Plan = board.PlanFri
+		} else {
+			card.Plan = board.PlanWed
+		}
+	case roles.Week != nil && id == roles.Week.ID && v.Date != "":
+		card.Week = v.Date
+	case roles.Team != nil && id == roles.Team.ID && v.Text != "":
+		card.Team = v.Text
+	case roles.ReviewOf != nil && id == roles.ReviewOf.ID && v.Text != "":
+		card.ReviewOf = v.Text
+	}
+}
+
+// domainFieldRoles resolves the board's fields onto the well-known roles the
+// board service reads and writes. It mirrors FieldRoles in
+// web/src/providers/types.ts (the subset aeman acts on).
+type domainFieldRoles struct {
+	Zone        *board.ProjectField
+	Progress    *board.ProjectField
+	Day         *board.ProjectField
+	Start       *board.ProjectField
+	SprintStart *board.ProjectField
+	Plan        *board.ProjectField
+	Week        *board.ProjectField
+	Stage       *board.ProjectField
+	Team        *board.ProjectField
+	ReviewOf    *board.ProjectField
+}
+
+// domainRoleAliases maps each role to the field names (case-insensitive) that
+// fill it. It mirrors ALIASES in web/src/providers/fields.ts (Stage is its own
+// role here, distinct from the default Status field).
+var domainRoleAliases = map[string][]string{
+	"zone":        {"zone", "priority zone", "зона"},
+	"progress":    {"progress", "readiness", "% done", "percent", "готовность"},
+	"day":         {"day", "date", "due date", "due", "finish", "finish date", "день", "дата"},
+	"start":       {"start", "start date", "начало", "старт"},
+	"sprintStart": {"sprint start", "sprintstart", "спринт старт"},
+	"plan":        {"plan", "план"},
+	"week":        {"week", "неделя"},
+	"stage":       {"stage", "состояние"},
+	"team":        {"team", "команда"},
+	"reviewOf":    {"review of", "reviewof"},
+}
+
+// domainRoles maps the board's fields onto the typed roles by name.
+func domainRoles(fields []board.ProjectField) domainFieldRoles {
+	var r domainFieldRoles
+	for i := range fields {
+		f := &fields[i]
+		name := strings.ToLower(strings.TrimSpace(f.Name))
+		switch {
+		case r.Zone == nil && domainMatchesAlias("zone", name):
+			r.Zone = f
+		case r.Progress == nil && domainMatchesAlias("progress", name):
+			r.Progress = f
+		case r.Day == nil && domainMatchesAlias("day", name):
+			r.Day = f
+		case r.Start == nil && domainMatchesAlias("start", name):
+			r.Start = f
+		case r.SprintStart == nil && domainMatchesAlias("sprintStart", name):
+			r.SprintStart = f
+		case r.Plan == nil && domainMatchesAlias("plan", name):
+			r.Plan = f
+		case r.Week == nil && domainMatchesAlias("week", name):
+			r.Week = f
+		case r.Stage == nil && domainMatchesAlias("stage", name):
+			r.Stage = f
+		case r.Team == nil && domainMatchesAlias("team", name):
+			r.Team = f
+		case r.ReviewOf == nil && domainMatchesAlias("reviewOf", name):
+			r.ReviewOf = f
+		}
+	}
+	return r
+}
+
+// get returns the field resolved for a role name, or nil.
+func (r domainFieldRoles) get(role string) *board.ProjectField {
+	switch role {
+	case "zone":
+		return r.Zone
+	case "progress":
+		return r.Progress
+	case "day":
+		return r.Day
+	case "start":
+		return r.Start
+	case "sprintStart":
+		return r.SprintStart
+	case "plan":
+		return r.Plan
+	case "week":
+		return r.Week
+	case "stage":
+		return r.Stage
+	case "team":
+		return r.Team
+	case "reviewOf":
+		return r.ReviewOf
+	default:
+		return nil
+	}
+}
+
+// domainMatchesAlias reports whether the lower-cased field name fills the role.
+func domainMatchesAlias(role, lowerName string) bool {
+	for _, alias := range domainRoleAliases[role] {
+		if alias == lowerName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ghprojects/load_test.go
+++ b/internal/ghprojects/load_test.go
@@ -1,0 +1,128 @@
+package ghprojects
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aenix-org/aeman/internal/board"
+)
+
+// domainBoardJSON is a raw project exercising the domain mapping: a normal card
+// with every typed role set, a linked review card, and a hidden sprint-state
+// card that must be split out into SprintStates (not Cards).
+const domainBoardJSON = `{
+  "id":"PVT_D","number":9,"title":"Domain","url":"https://example/9",
+  "fields":{"nodes":[
+    {"__typename":"ProjectV2SingleSelectField","id":"F_ZONE","name":"Zone","dataType":"SINGLE_SELECT","options":[
+       {"id":"o_gray","name":"Planned","color":"GRAY"},
+       {"id":"o_red","name":"Critical","color":"RED"}]},
+    {"__typename":"ProjectV2Field","id":"F_PROG","name":"Progress","dataType":"NUMBER"},
+    {"__typename":"ProjectV2SingleSelectField","id":"F_STAGE","name":"Stage","dataType":"SINGLE_SELECT","options":[
+       {"id":"s_locked","name":"Locked","color":"RED"},
+       {"id":"s_review","name":"Review","color":"YELLOW"},
+       {"id":"s_done","name":"Done","color":"GREEN"}]},
+    {"__typename":"ProjectV2Field","id":"F_START","name":"Start","dataType":"DATE"},
+    {"__typename":"ProjectV2Field","id":"F_SS","name":"Sprint Start","dataType":"DATE"},
+    {"__typename":"ProjectV2Field","id":"F_TEAM","name":"Team","dataType":"TEXT"},
+    {"__typename":"ProjectV2SingleSelectField","id":"F_PLAN","name":"Plan","dataType":"SINGLE_SELECT","options":[
+       {"id":"p_wed","name":"Wed","color":"BLUE"},
+       {"id":"p_fri","name":"Fri","color":"PURPLE"}]},
+    {"__typename":"ProjectV2Field","id":"F_WEEK","name":"Week","dataType":"DATE"},
+    {"__typename":"ProjectV2Field","id":"F_REV","name":"Review Of","dataType":"TEXT"}
+  ]},
+  "items":{"nodes":[
+    {"id":"I_ORIG","type":"DRAFT_ISSUE","createdAt":"2026-06-20T10:00:00Z",
+     "content":{"__typename":"DraftIssue","id":"DI_ORIG","title":"Build feature","assignees":{"nodes":[{"login":"bob"}]}},
+     "fieldValues":{"nodes":[
+        {"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"o_red","name":"Critical","field":{"id":"F_ZONE","name":"Zone"}},
+        {"__typename":"ProjectV2ItemFieldNumberValue","number":40,"field":{"id":"F_PROG","name":"Progress"}},
+        {"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"s_review","name":"Review","field":{"id":"F_STAGE","name":"Stage"}},
+        {"__typename":"ProjectV2ItemFieldDateValue","date":"2026-06-20","field":{"id":"F_START","name":"Start"}},
+        {"__typename":"ProjectV2ItemFieldDateValue","date":"2026-06-22","field":{"id":"F_SS","name":"Sprint Start"}},
+        {"__typename":"ProjectV2ItemFieldTextValue","text":"alpha","field":{"id":"F_TEAM","name":"Team"}},
+        {"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"p_wed","name":"Wed","field":{"id":"F_PLAN","name":"Plan"}},
+        {"__typename":"ProjectV2ItemFieldDateValue","date":"2026-06-22","field":{"id":"F_WEEK","name":"Week"}}
+     ]}},
+    {"id":"I_REV","type":"DRAFT_ISSUE","createdAt":"2026-06-21T10:00:00Z",
+     "content":{"__typename":"DraftIssue","id":"DI_REV","title":"review: Build feature","assignees":{"nodes":[{"login":"carol"}]}},
+     "fieldValues":{"nodes":[
+        {"__typename":"ProjectV2ItemFieldTextValue","text":"I_ORIG","field":{"id":"F_REV","name":"Review Of"}},
+        {"__typename":"ProjectV2ItemFieldTextValue","text":"alpha","field":{"id":"F_TEAM","name":"Team"}}
+     ]}},
+    {"id":"I_STATE","type":"DRAFT_ISSUE","createdAt":"2026-06-08T10:00:00Z",
+     "content":{"__typename":"DraftIssue","id":"DI_STATE","title":"aeman:sprint-state","assignees":{"nodes":[]}},
+     "fieldValues":{"nodes":[
+        {"__typename":"ProjectV2ItemFieldTextValue","text":"alpha","field":{"id":"F_TEAM","name":"Team"}},
+        {"__typename":"ProjectV2ItemFieldDateValue","date":"2026-06-22","field":{"id":"F_SS","name":"Sprint Start"}},
+        {"__typename":"ProjectV2ItemFieldDateValue","date":"2026-06-08","field":{"id":"F_START","name":"Start"}}
+     ]}}
+  ]}
+}`
+
+func TestMapDomainBoard(t *testing.T) {
+	var raw rawProject
+	if err := json.Unmarshal([]byte(domainBoardJSON), &raw); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	b := mapDomainBoard("acme", &raw)
+
+	if b.ID != "PVT_D" || b.Number != 9 || b.Owner != "acme" {
+		t.Fatalf("board identity = %+v", b)
+	}
+	if len(b.Cards) != 2 {
+		t.Fatalf("want 2 visible cards (state card split out), got %d", len(b.Cards))
+	}
+	if len(b.Fields) != 9 {
+		t.Fatalf("want 9 fields, got %d", len(b.Fields))
+	}
+
+	// The sprint-state card is split into SprintStates, not Cards.
+	st, ok := b.SprintStates["alpha"]
+	if !ok || st.Current != "2026-06-22" || st.Previous != "2026-06-08" || st.ItemID != "I_STATE" {
+		t.Fatalf("sprint state = %+v (ok=%v)", st, ok)
+	}
+	for _, c := range b.Cards {
+		if c.ItemID == "I_STATE" {
+			t.Fatal("sprint-state card must not appear in Cards")
+		}
+	}
+
+	orig := cardOf(t, b, "I_ORIG")
+	if !orig.IsDraft || orig.ContentID != "DI_ORIG" || orig.Title != "Build feature" {
+		t.Fatalf("orig identity = %+v", orig)
+	}
+	if orig.Zone != board.ZoneRed {
+		t.Errorf("orig zone = %q, want red", orig.Zone)
+	}
+	if orig.Progress != 40 {
+		t.Errorf("orig progress = %d, want 40", orig.Progress)
+	}
+	if orig.Stage != board.StageReview {
+		t.Errorf("orig stage = %q, want review", orig.Stage)
+	}
+	if orig.StartDate != "2026-06-20" || orig.SprintStart != "2026-06-22" {
+		t.Errorf("orig dates = %q / %q", orig.StartDate, orig.SprintStart)
+	}
+	if orig.Team != "alpha" || orig.Plan != board.PlanWed || orig.Week != "2026-06-22" {
+		t.Errorf("orig team/plan/week = %q / %q / %q", orig.Team, orig.Plan, orig.Week)
+	}
+	if len(orig.Assignees) != 1 || orig.Assignees[0] != "bob" {
+		t.Errorf("orig assignees = %v", orig.Assignees)
+	}
+
+	rev := cardOf(t, b, "I_REV")
+	if rev.ReviewOf != "I_ORIG" {
+		t.Errorf("review card ReviewOf = %q, want I_ORIG", rev.ReviewOf)
+	}
+}
+
+func cardOf(t *testing.T, b board.Board, itemID string) board.Card {
+	t.Helper()
+	for _, c := range b.Cards {
+		if c.ItemID == itemID {
+			return c
+		}
+	}
+	t.Fatalf("card %q not found", itemID)
+	return board.Card{}
+}

--- a/internal/ghprojects/mutations.go
+++ b/internal/ghprojects/mutations.go
@@ -43,9 +43,10 @@ func (c *Client) resolveUserID(ctx context.Context, login string) (string, error
 	return data.User.ID, nil
 }
 
-// CreateCard creates a draft-issue card on the board and applies the optional
-// fields, returning the loaded card.
-func (c *Client) CreateCard(ctx context.Context, board *Board, in CreateCardInput) (*Card, error) {
+// CreateProjectCard creates a draft-issue card on the board and applies the
+// optional fields, returning the loaded rich card. The domain-typed create used
+// by the board service is the CreateCard method in setters.go.
+func (c *Client) CreateProjectCard(ctx context.Context, board *Board, in CreateCardInput) (*Card, error) {
 	if strings.TrimSpace(in.Title) == "" {
 		return nil, fmt.Errorf("title is required")
 	}
@@ -119,7 +120,7 @@ func (c *Client) CreateCard(ctx context.Context, board *Board, in CreateCardInpu
 		return nil, err
 	}
 
-	reloaded, err := c.LoadBoard(ctx, board.Owner, board.Number)
+	reloaded, err := c.LoadProjectBoard(ctx, board.Owner, board.Number)
 	if err == nil {
 		if card := reloaded.cardByItemID(itemID); card != nil {
 			return card, nil
@@ -360,9 +361,10 @@ func (c *Client) setAssignee(ctx context.Context, isDraft bool, contentID string
 	return nil
 }
 
-// MoveCard reorders itemID to sit after afterID; a nil afterID moves it to the
-// top of the board.
-func (c *Client) MoveCard(ctx context.Context, board *Board, itemID string, afterID *string) error {
+// MoveProjectCard reorders itemID to sit after afterID; a nil afterID moves it
+// to the top of the board. The domain-typed move is the MoveCard method in
+// setters.go.
+func (c *Client) MoveProjectCard(ctx context.Context, board *Board, itemID string, afterID *string) error {
 	if board.cardByItemID(itemID) == nil {
 		return fmt.Errorf("%w: %s", ErrCardNotFound, itemID)
 	}
@@ -373,14 +375,16 @@ func (c *Client) MoveCard(ctx context.Context, board *Board, itemID string, afte
 	return c.graphql(ctx, moveItemMutation, vars, nil)
 }
 
-// DeleteCard removes the item from the board.
-func (c *Client) DeleteCard(ctx context.Context, board *Board, itemID string) error {
+// DeleteProjectCard removes the item from the board. The domain-typed delete is
+// the DeleteCard method in setters.go.
+func (c *Client) DeleteProjectCard(ctx context.Context, board *Board, itemID string) error {
 	return c.graphql(ctx, deleteItemMutation, map[string]any{"project": board.ID, "item": itemID}, nil)
 }
 
-// AddNote appends a note to the card: an issue comment, or a dated line in the
-// draft body when the card is a draft.
-func (c *Client) AddNote(ctx context.Context, board *Board, itemID, text string) error {
+// AddProjectNote appends a note to the card: an issue comment, or a dated line
+// in the draft body when the card is a draft. The domain-typed note is the
+// AddNote method in setters.go.
+func (c *Client) AddProjectNote(ctx context.Context, board *Board, itemID, text string) error {
 	card := board.cardByItemID(itemID)
 	if card == nil {
 		return fmt.Errorf("%w: %s", ErrCardNotFound, itemID)

--- a/internal/ghprojects/queries.go
+++ b/internal/ghprojects/queries.go
@@ -16,7 +16,8 @@ const projectBody = `
       ... on ProjectV2SingleSelectField { id name dataType options { id name color } }
     }
   }
-  items(first: 100) {
+  items(first: 100, after: $after) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       type
@@ -69,11 +70,11 @@ const projectBody = `
   }
 `
 
-const orgProjectQuery = `query($owner: String!, $number: Int!) {
+const orgProjectQuery = `query($owner: String!, $number: Int!, $after: String) {
   organization(login: $owner) { projectV2(number: $number) { ` + projectBody + ` } }
 }`
 
-const userProjectQuery = `query($owner: String!, $number: Int!) {
+const userProjectQuery = `query($owner: String!, $number: Int!, $after: String) {
   user(login: $owner) { projectV2(number: $number) { ` + projectBody + ` } }
 }`
 

--- a/internal/ghprojects/queries.go
+++ b/internal/ghprojects/queries.go
@@ -139,6 +139,18 @@ const addDraftMutation = `mutation($project: ID!, $title: String!, $assignees: [
   }
 }`
 
+const createFieldMutation = `mutation($project: ID!, $name: String!, $dataType: ProjectV2CustomFieldType!) {
+  createProjectV2Field(input: { projectId: $project, name: $name, dataType: $dataType }) {
+    projectV2Field { ... on ProjectV2FieldCommon { id name dataType } }
+  }
+}`
+
+const createSelectFieldMutation = `mutation($project: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  createProjectV2Field(input: { projectId: $project, name: $name, dataType: SINGLE_SELECT, singleSelectOptions: $options }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name dataType options { id name color } } }
+  }
+}`
+
 const deleteItemMutation = `mutation($project: ID!, $item: ID!) {
   deleteProjectV2Item(input: { projectId: $project, itemId: $item }) { deletedItemId }
 }`

--- a/internal/ghprojects/setters.go
+++ b/internal/ghprojects/setters.go
@@ -1,0 +1,509 @@
+package ghprojects
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aenix-org/aeman/internal/board"
+)
+
+// domainFieldCache memoises fields the domain setters lazily create, keyed by
+// "<projectID>\x00<role>". A project's fields persist on GitHub, so the cache is
+// only needed within a single board operation (where two setters may both need a
+// field the board did not have yet) and is safe for a per-request Client.
+type domainFieldCache struct {
+	mu sync.Mutex
+	m  map[string]board.ProjectField
+}
+
+func (d *domainFieldCache) load(key string) (board.ProjectField, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	f, ok := d.m[key]
+	return f, ok
+}
+
+func (d *domainFieldCache) store(key string, f board.ProjectField) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.m == nil {
+		d.m = map[string]board.ProjectField{}
+	}
+	d.m[key] = f
+}
+
+// domainSelectOption is one option of a single-select field aeman may create.
+type domainSelectOption struct {
+	name, color, description string
+}
+
+// domainFieldSpec describes how to create a missing role field. It mirrors
+// FIELD_SPECS in web/src/providers/github/githubProvider.ts.
+type domainFieldSpec struct {
+	name     string
+	dataType string // for non-select fields: NUMBER | DATE | TEXT
+	options  []domainSelectOption
+}
+
+// domainFieldSpecs lists the fields aeman lazily creates on a board that lacks
+// them. Roles without a spec (e.g. an absent custom field) cannot be created.
+var domainFieldSpecs = map[string]domainFieldSpec{
+	"zone": {name: "Zone", options: []domainSelectOption{
+		{"Critical today", "RED", "Must be resolved before the end of the day"},
+		{"Unplanned", "YELLOW", "Popped up unplanned during the day"},
+		{"Planned", "GRAY", "Regular, planned work"},
+		{"If time left", "GREEN", "Start only when every other zone is clear"},
+	}},
+	"stage": {name: "Stage", options: []domainSelectOption{
+		{"Locked", "RED", "Locked"},
+		{"Review", "YELLOW", "Review"},
+		{"Done", "GREEN", "Done"},
+	}},
+	"progress":    {name: "Progress", dataType: "NUMBER"},
+	"day":         {name: "Day", dataType: "DATE"},
+	"start":       {name: "Start", dataType: "DATE"},
+	"sprintStart": {name: "Sprint Start", dataType: "DATE"},
+	"plan": {name: "Plan", options: []domainSelectOption{
+		{"Wed", "BLUE", "By Wednesday"},
+		{"Fri", "PURPLE", "By Friday"},
+	}},
+	"week":     {name: "Week", dataType: "DATE"},
+	"team":     {name: "Team", dataType: "TEXT"},
+	"reviewOf": {name: "Review Of", dataType: "TEXT"},
+}
+
+// zoneGHColors maps each Ford zone onto the GitHub single-select option colours
+// that represent it. It mirrors web/src/zones.ts ghColors.
+var zoneGHColors = map[board.ZoneKey][]string{
+	board.ZoneGray:   {"GRAY"},
+	board.ZoneGreen:  {"GREEN"},
+	board.ZoneYellow: {"YELLOW", "ORANGE"},
+	board.ZoneRed:    {"RED", "PINK"},
+}
+
+// createdFieldRaw is the createProjectV2Field payload aeman reads.
+type createdFieldRaw struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	DataType string `json:"dataType"`
+	Options  []struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"options"`
+}
+
+func (f createdFieldRaw) toDomain() board.ProjectField {
+	field := board.ProjectField{ID: f.ID, Name: f.Name, DataType: f.DataType}
+	for _, o := range f.Options {
+		field.Options = append(field.Options, board.SingleSelectOption{ID: o.ID, Name: o.Name, Color: o.Color})
+	}
+	return field
+}
+
+// ensureDomainField returns the board field filling a role, creating it on the
+// project when it does not exist yet. It mirrors githubProvider.ensureField; the
+// created field is cached (see domainFieldCache) instead of pushed onto the
+// pass-by-value board.
+func (c *Client) ensureDomainField(ctx context.Context, b board.Board, role string) (board.ProjectField, error) {
+	if f := domainRoles(b.Fields).get(role); f != nil {
+		return *f, nil
+	}
+	key := b.ID + "\x00" + role
+	if f, ok := c.fieldCache.load(key); ok {
+		return f, nil
+	}
+	spec, ok := domainFieldSpecs[role]
+	if !ok {
+		return board.ProjectField{}, fmt.Errorf("%w: %s", ErrFieldNotFound, role)
+	}
+	field, err := c.createDomainField(ctx, b.ID, spec)
+	if err != nil {
+		return board.ProjectField{}, err
+	}
+	c.fieldCache.store(key, field)
+	return field, nil
+}
+
+// createDomainField creates a project field from its spec.
+func (c *Client) createDomainField(ctx context.Context, projectID string, spec domainFieldSpec) (board.ProjectField, error) {
+	var data struct {
+		CreateProjectV2Field struct {
+			ProjectV2Field createdFieldRaw `json:"projectV2Field"`
+		} `json:"createProjectV2Field"`
+	}
+	if len(spec.options) > 0 {
+		options := make([]map[string]any, len(spec.options))
+		for i, o := range spec.options {
+			options[i] = map[string]any{"name": o.name, "color": o.color, "description": o.description}
+		}
+		if err := c.graphql(ctx, createSelectFieldMutation,
+			map[string]any{"project": projectID, "name": spec.name, "options": options}, &data); err != nil {
+			return board.ProjectField{}, err
+		}
+		return data.CreateProjectV2Field.ProjectV2Field.toDomain(), nil
+	}
+	if err := c.graphql(ctx, createFieldMutation,
+		map[string]any{"project": projectID, "name": spec.name, "dataType": spec.dataType}, &data); err != nil {
+		return board.ProjectField{}, err
+	}
+	return data.CreateProjectV2Field.ProjectV2Field.toDomain(), nil
+}
+
+// domainOptionForZone finds the option id in a single-select field for a zone.
+func domainOptionForZone(field board.ProjectField, zone board.ZoneKey) string {
+	for _, opt := range field.Options {
+		for _, want := range zoneGHColors[zone] {
+			if strings.EqualFold(opt.Color, want) {
+				return opt.ID
+			}
+		}
+	}
+	return ""
+}
+
+// domainOptionForStage finds the option id in the Stage field for a stage.
+func domainOptionForStage(field board.ProjectField, stage board.StageKey) string {
+	for _, opt := range field.Options {
+		if board.StageFromName(opt.Name) == stage {
+			return opt.ID
+		}
+	}
+	return ""
+}
+
+// domainOptionByName finds the option id whose name matches (case-insensitively).
+func domainOptionByName(field board.ProjectField, name string) string {
+	for _, opt := range field.Options {
+		if strings.EqualFold(strings.TrimSpace(opt.Name), strings.TrimSpace(name)) {
+			return opt.ID
+		}
+	}
+	return ""
+}
+
+// SetZone sets (or clears, when zone is empty) the board's zone field.
+func (c *Client) SetZone(ctx context.Context, b board.Board, card board.Card, zone board.ZoneKey) error {
+	field, err := c.ensureDomainField(ctx, b, "zone")
+	if err != nil {
+		return err
+	}
+	if zone == "" {
+		return c.clearField(ctx, b.ID, card.ItemID, field.ID)
+	}
+	option := domainOptionForZone(field, zone)
+	if option == "" {
+		return fmt.Errorf("zone %q has no matching option on field %q", zone, field.Name)
+	}
+	return c.setSingleSelect(ctx, b.ID, card.ItemID, field.ID, option)
+}
+
+// SetStage sets (or clears, when stage is empty) the board's Stage field. The
+// progress side of the stage transition is owned by the board service.
+func (c *Client) SetStage(ctx context.Context, b board.Board, card board.Card, stage board.StageKey) error {
+	field, err := c.ensureDomainField(ctx, b, "stage")
+	if err != nil {
+		return err
+	}
+	if stage == "" {
+		return c.clearField(ctx, b.ID, card.ItemID, field.ID)
+	}
+	option := domainOptionForStage(field, stage)
+	if option == "" {
+		return fmt.Errorf("stage %q has no matching option on field %q", stage, field.Name)
+	}
+	return c.setSingleSelect(ctx, b.ID, card.ItemID, field.ID, option)
+}
+
+// SetProgress sets the readiness percentage.
+func (c *Client) SetProgress(ctx context.Context, b board.Board, card board.Card, progress int) error {
+	field, err := c.ensureDomainField(ctx, b, "progress")
+	if err != nil {
+		return err
+	}
+	return c.graphql(ctx, setNumberMutation,
+		map[string]any{"project": b.ID, "item": card.ItemID, "field": field.ID, "value": float64(progress)}, nil)
+}
+
+// SetPlan sets (or clears) the weekly-plan band.
+func (c *Client) SetPlan(ctx context.Context, b board.Board, card board.Card, plan board.PlanBand) error {
+	field, err := c.ensureDomainField(ctx, b, "plan")
+	if err != nil {
+		return err
+	}
+	if plan == "" {
+		return c.clearField(ctx, b.ID, card.ItemID, field.ID)
+	}
+	option := domainOptionByName(field, string(plan))
+	if option == "" {
+		return fmt.Errorf("plan field %q has no %q option", field.Name, plan)
+	}
+	return c.setSingleSelect(ctx, b.ID, card.ItemID, field.ID, option)
+}
+
+// SetDay sets (or clears) the card's Day field.
+func (c *Client) SetDay(ctx context.Context, b board.Board, card board.Card, day string) error {
+	return c.setDomainDate(ctx, b, card, "day", day)
+}
+
+// SetStart sets (or clears) the card's Start field.
+func (c *Client) SetStart(ctx context.Context, b board.Board, card board.Card, date string) error {
+	return c.setDomainDate(ctx, b, card, "start", date)
+}
+
+// SetSprintStart sets (or clears) the card's Sprint Start field.
+func (c *Client) SetSprintStart(ctx context.Context, b board.Board, card board.Card, date string) error {
+	return c.setDomainDate(ctx, b, card, "sprintStart", date)
+}
+
+// SetWeek sets (or clears) the card's Week field.
+func (c *Client) SetWeek(ctx context.Context, b board.Board, card board.Card, week string) error {
+	return c.setDomainDate(ctx, b, card, "week", week)
+}
+
+// setDomainDate sets (or clears, when value is empty) a date role field.
+func (c *Client) setDomainDate(ctx context.Context, b board.Board, card board.Card, role, value string) error {
+	field, err := c.ensureDomainField(ctx, b, role)
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return c.clearField(ctx, b.ID, card.ItemID, field.ID)
+	}
+	return c.graphql(ctx, setDateMutation,
+		map[string]any{"project": b.ID, "item": card.ItemID, "field": field.ID, "value": value}, nil)
+}
+
+// SetTeam sets (or clears) the card's team label.
+func (c *Client) SetTeam(ctx context.Context, b board.Board, card board.Card, team string) error {
+	return c.setDomainText(ctx, b, card, "team", team)
+}
+
+// SetReviewOf sets (or clears) the review-of link on a review card.
+func (c *Client) SetReviewOf(ctx context.Context, b board.Board, card board.Card, reviewOf string) error {
+	return c.setDomainText(ctx, b, card, "reviewOf", reviewOf)
+}
+
+// setDomainText sets (or clears, when value is empty) a text role field.
+func (c *Client) setDomainText(ctx context.Context, b board.Board, card board.Card, role, value string) error {
+	field, err := c.ensureDomainField(ctx, b, role)
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return c.clearField(ctx, b.ID, card.ItemID, field.ID)
+	}
+	return c.graphql(ctx, setTextMutation,
+		map[string]any{"project": b.ID, "item": card.ItemID, "field": field.ID, "value": value}, nil)
+}
+
+// SetAssignee replaces the card's assignee with login (empty clears it).
+func (c *Client) SetAssignee(ctx context.Context, _ board.Board, card board.Card, login string) error {
+	return c.setAssignee(ctx, card.IsDraft, card.ContentID, card.Assignees, login)
+}
+
+// RenameCard updates the card's title.
+func (c *Client) RenameCard(ctx context.Context, _ board.Board, card board.Card, title string) error {
+	return c.setTitle(ctx, card.IsDraft, card.ContentID, title)
+}
+
+// MoveCard reorders card to sit after afterID; an empty afterID moves it to the
+// top of the board.
+func (c *Client) MoveCard(ctx context.Context, b board.Board, card board.Card, afterID string) error {
+	vars := map[string]any{"project": b.ID, "item": card.ItemID, "after": nil}
+	if afterID != "" {
+		vars["after"] = afterID
+	}
+	return c.graphql(ctx, moveItemMutation, vars, nil)
+}
+
+// DeleteCard removes the card from the board.
+func (c *Client) DeleteCard(ctx context.Context, b board.Board, card board.Card) error {
+	return c.graphql(ctx, deleteItemMutation, map[string]any{"project": b.ID, "item": card.ItemID}, nil)
+}
+
+// AddNote appends a note to the card: an issue comment, or a dated line in the
+// draft body when the card is a draft. It mirrors the rich AddProjectNote.
+func (c *Client) AddNote(ctx context.Context, _ board.Board, card board.Card, text string) error {
+	if card.ContentID == "" {
+		return ErrNoContent
+	}
+	if card.IsDraft {
+		var data struct {
+			Node *struct {
+				Body string `json:"body"`
+			} `json:"node"`
+		}
+		if err := c.graphql(ctx, getDraftBodyQuery, map[string]any{"id": card.ContentID}, &data); err != nil {
+			return err
+		}
+		body := ""
+		if data.Node != nil {
+			body = data.Node.Body
+		}
+		line := fmt.Sprintf("- [%s] %s", time.Now().UTC().Format(time.RFC3339), text)
+		if body != "" {
+			line = body + "\n" + line
+		}
+		return c.graphql(ctx, updateDraftBodyMutation, map[string]any{"draft": card.ContentID, "body": line}, nil)
+	}
+	return c.graphql(ctx, addCommentMutation, map[string]any{"subject": card.ContentID, "body": text}, nil)
+}
+
+// CreateCard creates a draft-issue card and applies the optional fields,
+// returning an optimistic domain card. It mirrors githubProvider.createCard.
+func (c *Client) CreateCard(ctx context.Context, b board.Board, in board.CreateInput) (board.Card, error) {
+	var assigneeIDs []string
+	if in.Assignee != "" {
+		id, err := c.resolveUserID(ctx, in.Assignee)
+		if err != nil {
+			return board.Card{}, err
+		}
+		assigneeIDs = []string{id}
+	}
+	var created struct {
+		AddProjectV2DraftIssue struct {
+			ProjectItem struct {
+				ID      string `json:"id"`
+				Content *struct {
+					ID string `json:"id"`
+				} `json:"content"`
+			} `json:"projectItem"`
+		} `json:"addProjectV2DraftIssue"`
+	}
+	if err := c.graphql(ctx, addDraftMutation,
+		map[string]any{"project": b.ID, "title": in.Title, "assignees": assigneeIDs}, &created); err != nil {
+		return board.Card{}, err
+	}
+	item := created.AddProjectV2DraftIssue.ProjectItem
+	contentID := ""
+	if item.Content != nil {
+		contentID = item.Content.ID
+	}
+
+	if in.Zone != "" {
+		field, err := c.ensureDomainField(ctx, b, "zone")
+		if err != nil {
+			return board.Card{}, err
+		}
+		if option := domainOptionForZone(field, in.Zone); option != "" {
+			if err := c.setSingleSelect(ctx, b.ID, item.ID, field.ID, option); err != nil {
+				return board.Card{}, err
+			}
+		}
+	}
+	for _, df := range []struct{ role, value string }{
+		{"day", in.Day}, {"start", in.Start}, {"sprintStart", in.SprintStart}, {"week", in.Week},
+	} {
+		if df.value == "" {
+			continue
+		}
+		field, err := c.ensureDomainField(ctx, b, df.role)
+		if err != nil {
+			return board.Card{}, err
+		}
+		if err := c.graphql(ctx, setDateMutation,
+			map[string]any{"project": b.ID, "item": item.ID, "field": field.ID, "value": df.value}, nil); err != nil {
+			return board.Card{}, err
+		}
+	}
+	for _, tf := range []struct{ role, value string }{
+		{"team", in.Team}, {"reviewOf", in.ReviewOf},
+	} {
+		if tf.value == "" {
+			continue
+		}
+		field, err := c.ensureDomainField(ctx, b, tf.role)
+		if err != nil {
+			return board.Card{}, err
+		}
+		if err := c.graphql(ctx, setTextMutation,
+			map[string]any{"project": b.ID, "item": item.ID, "field": field.ID, "value": tf.value}, nil); err != nil {
+			return board.Card{}, err
+		}
+	}
+	if in.Plan != "" {
+		field, err := c.ensureDomainField(ctx, b, "plan")
+		if err != nil {
+			return board.Card{}, err
+		}
+		if option := domainOptionByName(field, string(in.Plan)); option != "" {
+			if err := c.setSingleSelect(ctx, b.ID, item.ID, field.ID, option); err != nil {
+				return board.Card{}, err
+			}
+		}
+	}
+
+	assignees := []string{}
+	if in.Assignee != "" {
+		assignees = []string{in.Assignee}
+	}
+	return board.Card{
+		ItemID:      item.ID,
+		ContentID:   contentID,
+		Title:       in.Title,
+		IsDraft:     true,
+		Assignees:   assignees,
+		Zone:        in.Zone,
+		StartDate:   in.Start,
+		SprintStart: in.SprintStart,
+		Plan:        in.Plan,
+		Week:        in.Week,
+		Team:        in.Team,
+		ReviewOf:    in.ReviewOf,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// SetSprintState creates or updates a team's hidden sprint-state card: Sprint
+// Start holds the current sprint, Start holds the previous one. team = "" is the
+// no-team group (its state card carries no team field). It mirrors
+// githubProvider.setSprintState.
+func (c *Client) SetSprintState(ctx context.Context, b board.Board, team, current, previous string) error {
+	itemID := b.SprintStates[team].ItemID
+	if itemID == "" {
+		var created struct {
+			AddProjectV2DraftIssue struct {
+				ProjectItem struct {
+					ID string `json:"id"`
+				} `json:"projectItem"`
+			} `json:"addProjectV2DraftIssue"`
+		}
+		if err := c.graphql(ctx, addDraftMutation,
+			map[string]any{"project": b.ID, "title": board.SprintStateTitle, "assignees": []string{}}, &created); err != nil {
+			return err
+		}
+		itemID = created.AddProjectV2DraftIssue.ProjectItem.ID
+		if team != "" {
+			teamField, err := c.ensureDomainField(ctx, b, "team")
+			if err != nil {
+				return err
+			}
+			if err := c.graphql(ctx, setTextMutation,
+				map[string]any{"project": b.ID, "item": itemID, "field": teamField.ID, "value": team}, nil); err != nil {
+				return err
+			}
+		}
+	}
+	if err := c.setSprintStateDate(ctx, b, itemID, "sprintStart", current); err != nil {
+		return err
+	}
+	return c.setSprintStateDate(ctx, b, itemID, "start", previous)
+}
+
+// setSprintStateDate sets (or clears, when value is empty) a date field on the
+// sprint-state card identified by itemID.
+func (c *Client) setSprintStateDate(ctx context.Context, b board.Board, itemID, role, value string) error {
+	field, err := c.ensureDomainField(ctx, b, role)
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return c.clearField(ctx, b.ID, itemID, field.ID)
+	}
+	return c.graphql(ctx, setDateMutation,
+		map[string]any{"project": b.ID, "item": itemID, "field": field.ID, "value": value}, nil)
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -121,7 +121,7 @@ func (h *server) board(ctx context.Context, owner string, project int) (*ghproje
 	if err != nil {
 		return nil, nil, err
 	}
-	board, err := client.LoadBoard(ctx, o, p)
+	board, err := client.LoadProjectBoard(ctx, o, p)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1,6 +1,7 @@
-// Package mcpserver exposes aeman's GitHub Projects v2 operations as a Model
-// Context Protocol (MCP) server over stdio, sharing the ghprojects client with
-// the HTTP API.
+// Package mcpserver exposes aeman's board operations as a Model Context Protocol
+// (MCP) server over stdio. Its tools mirror the UI's views and actions by
+// calling the boardservice layer (the same logic the web frontend runs), not by
+// proxying GitHub directly.
 package mcpserver
 
 import (
@@ -9,6 +10,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/aenix-org/aeman/internal/boardservice"
 	"github.com/aenix-org/aeman/internal/ghprojects"
 )
 
@@ -39,42 +41,44 @@ func Serve(ctx context.Context, s *mcp.Server) error {
 // server holds the configuration shared by all tool handlers.
 type server struct {
 	cfg Config
+	// newBackend builds the board backend for a call. It defaults to a
+	// ghprojects client over a freshly resolved token and is overridden in tests
+	// with a fake Backend.
+	newBackend func(ctx context.Context) (boardservice.Backend, error)
 }
 
 // New builds an MCP server with the aeman tool set.
 func New(cfg Config) *mcp.Server {
 	h := &server{cfg: cfg}
-	s := mcp.NewServer(&mcp.Implementation{Name: "aeman", Version: cfg.Version}, nil)
+	h.newBackend = h.defaultBackend
+	return h.mcpServer()
+}
 
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_board",
-		Description: "Get the project board identity and its field metadata (columns, single-select options).",
-	}, h.getBoard)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_cards",
-		Description: "List all cards on the board with their zone, assignees, progress, status, day, notes and field values.",
-	}, h.listCards)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "create_card",
-		Description: "Create a draft-issue card on the board, optionally setting zone, assignee, day, status, team and progress.",
-	}, h.createCard)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_card",
-		Description: "Update a card: any of title, zone, progress, day, assignee, status, team, or arbitrary board fields.",
-	}, h.updateCard)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "move_card",
-		Description: "Reorder a card to sit after another card; an empty afterId moves it to the top of the board.",
-	}, h.moveCard)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_card",
-		Description: "Delete a card (project item) from the board.",
-	}, h.deleteCard)
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "add_note",
-		Description: "Add a work note to a card: an issue comment, or a dated line in a draft issue's body.",
-	}, h.addNote)
-
+// mcpServer registers the tool set on a fresh MCP server. The tools mirror the
+// /api/v1 operation set: every name maps to one boardservice method.
+func (h *server) mcpServer() *mcp.Server {
+	s := mcp.NewServer(&mcp.Implementation{Name: "aeman", Version: h.cfg.Version}, nil)
+	mcp.AddTool(s, &mcp.Tool{Name: "get_board", Description: "Get the board identity, field metadata and the per-team sprint pointers."}, h.getBoard)
+	mcp.AddTool(s, &mcp.Tool{Name: "team_view", Description: "List the Team board's cards for a team on a day (day defaults to today)."}, h.teamView)
+	mcp.AddTool(s, &mcp.Tool{Name: "me_view", Description: "List a person's day-board cards (user defaults to everyone, day to today)."}, h.meView)
+	mcp.AddTool(s, &mcp.Tool{Name: "weekly_plan", Description: "Get a team's weekly-plan cards for a week, split into the wed/fri bands."}, h.weeklyPlan)
+	mcp.AddTool(s, &mcp.Tool{Name: "create_card", Description: "Create a card that joins (or starts) its team's sprint."}, h.createCard)
+	mcp.AddTool(s, &mcp.Tool{Name: "carry_over", Description: "Advance a team's sprint to today and carry its unfinished cards forward."}, h.carryOver)
+	mcp.AddTool(s, &mcp.Tool{Name: "carry_week", Description: "Pull a team's unfinished plan cards from earlier weeks into the target week."}, h.carryWeek)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_stage", Description: "Set a card's stage: locked, review, done, or empty to clear it."}, h.setStage)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_in_progress", Description: "Move a card to the implicit In Progress status (clears the stage)."}, h.setInProgress)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_progress", Description: "Set a card's readiness percentage (0..100), running the done auto-link."}, h.setProgress)
+	mcp.AddTool(s, &mcp.Tool{Name: "send_to_review", Description: "Create a linked review card for a reviewer and put the card on review."}, h.sendToReview)
+	mcp.AddTool(s, &mcp.Tool{Name: "reassign_reviewer", Description: "Point a card's review at another reviewer (sends to review if it has none)."}, h.reassignReviewer)
+	mcp.AddTool(s, &mcp.Tool{Name: "remove_reviewer", Description: "Delete a card's linked review card."}, h.removeReviewer)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_assignee", Description: "Set or clear a card's assignee."}, h.setAssignee)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_team", Description: "Move a card to a team and join that team's current sprint."}, h.setTeam)
+	mcp.AddTool(s, &mcp.Tool{Name: "take_into_plan", Description: "Take a weekly-plan card into work: assign it and join the team's sprint."}, h.takeIntoPlan)
+	mcp.AddTool(s, &mcp.Tool{Name: "release_from_plan", Description: "Release a card from the weekly plan."}, h.releaseFromPlan)
+	mcp.AddTool(s, &mcp.Tool{Name: "move_card", Description: "Reorder a card to sit after another; an empty afterId moves it to the top."}, h.moveCard)
+	mcp.AddTool(s, &mcp.Tool{Name: "delete_card", Description: "Delete a card, cascading to its linked review card."}, h.deleteCard)
+	mcp.AddTool(s, &mcp.Tool{Name: "add_note", Description: "Append a work note to a card."}, h.addNote)
+	mcp.AddTool(s, &mcp.Tool{Name: "rename_card", Description: "Change a card's title."}, h.renameCard)
 	return s
 }
 
@@ -95,8 +99,9 @@ func (h *server) resolve(owner string, project int) (string, int, error) {
 	return o, p, nil
 }
 
-// client builds a ghprojects client with a freshly resolved token.
-func (h *server) client(ctx context.Context) (*ghprojects.Client, error) {
+// defaultBackend builds a ghprojects client with a freshly resolved token. It is
+// the production newBackend (*ghprojects.Client satisfies boardservice.Backend).
+func (h *server) defaultBackend(ctx context.Context) (boardservice.Backend, error) {
 	tok, err := h.cfg.ResolveToken(ctx)
 	if err != nil {
 		return nil, err
@@ -111,19 +116,15 @@ func (h *server) client(ctx context.Context) (*ghprojects.Client, error) {
 	return ghprojects.New(tok, opts...), nil
 }
 
-// board resolves the reference, builds a client and loads the board.
-func (h *server) board(ctx context.Context, owner string, project int) (*ghprojects.Client, *ghprojects.Board, error) {
-	o, p, err := h.resolve(owner, project)
+// ref resolves the board reference and builds the board service for a call.
+func (h *server) ref(ctx context.Context, in boardRef) (svc *boardservice.Service, owner string, project int, err error) {
+	owner, project, err = h.resolve(in.Owner, in.Project)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", 0, err
 	}
-	client, err := h.client(ctx)
+	backend, err := h.newBackend(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", 0, err
 	}
-	board, err := client.LoadProjectBoard(ctx, o, p)
-	if err != nil {
-		return nil, nil, err
-	}
-	return client, board, nil
+	return boardservice.New(backend), owner, project, nil
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -2,57 +2,26 @@ package mcpserver
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/boardservice"
+	"github.com/aenix-org/aeman/internal/boardservice/boardservicetest"
 )
 
-const boardJSON = `{"organization":{"projectV2":{
-  "id":"PVT_1","number":7,"title":"Board","url":"https://example/7",
-  "fields":{"nodes":[
-    {"__typename":"ProjectV2SingleSelectField","id":"F_ZONE","name":"Zone","dataType":"SINGLE_SELECT","options":[
-      {"id":"o_red","name":"Critical","color":"RED"}]}
-  ]},
-  "items":{"nodes":[
-    {"id":"I_DRAFT","type":"DRAFT_ISSUE","createdAt":"2026-06-20T10:00:00Z",
-     "content":{"__typename":"DraftIssue","id":"DI_1","title":"Draft","body":"","assignees":{"nodes":[]}},
-     "fieldValues":{"nodes":[
-       {"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"o_red","name":"Critical","field":{"id":"F_ZONE","name":"Zone"}}
-     ]}}
-  ]}
-}}}`
-
-func fakeGitHub(t *testing.T) (string, *[]string) {
-	t.Helper()
-	var queries []string
-	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Query string `json:"query"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		queries = append(queries, body.Query)
-		data := "{}"
-		switch {
-		case strings.Contains(body.Query, "organization(login:") && strings.Contains(body.Query, "projectV2(number:"):
-			data = boardJSON
-		case strings.Contains(body.Query, "addProjectV2DraftIssue"):
-			data = `{"addProjectV2DraftIssue":{"projectItem":{"id":"I_NEW","content":{"id":"DI_NEW"}}}}`
-		}
-		_, _ = w.Write([]byte(`{"data":` + data + `}`))
-	}))
-	t.Cleanup(gh.Close)
-	return gh.URL, &queries
-}
-
-// connect builds an in-memory MCP client session against an aeman MCP server.
-func connect(t *testing.T, cfg Config) *mcp.ClientSession {
+// connect builds an in-memory MCP client session against an aeman MCP server
+// whose board backend is the given fake, so the tools exercise the real
+// boardservice logic without touching GitHub.
+func connect(t *testing.T, cfg Config, backend boardservice.Backend) *mcp.ClientSession {
 	t.Helper()
 	ctx := context.Background()
-	srv := New(cfg)
+	h := &server{cfg: cfg}
+	h.newBackend = func(context.Context) (boardservice.Backend, error) { return backend, nil }
+	srv := h.mcpServer()
+
 	t1, t2 := mcp.NewInMemoryTransports()
 	if _, err := srv.Connect(ctx, t1, nil); err != nil {
 		t.Fatalf("server connect: %v", err)
@@ -66,78 +35,6 @@ func connect(t *testing.T, cfg Config) *mcp.ClientSession {
 	return cs
 }
 
-func staticToken(string) func(context.Context) (string, error) {
-	return func(context.Context) (string, error) { return "test-token", nil }
-}
-
-func TestMCPListsTools(t *testing.T) {
-	url, _ := fakeGitHub(t)
-	cs := connect(t, Config{Owner: "acme", Project: 7, Endpoint: url, ResolveToken: staticToken("")})
-	names := map[string]bool{}
-	for tool, err := range cs.Tools(context.Background(), nil) {
-		if err != nil {
-			t.Fatalf("list tools: %v", err)
-		}
-		names[tool.Name] = true
-	}
-	for _, want := range []string{"get_board", "list_cards", "create_card", "update_card", "move_card", "delete_card", "add_note"} {
-		if !names[want] {
-			t.Errorf("missing tool %q", want)
-		}
-	}
-}
-
-func TestMCPListCards(t *testing.T) {
-	url, _ := fakeGitHub(t)
-	cs := connect(t, Config{Owner: "acme", Project: 7, Endpoint: url, ResolveToken: staticToken("")})
-	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_cards"})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
-	}
-	if res.IsError {
-		t.Fatalf("tool error: %s", textOf(res))
-	}
-	if !strings.Contains(textOf(res), "I_DRAFT") {
-		t.Fatalf("result missing card: %s", textOf(res))
-	}
-}
-
-func TestMCPCreateCard(t *testing.T) {
-	url, queries := fakeGitHub(t)
-	cs := connect(t, Config{Owner: "acme", Project: 7, Endpoint: url, ResolveToken: staticToken("")})
-	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
-		Name:      "create_card",
-		Arguments: map[string]any{"title": "Hello"},
-	})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
-	}
-	if res.IsError {
-		t.Fatalf("tool error: %s", textOf(res))
-	}
-	created := false
-	for _, q := range *queries {
-		if strings.Contains(q, "addProjectV2DraftIssue") {
-			created = true
-		}
-	}
-	if !created {
-		t.Fatal("expected a draft creation request")
-	}
-}
-
-func TestMCPMissingBoardConfig(t *testing.T) {
-	url, _ := fakeGitHub(t)
-	cs := connect(t, Config{Endpoint: url, ResolveToken: staticToken("")})
-	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_cards"})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
-	}
-	if !res.IsError || !strings.Contains(textOf(res), "owner and project are required") {
-		t.Fatalf("expected board-required error, got isError=%v text=%s", res.IsError, textOf(res))
-	}
-}
-
 func textOf(res *mcp.CallToolResult) string {
 	var sb strings.Builder
 	for _, c := range res.Content {
@@ -146,4 +43,104 @@ func textOf(res *mcp.CallToolResult) string {
 		}
 	}
 	return sb.String()
+}
+
+func TestMCPListsTools(t *testing.T) {
+	cs := connect(t, Config{Owner: "acme", Project: 1}, boardservicetest.New(nil, nil))
+	names := map[string]bool{}
+	for tool, err := range cs.Tools(context.Background(), nil) {
+		if err != nil {
+			t.Fatalf("list tools: %v", err)
+		}
+		names[tool.Name] = true
+	}
+	want := []string{
+		"get_board", "team_view", "me_view", "weekly_plan", "create_card",
+		"carry_over", "carry_week", "set_stage", "set_in_progress", "set_progress",
+		"send_to_review", "reassign_reviewer", "remove_reviewer", "set_assignee",
+		"set_team", "take_into_plan", "release_from_plan", "move_card",
+		"delete_card", "add_note", "rename_card",
+	}
+	for _, w := range want {
+		if !names[w] {
+			t.Errorf("missing tool %q", w)
+		}
+	}
+	if len(names) != len(want) {
+		t.Errorf("tool count = %d, want %d (%v)", len(names), len(want), names)
+	}
+}
+
+func TestMCPTeamView(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "c1", Team: "alpha", StartDate: today, SprintStart: today},
+	}, nil)
+	cs := connect(t, Config{Owner: "acme", Project: 1}, fake)
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "team_view",
+		Arguments: map[string]any{"team": "alpha"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", textOf(res))
+	}
+	if !strings.Contains(textOf(res), "c1") {
+		t.Fatalf("result missing card: %s", textOf(res))
+	}
+}
+
+func TestMCPCreateCard(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	cs := connect(t, Config{Owner: "acme", Project: 1}, fake)
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "create_card",
+		Arguments: map[string]any{"team": "alpha", "title": "Hello"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", textOf(res))
+	}
+	if len(fake.Creates()) != 1 || fake.Creates()[0].Title != "Hello" {
+		t.Fatalf("creates = %+v", fake.Creates())
+	}
+}
+
+func TestMCPDeleteCardCascades(t *testing.T) {
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "orig", Title: "x"},
+		{ItemID: "rev", ReviewOf: "orig"},
+	}, nil)
+	cs := connect(t, Config{Owner: "acme", Project: 1}, fake)
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "delete_card",
+		Arguments: map[string]any{"itemId": "orig"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", textOf(res))
+	}
+	if fake.Card("orig") != nil || fake.Card("rev") != nil {
+		t.Fatalf("both cards should be gone")
+	}
+	if fake.Count("DeleteCard") != 2 {
+		t.Fatalf("want 2 deletes, got %d", fake.Count("DeleteCard"))
+	}
+}
+
+func TestMCPMissingBoardConfig(t *testing.T) {
+	cs := connect(t, Config{}, boardservicetest.New(nil, nil))
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "team_view"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError || !strings.Contains(textOf(res), "owner and project are required") {
+		t.Fatalf("expected board-required error, got isError=%v text=%s", res.IsError, textOf(res))
+	}
 }

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/internal/ghprojects"
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/boardservice"
 )
 
 // boardRef is embedded in every tool input to select the target board.
@@ -14,119 +15,333 @@ type boardRef struct {
 	Project int    `json:"project,omitempty" jsonschema:"GitHub Project number; defaults to the server configuration"`
 }
 
-// boardMetaOutput is the get_board result (no cards).
+// itemInput identifies a single card on a board.
+type itemInput struct {
+	boardRef
+	ItemID string `json:"itemId" jsonschema:"project item id of the card (required)"`
+}
+
+// boardMetaOutput is the get_board result: board identity, fields and sprint
+// pointers (no cards).
 type boardMetaOutput struct {
-	ID     string                    `json:"id"`
-	Number int                       `json:"number"`
-	Title  string                    `json:"title"`
-	URL    string                    `json:"url"`
-	Owner  string                    `json:"owner"`
-	Fields []ghprojects.ProjectField `json:"fields"`
+	ID           string                       `json:"id"`
+	Number       int                          `json:"number"`
+	Owner        string                       `json:"owner"`
+	Fields       []board.ProjectField         `json:"fields"`
+	SprintStates map[string]board.SprintState `json:"sprintStates"`
 }
 
-func (h *server) getBoard(ctx context.Context, _ *mcp.CallToolRequest, in boardRef) (*mcp.CallToolResult, boardMetaOutput, error) {
-	_, board, err := h.board(ctx, in.Owner, in.Project)
-	if err != nil {
-		return nil, boardMetaOutput{}, err
-	}
-	return nil, boardMetaOutput{
-		ID:     board.ID,
-		Number: board.Number,
-		Title:  board.Title,
-		URL:    board.URL,
-		Owner:  board.Owner,
-		Fields: board.Fields,
-	}, nil
-}
-
-// cardsOutput is the list_cards result.
+// cardsOutput is a list of cards returned by a view or a carry action.
 type cardsOutput struct {
-	Cards []ghprojects.Card `json:"cards"`
+	Cards []board.Card `json:"cards"`
 }
 
-func (h *server) listCards(ctx context.Context, _ *mcp.CallToolRequest, in boardRef) (*mcp.CallToolResult, cardsOutput, error) {
-	_, board, err := h.board(ctx, in.Owner, in.Project)
-	if err != nil {
-		return nil, cardsOutput{}, err
-	}
-	return nil, cardsOutput{Cards: board.Cards}, nil
-}
-
-// createCardInput describes a card to create.
-type createCardInput struct {
-	boardRef
-	Title    string   `json:"title" jsonschema:"card title (required)"`
-	Zone     string   `json:"zone,omitempty" jsonschema:"Ford zone: gray, green, yellow or red"`
-	Assignee string   `json:"assignee,omitempty" jsonschema:"GitHub login to assign"`
-	Day      string   `json:"day,omitempty" jsonschema:"planned day as yyyy-mm-dd"`
-	Status   string   `json:"status,omitempty" jsonschema:"status/stage single-select option name"`
-	Team     string   `json:"team,omitempty" jsonschema:"team field value"`
-	Progress *float64 `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
-	// StartNewSprint controls sprint membership for a team card: omit for auto
-	// (join the team's running sprint, else start a new one today), true to force
-	// a new sprint today, false to force-join the current sprint. When engaged,
-	// startDate = sprintStart and day defaults to today.
-	StartNewSprint *bool `json:"startNewSprint,omitempty" jsonschema:"force a new sprint (true) or join the current one (false); omit for auto"`
-}
-
-func (h *server) createCard(ctx context.Context, _ *mcp.CallToolRequest, in createCardInput) (*mcp.CallToolResult, ghprojects.Card, error) {
-	client, board, err := h.board(ctx, in.Owner, in.Project)
-	if err != nil {
-		return nil, ghprojects.Card{}, err
-	}
-	card, err := client.CreateProjectCard(ctx, board, ghprojects.CreateCardInput{
-		Title:          in.Title,
-		Zone:           ghprojects.ZoneKey(in.Zone),
-		Assignee:       in.Assignee,
-		Day:            in.Day,
-		Status:         in.Status,
-		Team:           in.Team,
-		Progress:       in.Progress,
-		StartNewSprint: in.StartNewSprint,
-	})
-	if err != nil {
-		return nil, ghprojects.Card{}, err
-	}
-	return nil, *card, nil
-}
-
-// updateCardInput describes a partial card update.
-type updateCardInput struct {
-	boardRef
-	ItemID   string   `json:"itemId" jsonschema:"project item id of the card (required)"`
-	Title    *string  `json:"title,omitempty" jsonschema:"new title"`
-	Zone     *string  `json:"zone,omitempty" jsonschema:"Ford zone (gray/green/yellow/red); empty string clears it"`
-	Progress *float64 `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
-	Day      *string  `json:"day,omitempty" jsonschema:"planned day yyyy-mm-dd; empty string clears it"`
-	Assignee *string  `json:"assignee,omitempty" jsonschema:"GitHub login; empty string clears it"`
-	Status   *string  `json:"status,omitempty" jsonschema:"status/stage option name; empty string clears it"`
-	Team     *string  `json:"team,omitempty" jsonschema:"team value; empty string clears it"`
-}
-
-// statusOutput is a simple acknowledgement.
+// statusOutput acknowledges an action that leaves no single card to echo.
 type statusOutput struct {
 	Status string `json:"status"`
 	ItemID string `json:"itemId,omitempty"`
 }
 
-func (h *server) updateCard(ctx context.Context, _ *mcp.CallToolRequest, in updateCardInput) (*mcp.CallToolResult, statusOutput, error) {
-	client, board, err := h.board(ctx, in.Owner, in.Project)
+// cardResult reloads and returns the card resulting from an action.
+func (h *server) cardResult(ctx context.Context, svc *boardservice.Service, owner string, project int, id string) (*mcp.CallToolResult, board.Card, error) {
+	card, err := svc.Card(ctx, owner, project, id)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	return nil, card, nil
+}
+
+func (h *server) getBoard(ctx context.Context, _ *mcp.CallToolRequest, in boardRef) (*mcp.CallToolResult, boardMetaOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in)
+	if err != nil {
+		return nil, boardMetaOutput{}, err
+	}
+	b, err := svc.Board(ctx, owner, project)
+	if err != nil {
+		return nil, boardMetaOutput{}, err
+	}
+	return nil, boardMetaOutput{ID: b.ID, Number: b.Number, Owner: b.Owner, Fields: b.Fields, SprintStates: b.SprintStates}, nil
+}
+
+// teamViewInput selects a team and day for the Team grid view.
+type teamViewInput struct {
+	boardRef
+	Team string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Day  string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) teamView(ctx context.Context, _ *mcp.CallToolRequest, in teamViewInput) (*mcp.CallToolResult, cardsOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, cardsOutput{}, err
+	}
+	cards, err := svc.TeamView(ctx, owner, project, in.Team, in.Day)
+	if err != nil {
+		return nil, cardsOutput{}, err
+	}
+	return nil, cardsOutput{Cards: cards}, nil
+}
+
+// meViewInput selects a user and day for the personal day view.
+type meViewInput struct {
+	boardRef
+	User string `json:"user,omitempty" jsonschema:"GitHub login; empty is everyone"`
+	Day  string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) meView(ctx context.Context, _ *mcp.CallToolRequest, in meViewInput) (*mcp.CallToolResult, cardsOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, cardsOutput{}, err
+	}
+	cards, err := svc.MeView(ctx, owner, project, in.User, in.Day)
+	if err != nil {
+		return nil, cardsOutput{}, err
+	}
+	return nil, cardsOutput{Cards: cards}, nil
+}
+
+// weeklyPlanInput selects a team and week for the weekly plan.
+type weeklyPlanInput struct {
+	boardRef
+	Team string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Week string `json:"week,omitempty" jsonschema:"week Monday as yyyy-mm-dd; defaults to the current week"`
+}
+
+func (h *server) weeklyPlan(ctx context.Context, _ *mcp.CallToolRequest, in weeklyPlanInput) (*mcp.CallToolResult, board.WeeklyBands, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.WeeklyBands{}, err
+	}
+	bands, err := svc.WeeklyPlan(ctx, owner, project, in.Team, in.Week)
+	if err != nil {
+		return nil, board.WeeklyBands{}, err
+	}
+	return nil, bands, nil
+}
+
+// createCardInput describes a card to create.
+type createCardInput struct {
+	boardRef
+	Team     string `json:"team,omitempty" jsonschema:"team the card joins; empty is the no-team group"`
+	Zone     string `json:"zone,omitempty" jsonschema:"Ford zone: gray, green, yellow or red"`
+	Title    string `json:"title" jsonschema:"card title (required)"`
+	Assignee string `json:"assignee,omitempty" jsonschema:"GitHub login to assign"`
+	Day      string `json:"day,omitempty" jsonschema:"create day as yyyy-mm-dd; defaults to today"`
+	// StartNewSprint controls sprint membership: omit for auto (join the team's
+	// running sprint, else start one today), true to force a new sprint today,
+	// false to force-join the current sprint.
+	StartNewSprint *bool `json:"startNewSprint,omitempty" jsonschema:"force a new sprint (true) or join the current one (false); omit for auto"`
+}
+
+func (h *server) createCard(ctx context.Context, _ *mcp.CallToolRequest, in createCardInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	card, err := svc.CreateCard(ctx, owner, project, boardservice.CreateCardArgs{
+		Team:           in.Team,
+		Zone:           board.ZoneKey(in.Zone),
+		Title:          in.Title,
+		Assignee:       in.Assignee,
+		Day:            in.Day,
+		StartNewSprint: in.StartNewSprint,
+	})
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	return nil, card, nil
+}
+
+// teamInput names a team for a sprint-wide action.
+type teamInput struct {
+	boardRef
+	Team string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+}
+
+func (h *server) carryOver(ctx context.Context, _ *mcp.CallToolRequest, in teamInput) (*mcp.CallToolResult, statusOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
 	if err != nil {
 		return nil, statusOutput{}, err
 	}
-	upd := ghprojects.UpdateCardInput{
-		Title:    in.Title,
-		Progress: in.Progress,
-		Day:      in.Day,
-		Assignee: in.Assignee,
-		Status:   in.Status,
-		Team:     in.Team,
+	if err := svc.CarryOver(ctx, owner, project, in.Team); err != nil {
+		return nil, statusOutput{}, err
 	}
-	if in.Zone != nil {
-		z := ghprojects.ZoneKey(*in.Zone)
-		upd.Zone = &z
+	return nil, statusOutput{Status: "ok"}, nil
+}
+
+// carryWeekInput names a team and target week for the weekly carry.
+type carryWeekInput struct {
+	boardRef
+	Team string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Week string `json:"week,omitempty" jsonschema:"target week Monday as yyyy-mm-dd; defaults to the current week"`
+}
+
+func (h *server) carryWeek(ctx context.Context, _ *mcp.CallToolRequest, in carryWeekInput) (*mcp.CallToolResult, cardsOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, cardsOutput{}, err
 	}
-	if err := client.UpdateCard(ctx, board, in.ItemID, upd); err != nil {
+	carried, err := svc.CarryWeek(ctx, owner, project, in.Team, in.Week)
+	if err != nil {
+		return nil, cardsOutput{}, err
+	}
+	return nil, cardsOutput{Cards: carried}, nil
+}
+
+// setStageInput moves a card to a stage.
+type setStageInput struct {
+	itemInput
+	Stage string `json:"stage,omitempty" jsonschema:"locked, review, done, or empty to clear"`
+}
+
+func (h *server) setStage(ctx context.Context, _ *mcp.CallToolRequest, in setStageInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.SetStage(ctx, owner, project, in.ItemID, board.StageKey(in.Stage)); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+func (h *server) setInProgress(ctx context.Context, _ *mcp.CallToolRequest, in itemInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.SetInProgress(ctx, owner, project, in.ItemID); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+// setProgressInput sets a card's readiness percentage.
+type setProgressInput struct {
+	itemInput
+	Progress int `json:"progress" jsonschema:"readiness percentage 0..100"`
+}
+
+func (h *server) setProgress(ctx context.Context, _ *mcp.CallToolRequest, in setProgressInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.SetProgress(ctx, owner, project, in.ItemID, in.Progress); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+// sendToReviewInput sends a card to review for a reviewer.
+type sendToReviewInput struct {
+	itemInput
+	Reviewer string `json:"reviewer,omitempty" jsonschema:"GitHub login of the reviewer"`
+	Day      string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) sendToReview(ctx context.Context, _ *mcp.CallToolRequest, in sendToReviewInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	review, err := svc.SendToReview(ctx, owner, project, in.ItemID, in.Reviewer, in.Day)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	return nil, review, nil
+}
+
+// reassignReviewerInput points a card's review at another reviewer.
+type reassignReviewerInput struct {
+	itemInput
+	Reviewer string `json:"reviewer,omitempty" jsonschema:"GitHub login of the new reviewer"`
+	Day      string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) reassignReviewer(ctx context.Context, _ *mcp.CallToolRequest, in reassignReviewerInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.ReassignReviewer(ctx, owner, project, in.ItemID, in.Reviewer, in.Day); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+func (h *server) removeReviewer(ctx context.Context, _ *mcp.CallToolRequest, in itemInput) (*mcp.CallToolResult, statusOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, statusOutput{}, err
+	}
+	if err := svc.RemoveReviewer(ctx, owner, project, in.ItemID); err != nil {
+		return nil, statusOutput{}, err
+	}
+	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
+}
+
+// setAssigneeInput sets or clears a card's assignee.
+type setAssigneeInput struct {
+	itemInput
+	Login string `json:"login,omitempty" jsonschema:"GitHub login; empty unassigns"`
+}
+
+func (h *server) setAssignee(ctx context.Context, _ *mcp.CallToolRequest, in setAssigneeInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.SetAssignee(ctx, owner, project, in.ItemID, in.Login); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+// setTeamInput moves a card to a team.
+type setTeamInput struct {
+	itemInput
+	Team string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Day  string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) setTeam(ctx context.Context, _ *mcp.CallToolRequest, in setTeamInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.SetTeam(ctx, owner, project, in.ItemID, in.Team, in.Day); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+// takeIntoPlanInput takes a weekly-plan card into work.
+type takeIntoPlanInput struct {
+	itemInput
+	Engineer string `json:"engineer,omitempty" jsonschema:"GitHub login to assign; empty unassigns"`
+	Zone     string `json:"zone,omitempty" jsonschema:"Ford zone; empty keeps the card's own zone"`
+	Day      string `json:"day,omitempty" jsonschema:"day as yyyy-mm-dd; defaults to today"`
+}
+
+func (h *server) takeIntoPlan(ctx context.Context, _ *mcp.CallToolRequest, in takeIntoPlanInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.TakeIntoPlan(ctx, owner, project, in.ItemID, in.Engineer, board.ZoneKey(in.Zone), in.Day); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
+}
+
+func (h *server) releaseFromPlan(ctx context.Context, _ *mcp.CallToolRequest, in itemInput) (*mcp.CallToolResult, statusOutput, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, statusOutput{}, err
+	}
+	if err := svc.ReleaseFromPlan(ctx, owner, project, in.ItemID); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
@@ -134,38 +349,27 @@ func (h *server) updateCard(ctx context.Context, _ *mcp.CallToolRequest, in upda
 
 // moveCardInput reorders a card.
 type moveCardInput struct {
-	boardRef
-	ItemID  string `json:"itemId" jsonschema:"project item id to move (required)"`
+	itemInput
 	AfterID string `json:"afterId,omitempty" jsonschema:"item id to position after; empty moves to the top"`
 }
 
-func (h *server) moveCard(ctx context.Context, _ *mcp.CallToolRequest, in moveCardInput) (*mcp.CallToolResult, statusOutput, error) {
-	client, board, err := h.board(ctx, in.Owner, in.Project)
+func (h *server) moveCard(ctx context.Context, _ *mcp.CallToolRequest, in moveCardInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
 	if err != nil {
-		return nil, statusOutput{}, err
+		return nil, board.Card{}, err
 	}
-	var after *string
-	if in.AfterID != "" {
-		after = &in.AfterID
+	if err := svc.MoveCard(ctx, owner, project, in.ItemID, in.AfterID); err != nil {
+		return nil, board.Card{}, err
 	}
-	if err := client.MoveProjectCard(ctx, board, in.ItemID, after); err != nil {
-		return nil, statusOutput{}, err
-	}
-	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
-}
-
-// itemInput identifies a single card.
-type itemInput struct {
-	boardRef
-	ItemID string `json:"itemId" jsonschema:"project item id (required)"`
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
 }
 
 func (h *server) deleteCard(ctx context.Context, _ *mcp.CallToolRequest, in itemInput) (*mcp.CallToolResult, statusOutput, error) {
-	client, board, err := h.board(ctx, in.Owner, in.Project)
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
 	if err != nil {
 		return nil, statusOutput{}, err
 	}
-	if err := client.DeleteProjectCard(ctx, board, in.ItemID); err != nil {
+	if err := svc.DeleteCard(ctx, owner, project, in.ItemID); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
@@ -173,18 +377,34 @@ func (h *server) deleteCard(ctx context.Context, _ *mcp.CallToolRequest, in item
 
 // addNoteInput attaches a note to a card.
 type addNoteInput struct {
-	boardRef
-	ItemID string `json:"itemId" jsonschema:"project item id (required)"`
-	Text   string `json:"text" jsonschema:"note text (required)"`
+	itemInput
+	Text string `json:"text" jsonschema:"note text (required)"`
 }
 
 func (h *server) addNote(ctx context.Context, _ *mcp.CallToolRequest, in addNoteInput) (*mcp.CallToolResult, statusOutput, error) {
-	client, board, err := h.board(ctx, in.Owner, in.Project)
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
 	if err != nil {
 		return nil, statusOutput{}, err
 	}
-	if err := client.AddProjectNote(ctx, board, in.ItemID, in.Text); err != nil {
+	if err := svc.AddNote(ctx, owner, project, in.ItemID, in.Text); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
+}
+
+// renameCardInput changes a card's title.
+type renameCardInput struct {
+	itemInput
+	Title string `json:"title" jsonschema:"new title (required)"`
+}
+
+func (h *server) renameCard(ctx context.Context, _ *mcp.CallToolRequest, in renameCardInput) (*mcp.CallToolResult, board.Card, error) {
+	svc, owner, project, err := h.ref(ctx, in.boardRef)
+	if err != nil {
+		return nil, board.Card{}, err
+	}
+	if err := svc.Rename(ctx, owner, project, in.ItemID, in.Title); err != nil {
+		return nil, board.Card{}, err
+	}
+	return h.cardResult(ctx, svc, owner, project, in.ItemID)
 }

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -74,7 +74,7 @@ func (h *server) createCard(ctx context.Context, _ *mcp.CallToolRequest, in crea
 	if err != nil {
 		return nil, ghprojects.Card{}, err
 	}
-	card, err := client.CreateCard(ctx, board, ghprojects.CreateCardInput{
+	card, err := client.CreateProjectCard(ctx, board, ghprojects.CreateCardInput{
 		Title:          in.Title,
 		Zone:           ghprojects.ZoneKey(in.Zone),
 		Assignee:       in.Assignee,
@@ -148,7 +148,7 @@ func (h *server) moveCard(ctx context.Context, _ *mcp.CallToolRequest, in moveCa
 	if in.AfterID != "" {
 		after = &in.AfterID
 	}
-	if err := client.MoveCard(ctx, board, in.ItemID, after); err != nil {
+	if err := client.MoveProjectCard(ctx, board, in.ItemID, after); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
@@ -165,7 +165,7 @@ func (h *server) deleteCard(ctx context.Context, _ *mcp.CallToolRequest, in item
 	if err != nil {
 		return nil, statusOutput{}, err
 	}
-	if err := client.DeleteCard(ctx, board, in.ItemID); err != nil {
+	if err := client.DeleteProjectCard(ctx, board, in.ItemID); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil
@@ -183,7 +183,7 @@ func (h *server) addNote(ctx context.Context, _ *mcp.CallToolRequest, in addNote
 	if err != nil {
 		return nil, statusOutput{}, err
 	}
-	if err := client.AddNote(ctx, board, in.ItemID, in.Text); err != nil {
+	if err := client.AddProjectNote(ctx, board, in.ItemID, in.Text); err != nil {
 		return nil, statusOutput{}, err
 	}
 	return nil, statusOutput{Status: "ok", ItemID: in.ItemID}, nil

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -22,6 +22,7 @@ var errMissingBoard = errors.New("owner and project are required (set ?owner=&pr
 //
 // Routes:
 //
+//	GET    /api/v1                             public route catalog (no auth)
 //	GET    /api/v1/board                       board meta + per-team sprint states
 //	GET    /api/v1/team?team=&day=             Team grid view (day defaults to today)
 //	GET    /api/v1/me?user=&day=               personal day view
@@ -44,6 +45,7 @@ var errMissingBoard = errors.New("owner and project are required (set ?owner=&pr
 //	POST   /api/v1/cards/{id}/review/remove    delete the linked review card
 //	DELETE /api/v1/cards/{id}                  delete a card (cascades to its review)
 func (s *Server) registerAPI(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1", s.handleAPIIndex)
 	mux.HandleFunc("GET /api/v1/board", s.handleGetBoard)
 	mux.HandleFunc("GET /api/v1/team", s.handleTeamView)
 	mux.HandleFunc("GET /api/v1/me", s.handleMeView)
@@ -65,6 +67,55 @@ func (s *Server) registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/cards/{id}/review", s.handleSendToReview)
 	mux.HandleFunc("POST /api/v1/cards/{id}/review/reassign", s.handleReassignReviewer)
 	mux.HandleFunc("POST /api/v1/cards/{id}/review/remove", s.handleRemoveReviewer)
+}
+
+// apiEndpoint describes one route in the GET /api/v1 catalog.
+type apiEndpoint struct {
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Description string `json:"description"`
+}
+
+// apiIndex is the public GET /api/v1 catalog: identity, the MCP mount point and
+// the full route list. It carries no board data, so it needs no authentication.
+type apiIndex struct {
+	Name      string        `json:"name"`
+	Version   string        `json:"version"`
+	MCP       string        `json:"mcp"`
+	Endpoints []apiEndpoint `json:"endpoints"`
+}
+
+// handleAPIIndex serves the public API catalog. It mirrors the routes wired in
+// registerAPI so a client can discover them without a token.
+func (s *Server) handleAPIIndex(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, apiIndex{
+		Name:    "aeman",
+		Version: s.opts.Version,
+		MCP:     "/mcp",
+		Endpoints: []apiEndpoint{
+			{"GET", "/api/v1/board", "Board identity, fields and per-team sprint states"},
+			{"GET", "/api/v1/team?team=&day=", "Team grid view (day defaults to today)"},
+			{"GET", "/api/v1/me?user=&day=", "Personal day view"},
+			{"GET", "/api/v1/weekly?team=&week=", "Weekly plan, split into wed/fri bands"},
+			{"POST", "/api/v1/cards", "Create a card (joins or starts a sprint)"},
+			{"POST", "/api/v1/carry-over", "Advance a team's sprint, carry unfinished cards"},
+			{"POST", "/api/v1/carry-week", "Pull unfinished plan cards into the week"},
+			{"DELETE", "/api/v1/cards/{id}", "Delete a card (cascades to its review)"},
+			{"POST", "/api/v1/cards/{id}/stage", "Set the stage (locked/review/done/empty)"},
+			{"POST", "/api/v1/cards/{id}/in-progress", "Move to the implicit In Progress status"},
+			{"POST", "/api/v1/cards/{id}/progress", "Set the readiness percentage"},
+			{"POST", "/api/v1/cards/{id}/assignee", "Set or clear the assignee"},
+			{"POST", "/api/v1/cards/{id}/team", "Move to a team (joins its sprint)"},
+			{"POST", "/api/v1/cards/{id}/take-plan", "Take a plan card into work"},
+			{"POST", "/api/v1/cards/{id}/release-plan", "Release a card from the weekly plan"},
+			{"POST", "/api/v1/cards/{id}/move", "Reorder a card after another"},
+			{"POST", "/api/v1/cards/{id}/note", "Append a work note"},
+			{"POST", "/api/v1/cards/{id}/rename", "Rename a card"},
+			{"POST", "/api/v1/cards/{id}/review", "Send to review (creates a review card)"},
+			{"POST", "/api/v1/cards/{id}/review/reassign", "Point the review at another reviewer"},
+			{"POST", "/api/v1/cards/{id}/review/remove", "Delete the linked review card"},
+		},
+	})
 }
 
 // boardRef resolves the target board from query parameters, honouring the

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -75,7 +75,7 @@ func (s *Server) loadBoard(w http.ResponseWriter, r *http.Request) (*ghprojects.
 		writeJSONError(w, http.StatusUnauthorized, "not authenticated: "+err.Error())
 		return nil, nil, false
 	}
-	board, err := client.LoadBoard(r.Context(), owner, project)
+	board, err := client.LoadProjectBoard(r.Context(), owner, project)
 	if err != nil {
 		s.apiError(w, err)
 		return nil, nil, false
@@ -125,7 +125,7 @@ func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	card, err := client.CreateCard(r.Context(), board, in)
+	card, err := client.CreateProjectCard(r.Context(), board, in)
 	if err != nil {
 		s.apiError(w, err)
 		return
@@ -160,7 +160,7 @@ func (s *Server) handleMoveCard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := client.MoveCard(r.Context(), board, r.PathValue("id"), in.AfterID); err != nil {
+	if err := client.MoveProjectCard(r.Context(), board, r.PathValue("id"), in.AfterID); err != nil {
 		s.apiError(w, err)
 		return
 	}
@@ -172,7 +172,7 @@ func (s *Server) handleDeleteCard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := client.DeleteCard(r.Context(), board, r.PathValue("id")); err != nil {
+	if err := client.DeleteProjectCard(r.Context(), board, r.PathValue("id")); err != nil {
 		s.apiError(w, err)
 		return
 	}
@@ -194,7 +194,7 @@ func (s *Server) handleAddNote(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := client.AddNote(r.Context(), board, r.PathValue("id"), in.Text); err != nil {
+	if err := client.AddProjectNote(r.Context(), board, r.PathValue("id"), in.Text); err != nil {
 		s.apiError(w, err)
 		return
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/boardservice"
 	"github.com/aenix-org/aeman/internal/ghprojects"
 )
 
@@ -14,15 +16,55 @@ import (
 // identify a board.
 var errMissingBoard = errors.New("owner and project are required (set ?owner=&project= or server defaults)")
 
-// registerAPI wires the native JSON API under /api/v1.
+// registerAPI wires the native JSON API under /api/v1. The API mirrors the UI's
+// board views and actions by calling the boardservice layer (the same logic the
+// web frontend's TeamBoard/MeBoard run), not by proxying GitHub directly.
+//
+// Routes:
+//
+//	GET    /api/v1/board                       board meta + per-team sprint states
+//	GET    /api/v1/team?team=&day=             Team grid view (day defaults to today)
+//	GET    /api/v1/me?user=&day=               personal day view
+//	GET    /api/v1/weekly?team=&week=          weekly plan, split into wed/fri bands
+//	POST   /api/v1/cards                       create a card (joins/starts a sprint)
+//	POST   /api/v1/carry-over                  advance a team's sprint, carry unfinished
+//	POST   /api/v1/carry-week                  pull unfinished plan cards into the week
+//	POST   /api/v1/cards/{id}/stage            set the stage (locked/review/done/"")
+//	POST   /api/v1/cards/{id}/in-progress      move to the implicit In Progress status
+//	POST   /api/v1/cards/{id}/progress         set the readiness percentage
+//	POST   /api/v1/cards/{id}/assignee         set/clear the assignee
+//	POST   /api/v1/cards/{id}/team             move to a team (joins its sprint)
+//	POST   /api/v1/cards/{id}/take-plan        take a plan card into work
+//	POST   /api/v1/cards/{id}/release-plan     release a card from the weekly plan
+//	POST   /api/v1/cards/{id}/move             reorder a card after another
+//	POST   /api/v1/cards/{id}/note             append a work note
+//	POST   /api/v1/cards/{id}/rename           rename a card
+//	POST   /api/v1/cards/{id}/review           send to review (creates a review card)
+//	POST   /api/v1/cards/{id}/review/reassign  point the review at another reviewer
+//	POST   /api/v1/cards/{id}/review/remove    delete the linked review card
+//	DELETE /api/v1/cards/{id}                  delete a card (cascades to its review)
 func (s *Server) registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/board", s.handleGetBoard)
-	mux.HandleFunc("GET /api/v1/cards", s.handleListCards)
+	mux.HandleFunc("GET /api/v1/team", s.handleTeamView)
+	mux.HandleFunc("GET /api/v1/me", s.handleMeView)
+	mux.HandleFunc("GET /api/v1/weekly", s.handleWeeklyView)
 	mux.HandleFunc("POST /api/v1/cards", s.handleCreateCard)
-	mux.HandleFunc("PATCH /api/v1/cards/{id}", s.handleUpdateCard)
-	mux.HandleFunc("POST /api/v1/cards/{id}/move", s.handleMoveCard)
+	mux.HandleFunc("POST /api/v1/carry-over", s.handleCarryOver)
+	mux.HandleFunc("POST /api/v1/carry-week", s.handleCarryWeek)
 	mux.HandleFunc("DELETE /api/v1/cards/{id}", s.handleDeleteCard)
-	mux.HandleFunc("POST /api/v1/cards/{id}/notes", s.handleAddNote)
+	mux.HandleFunc("POST /api/v1/cards/{id}/stage", s.handleSetStage)
+	mux.HandleFunc("POST /api/v1/cards/{id}/in-progress", s.handleSetInProgress)
+	mux.HandleFunc("POST /api/v1/cards/{id}/progress", s.handleSetProgress)
+	mux.HandleFunc("POST /api/v1/cards/{id}/assignee", s.handleSetAssignee)
+	mux.HandleFunc("POST /api/v1/cards/{id}/team", s.handleSetTeam)
+	mux.HandleFunc("POST /api/v1/cards/{id}/take-plan", s.handleTakePlan)
+	mux.HandleFunc("POST /api/v1/cards/{id}/release-plan", s.handleReleasePlan)
+	mux.HandleFunc("POST /api/v1/cards/{id}/move", s.handleMoveCard)
+	mux.HandleFunc("POST /api/v1/cards/{id}/note", s.handleAddNote)
+	mux.HandleFunc("POST /api/v1/cards/{id}/rename", s.handleRename)
+	mux.HandleFunc("POST /api/v1/cards/{id}/review", s.handleSendToReview)
+	mux.HandleFunc("POST /api/v1/cards/{id}/review/reassign", s.handleReassignReviewer)
+	mux.HandleFunc("POST /api/v1/cards/{id}/review/remove", s.handleRemoveReviewer)
 }
 
 // boardRef resolves the target board from query parameters, honouring the
@@ -62,70 +104,144 @@ func (s *Server) apiClient(r *http.Request) (*ghprojects.Client, error) {
 	return ghprojects.New(tok, opts...), nil
 }
 
-// loadBoard resolves the board reference, builds a client and loads the board.
-// On failure it writes an error response and returns ok=false.
-func (s *Server) loadBoard(w http.ResponseWriter, r *http.Request) (*ghprojects.Client, *ghprojects.Board, bool) {
+// defaultService is the production newService: it builds a boardservice over the
+// per-request ghprojects client (*ghprojects.Client satisfies boardservice.Backend).
+func (s *Server) defaultService(r *http.Request) (*boardservice.Service, error) {
+	client, err := s.apiClient(r)
+	if err != nil {
+		return nil, err
+	}
+	return boardservice.New(client), nil
+}
+
+// service resolves the board reference and builds the per-request board service.
+// On failure it writes the response (400 on a bad ref, 401 on no token) and
+// returns ok=false.
+func (s *Server) service(w http.ResponseWriter, r *http.Request) (svc *boardservice.Service, owner string, project int, ok bool) {
 	owner, project, err := s.boardRef(r)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
-		return nil, nil, false
+		return nil, "", 0, false
 	}
-	client, err := s.apiClient(r)
+	svc, err = s.newService(r)
 	if err != nil {
 		writeJSONError(w, http.StatusUnauthorized, "not authenticated: "+err.Error())
-		return nil, nil, false
+		return nil, "", 0, false
 	}
-	board, err := client.LoadProjectBoard(r.Context(), owner, project)
-	if err != nil {
-		s.apiError(w, err)
-		return nil, nil, false
-	}
-	return client, board, true
+	return svc, owner, project, true
 }
 
-// boardMeta is the /api/v1/board response: identity plus field metadata.
+// boardMeta is the GET /api/v1/board response: board identity, field metadata
+// and the per-team sprint pointers.
 type boardMeta struct {
-	ID     string                    `json:"id"`
-	Number int                       `json:"number"`
-	Title  string                    `json:"title"`
-	URL    string                    `json:"url"`
-	Owner  string                    `json:"owner"`
-	Fields []ghprojects.ProjectField `json:"fields"`
+	ID           string                       `json:"id"`
+	Number       int                          `json:"number"`
+	Owner        string                       `json:"owner"`
+	Fields       []board.ProjectField         `json:"fields"`
+	SprintStates map[string]board.SprintState `json:"sprintStates"`
+}
+
+// cardsResponse wraps a list of cards returned by a view.
+type cardsResponse struct {
+	Cards []board.Card `json:"cards"`
+}
+
+// statusResponse is the acknowledgement returned by actions that leave no single
+// card to echo (delete, release, carry-over).
+type statusResponse struct {
+	Status string `json:"status"`
+	ItemID string `json:"itemId,omitempty"`
 }
 
 func (s *Server) handleGetBoard(w http.ResponseWriter, r *http.Request) {
-	_, board, ok := s.loadBoard(w, r)
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
+		return
+	}
+	b, err := svc.Board(r.Context(), owner, project)
+	if err != nil {
+		s.apiError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, boardMeta{
-		ID:     board.ID,
-		Number: board.Number,
-		Title:  board.Title,
-		URL:    board.URL,
-		Owner:  board.Owner,
-		Fields: board.Fields,
+		ID:           b.ID,
+		Number:       b.Number,
+		Owner:        b.Owner,
+		Fields:       b.Fields,
+		SprintStates: b.SprintStates,
 	})
 }
 
-func (s *Server) handleListCards(w http.ResponseWriter, r *http.Request) {
-	_, board, ok := s.loadBoard(w, r)
+func (s *Server) handleTeamView(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"cards": board.Cards})
+	q := r.URL.Query()
+	cards, err := svc.TeamView(r.Context(), owner, project, q.Get("team"), q.Get("day"))
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cardsResponse{Cards: cards})
+}
+
+func (s *Server) handleMeView(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	cards, err := svc.MeView(r.Context(), owner, project, q.Get("user"), q.Get("day"))
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cardsResponse{Cards: cards})
+}
+
+func (s *Server) handleWeeklyView(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	bands, err := svc.WeeklyPlan(r.Context(), owner, project, q.Get("team"), q.Get("week"))
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bands)
 }
 
 func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
-	var in ghprojects.CreateCardInput
+	var in struct {
+		Team           string `json:"team"`
+		Zone           string `json:"zone"`
+		Title          string `json:"title"`
+		Assignee       string `json:"assignee"`
+		Day            string `json:"day"`
+		StartNewSprint *bool  `json:"startNewSprint"`
+	}
 	if !decodeJSON(w, r, &in) {
 		return
 	}
-	client, board, ok := s.loadBoard(w, r)
+	if in.Title == "" {
+		writeJSONError(w, http.StatusBadRequest, "title is required")
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
 		return
 	}
-	card, err := client.CreateProjectCard(r.Context(), board, in)
+	card, err := svc.CreateCard(r.Context(), owner, project, boardservice.CreateCardArgs{
+		Team:           in.Team,
+		Zone:           board.ZoneKey(in.Zone),
+		Title:          in.Title,
+		Assignee:       in.Assignee,
+		Day:            in.Day,
+		StartNewSprint: in.StartNewSprint,
+	})
 	if err != nil {
 		s.apiError(w, err)
 		return
@@ -133,50 +249,188 @@ func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, card)
 }
 
-func (s *Server) handleUpdateCard(w http.ResponseWriter, r *http.Request) {
-	var in ghprojects.UpdateCardInput
+func (s *Server) handleCarryOver(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Team string `json:"team"`
+	}
 	if !decodeJSON(w, r, &in) {
 		return
 	}
-	client, board, ok := s.loadBoard(w, r)
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
 		return
 	}
-	if err := client.UpdateCard(r.Context(), board, r.PathValue("id"), in); err != nil {
+	if err := svc.CarryOver(r.Context(), owner, project, in.Team); err != nil {
 		s.apiError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
+}
+
+func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Team string `json:"team"`
+		Week string `json:"week"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	carried, err := svc.CarryWeek(r.Context(), owner, project, in.Team, in.Week)
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	if carried == nil {
+		carried = []board.Card{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"carried": carried})
+}
+
+func (s *Server) handleSetStage(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Stage string `json:"stage"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetStage(r.Context(), owner, project, id, board.StageKey(in.Stage)); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSetInProgress(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetInProgress(r.Context(), owner, project, id); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSetProgress(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Progress int `json:"progress"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetProgress(r.Context(), owner, project, id, in.Progress); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSetAssignee(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Login string `json:"login"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetAssignee(r.Context(), owner, project, id, in.Login); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSetTeam(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Team string `json:"team"`
+		Day  string `json:"day"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetTeam(r.Context(), owner, project, id, in.Team, in.Day); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleTakePlan(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Engineer string `json:"engineer"`
+		Zone     string `json:"zone"`
+		Day      string `json:"day"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.TakeIntoPlan(r.Context(), owner, project, id, in.Engineer, board.ZoneKey(in.Zone), in.Day); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleReleasePlan(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.ReleaseFromPlan(r.Context(), owner, project, id); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok", ItemID: id})
 }
 
 func (s *Server) handleMoveCard(w http.ResponseWriter, r *http.Request) {
 	var in struct {
-		AfterID *string `json:"afterId"`
+		AfterID string `json:"afterId"`
 	}
 	if !decodeJSON(w, r, &in) {
 		return
 	}
-	client, board, ok := s.loadBoard(w, r)
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
 		return
 	}
-	if err := client.MoveProjectCard(r.Context(), board, r.PathValue("id"), in.AfterID); err != nil {
+	id := r.PathValue("id")
+	if err := svc.MoveCard(r.Context(), owner, project, id, in.AfterID); err != nil {
 		s.apiError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-}
-
-func (s *Server) handleDeleteCard(w http.ResponseWriter, r *http.Request) {
-	client, board, ok := s.loadBoard(w, r)
-	if !ok {
-		return
-	}
-	if err := client.DeleteProjectCard(r.Context(), board, r.PathValue("id")); err != nil {
-		s.apiError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	s.cardResponse(w, r, svc, owner, project, id)
 }
 
 func (s *Server) handleAddNote(w http.ResponseWriter, r *http.Request) {
@@ -190,15 +444,117 @@ func (s *Server) handleAddNote(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "text is required")
 		return
 	}
-	client, board, ok := s.loadBoard(w, r)
+	svc, owner, project, ok := s.service(w, r)
 	if !ok {
 		return
 	}
-	if err := client.AddProjectNote(r.Context(), board, r.PathValue("id"), in.Text); err != nil {
+	id := r.PathValue("id")
+	if err := svc.AddNote(r.Context(), owner, project, id, in.Text); err != nil {
 		s.apiError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok", ItemID: id})
+}
+
+func (s *Server) handleRename(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Title string `json:"title"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	if in.Title == "" {
+		writeJSONError(w, http.StatusBadRequest, "title is required")
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.Rename(r.Context(), owner, project, id, in.Title); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Reviewer string `json:"reviewer"`
+		Day      string `json:"day"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	review, err := svc.SendToReview(r.Context(), owner, project, id, in.Reviewer, in.Day)
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, review)
+}
+
+func (s *Server) handleReassignReviewer(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Reviewer string `json:"reviewer"`
+		Day      string `json:"day"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.ReassignReviewer(r.Context(), owner, project, id, in.Reviewer, in.Day); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleRemoveReviewer(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.RemoveReviewer(r.Context(), owner, project, id); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok", ItemID: id})
+}
+
+func (s *Server) handleDeleteCard(w http.ResponseWriter, r *http.Request) {
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.DeleteCard(r.Context(), owner, project, id); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok", ItemID: id})
+}
+
+// cardResponse loads and returns the single card resulting from an action, so
+// the API reply reflects the card the way the UI re-renders the one it changed.
+func (s *Server) cardResponse(w http.ResponseWriter, r *http.Request, svc *boardservice.Service, owner string, project int, id string) {
+	card, err := svc.Card(r.Context(), owner, project, id)
+	if err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, card)
 }
 
 // decodeJSON decodes a JSON request body, writing a 400 on failure. An empty
@@ -216,10 +572,12 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	return true
 }
 
-// apiError maps a ghprojects error onto an HTTP status and JSON body.
+// apiError maps a boardservice/ghprojects error onto an HTTP status and JSON body.
 func (s *Server) apiError(w http.ResponseWriter, err error) {
 	switch {
-	case errors.Is(err, ghprojects.ErrBoardNotFound), errors.Is(err, ghprojects.ErrCardNotFound):
+	case errors.Is(err, boardservice.ErrCardNotFound),
+		errors.Is(err, ghprojects.ErrBoardNotFound),
+		errors.Is(err, ghprojects.ErrCardNotFound):
 		writeJSONError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, ghprojects.ErrFieldNotFound), errors.Is(err, ghprojects.ErrNoContent):
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -80,8 +80,8 @@ func TestAPITeamView(t *testing.T) {
 
 func TestAPIMeView(t *testing.T) {
 	today := board.TodayIso()
-	// Me shows a card while its day (sprintStart) sits between the team's current
-	// sprint and the viewed day, so the no-team group needs a sprint anchor.
+	// Me shows a card whose sprintStart equals the sprint active on the viewed day
+	// and whose startDate has arrived, so the no-team group needs a sprint anchor.
 	fake := boardservicetest.New([]board.Card{
 		{ItemID: "c1", Assignees: []string{"bob"}, StartDate: today, SprintStart: today},
 	}, map[string]board.SprintState{"": {Current: today}})

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -215,6 +215,35 @@ func TestAPILockBoardIgnoresQuery(t *testing.T) {
 	}
 }
 
+func TestAPIIndex(t *testing.T) {
+	srv := apiServer(t, Options{Version: "test-1.2.3"}, boardservicetest.New(nil, nil))
+	// The catalog is public metadata: it must not resolve a token or board.
+	srv.newService = func(*http.Request) (*boardservice.Service, error) {
+		t.Fatal("index must not build a board service")
+		return nil, nil
+	}
+	rec := do(t, srv, http.MethodGet, "/api/v1", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var idx apiIndex
+	if err := json.Unmarshal(rec.Body.Bytes(), &idx); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if idx.Name != "aeman" {
+		t.Fatalf("name = %q, want aeman", idx.Name)
+	}
+	if idx.Version != "test-1.2.3" {
+		t.Fatalf("version = %q, want test-1.2.3", idx.Version)
+	}
+	if idx.MCP != "/mcp" {
+		t.Fatalf("mcp = %q, want /mcp", idx.MCP)
+	}
+	if len(idx.Endpoints) == 0 {
+		t.Fatal("endpoints is empty")
+	}
+}
+
 func TestAPIInvalidJSON(t *testing.T) {
 	fake := boardservicetest.New(nil, nil)
 	srv := apiServer(t, Options{}, fake)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8,67 +8,29 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/aenix-org/aeman/internal/board"
+	"github.com/aenix-org/aeman/internal/boardservice"
+	"github.com/aenix-org/aeman/internal/boardservice/boardservicetest"
 )
 
-// fakeGraphQL spins up a stub GitHub GraphQL endpoint and returns an aeman
-// Server wired to it, plus a slice capturing the requests it received. The API
-// token is stubbed via the apiTokens seam so tests never touch gh or OAuth.
-func fakeGraphQL(t *testing.T, opts Options, respond func(query string, vars map[string]any) string) (*Server, *[]map[string]any) {
+// apiServer wires an aeman Server whose /api/v1 board service is backed by the
+// in-memory fake, so the handlers exercise the real boardservice logic without
+// touching GitHub or the token sources.
+func apiServer(t *testing.T, opts Options, fake *boardservicetest.Backend) *Server {
 	t.Helper()
-	var reqs []map[string]any
-	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Query     string         `json:"query"`
-			Variables map[string]any `json:"variables"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		reqs = append(reqs, map[string]any{"query": body.Query, "vars": body.Variables})
-		data := respond(body.Query, body.Variables)
-		if data == "" {
-			data = "{}"
-		}
-		_, _ = w.Write([]byte(`{"data":` + data + `}`))
-	}))
-	t.Cleanup(gh.Close)
-
 	opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	srv, err := New(opts)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	srv.graphqlEndpoint = gh.URL
-	srv.apiTokens = func(*http.Request) (string, string, error) { return "test-token", "tester", nil }
-	return srv, &reqs
-}
-
-const apiBoardJSON = `{"organization":{"projectV2":{
-  "id":"PVT_1","number":7,"title":"Board","url":"https://example/7",
-  "fields":{"nodes":[
-    {"__typename":"ProjectV2SingleSelectField","id":"F_ZONE","name":"Zone","dataType":"SINGLE_SELECT","options":[
-      {"id":"o_gray","name":"Planned","color":"GRAY"},{"id":"o_red","name":"Critical","color":"RED"}]},
-    {"__typename":"ProjectV2Field","id":"F_PROG","name":"Progress","dataType":"NUMBER"}
-  ]},
-  "items":{"nodes":[
-    {"id":"I_DRAFT","type":"DRAFT_ISSUE","createdAt":"2026-06-20T10:00:00Z",
-     "content":{"__typename":"DraftIssue","id":"DI_1","title":"Draft","body":"","assignees":{"nodes":[]}},
-     "fieldValues":{"nodes":[
-       {"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"o_red","name":"Critical","field":{"id":"F_ZONE","name":"Zone"}}
-     ]}}
-  ]}
-}}}`
-
-func apiRespond(query string, _ map[string]any) string {
-	switch {
-	case strings.Contains(query, "organization(login:") && strings.Contains(query, "projectV2(number:"):
-		return apiBoardJSON
-	case strings.Contains(query, "addProjectV2DraftIssue"):
-		return `{"addProjectV2DraftIssue":{"projectItem":{"id":"I_NEW","content":{"id":"DI_NEW"}}}}`
-	default:
-		return "{}"
+	srv.newService = func(*http.Request) (*boardservice.Service, error) {
+		return boardservice.New(fake), nil
 	}
+	return srv
 }
 
-func do(t *testing.T, srv *Server, method, target string, body string) *httptest.ResponseRecorder {
+func do(t *testing.T, srv *Server, method, target, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	var r *http.Request
 	if body == "" {
@@ -82,9 +44,10 @@ func do(t *testing.T, srv *Server, method, target string, body string) *httptest
 	return rec
 }
 
-func TestAPIGetBoard(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodGet, "/api/v1/board?owner=acme&project=7", "")
+func TestAPIBoardMeta(t *testing.T) {
+	fake := boardservicetest.New(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodGet, "/api/v1/board?owner=acme&project=1", "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
@@ -92,141 +55,168 @@ func TestAPIGetBoard(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &meta); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if meta.ID != "PVT_1" || len(meta.Fields) != 2 {
+	if meta.Owner != "acme" || meta.SprintStates["alpha"].Current != "2026-06-20" {
 		t.Fatalf("meta = %+v", meta)
 	}
 }
 
-func TestAPIListCards(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=7", "")
+func TestAPITeamView(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "c1", Team: "alpha", StartDate: today, SprintStart: today},
+		{ItemID: "c2", Team: "beta", StartDate: today, SprintStart: today},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodGet, "/api/v1/team?owner=acme&project=1&team=alpha", "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
 	}
-	var out struct {
-		Cards []map[string]any `json:"cards"`
-	}
+	var out cardsResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &out)
-	if len(out.Cards) != 1 || out.Cards[0]["zone"] != "red" {
+	if len(out.Cards) != 1 || out.Cards[0].ItemID != "c1" {
 		t.Fatalf("cards = %+v", out.Cards)
 	}
 }
 
+func TestAPIMeView(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "c1", Assignees: []string{"bob"}, StartDate: today, SprintStart: today},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodGet, "/api/v1/me?owner=acme&project=1&user=bob", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var out cardsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if len(out.Cards) != 1 || out.Cards[0].ItemID != "c1" {
+		t.Fatalf("cards = %+v", out.Cards)
+	}
+}
+
+func TestAPIWeeklyView(t *testing.T) {
+	week := "2026-06-22"
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "a1", Plan: board.PlanWed, Week: week, Team: "alpha"},
+		{ItemID: "a2", Plan: board.PlanFri, Week: week, Team: "alpha"},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodGet, "/api/v1/weekly?owner=acme&project=1&team=alpha&week="+week, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var bands board.WeeklyBands
+	_ = json.Unmarshal(rec.Body.Bytes(), &bands)
+	if len(bands.Wed) != 1 || len(bands.Fri) != 1 {
+		t.Fatalf("bands = %+v", bands)
+	}
+}
+
+func TestAPICreateCard(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards?owner=acme&project=1",
+		`{"team":"alpha","zone":"red","title":"New","assignee":"bob"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var card board.Card
+	_ = json.Unmarshal(rec.Body.Bytes(), &card)
+	if card.Title != "New" || card.Team != "alpha" {
+		t.Fatalf("card = %+v", card)
+	}
+	if len(fake.Creates()) != 1 || fake.Creates()[0].Zone != board.ZoneRed {
+		t.Fatalf("creates = %+v", fake.Creates())
+	}
+}
+
+func TestAPICreateRequiresTitle(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards?owner=acme&project=1", `{"team":"alpha"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestAPISetProgressDoneLink(t *testing.T) {
+	fake := boardservicetest.New([]board.Card{{ItemID: "c1", Progress: 50}}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards/c1/progress?owner=acme&project=1", `{"progress":100}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var card board.Card
+	_ = json.Unmarshal(rec.Body.Bytes(), &card)
+	if card.Progress != 100 || card.Stage != board.StageDone {
+		t.Fatalf("100%% should auto-set done: %+v", card)
+	}
+}
+
+func TestAPISetStage(t *testing.T) {
+	fake := boardservicetest.New([]board.Card{{ItemID: "c1", Progress: 100}}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards/c1/stage?owner=acme&project=1", `{"stage":"review"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var card board.Card
+	_ = json.Unmarshal(rec.Body.Bytes(), &card)
+	if card.Stage != board.StageReview || card.Progress != 90 {
+		t.Fatalf("review should knock a full card to 90: %+v", card)
+	}
+}
+
+func TestAPIDeleteCascadesToReview(t *testing.T) {
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "orig", Title: "x"},
+		{ItemID: "rev", ReviewOf: "orig"},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodDelete, "/api/v1/cards/orig?owner=acme&project=1", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if fake.Card("orig") != nil || fake.Card("rev") != nil {
+		t.Fatalf("both cards should be gone; orig=%v rev=%v", fake.Card("orig"), fake.Card("rev"))
+	}
+	if fake.Count("DeleteCard") != 2 {
+		t.Fatalf("expected two deletes, got %d", fake.Count("DeleteCard"))
+	}
+}
+
+func TestAPIUnknownCardReturns404(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards/nope/progress?owner=acme&project=1", `{"progress":50}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
 func TestAPIMissingBoardRef(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodGet, "/api/v1/cards", "")
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodGet, "/api/v1/team", "")
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 }
 
 func TestAPILockBoardIgnoresQuery(t *testing.T) {
-	srv, reqs := fakeGraphQL(t, Options{DefaultOwner: "acme", DefaultProject: 7, LockBoard: true}, apiRespond)
+	fake := boardservicetest.New(nil, map[string]board.SprintState{"alpha": {Current: "x"}})
+	srv := apiServer(t, Options{DefaultOwner: "acme", DefaultProject: 7, LockBoard: true}, fake)
 	rec := do(t, srv, http.MethodGet, "/api/v1/board?owner=evil&project=99", "")
 	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
-	for _, r := range *reqs {
-		vars, _ := r["vars"].(map[string]any)
-		if owner, ok := vars["owner"]; ok && owner != "acme" {
-			t.Fatalf("locked board used owner %v", owner)
-		}
-	}
-}
-
-func TestAPICreateCard(t *testing.T) {
-	srv, reqs := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPost, "/api/v1/cards?owner=acme&project=7", `{"title":"New","zone":"red"}`)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
-	}
-	sawDraft := false
-	for _, r := range *reqs {
-		if q, _ := r["query"].(string); strings.Contains(q, "addProjectV2DraftIssue") {
-			sawDraft = true
-		}
-	}
-	if !sawDraft {
-		t.Fatal("expected a draft-issue creation request")
-	}
-}
-
-func TestAPIUpdateCard(t *testing.T) {
-	srv, reqs := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPatch, "/api/v1/cards/I_DRAFT?owner=acme&project=7", `{"progress":80}`)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
-	}
-	sawNumber := false
-	for _, r := range *reqs {
-		q, _ := r["query"].(string)
-		vars, _ := r["vars"].(map[string]any)
-		if strings.Contains(q, "value: { number: $value }") && vars["value"] == 80.0 {
-			sawNumber = true
-		}
-	}
-	if !sawNumber {
-		t.Fatal("expected a number mutation with value 80")
-	}
-}
-
-func TestAPIUpdateUnknownCardReturns404(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPatch, "/api/v1/cards/NOPE?owner=acme&project=7", `{"progress":80}`)
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", rec.Code)
-	}
-}
-
-func TestAPIMoveCard(t *testing.T) {
-	srv, reqs := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPost, "/api/v1/cards/I_DRAFT/move?owner=acme&project=7", `{"afterId":"I_OTHER"}`)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
-	}
-	sawMove := false
-	for _, r := range *reqs {
-		q, _ := r["query"].(string)
-		vars, _ := r["vars"].(map[string]any)
-		if strings.Contains(q, "updateProjectV2ItemPosition") && vars["item"] == "I_DRAFT" && vars["after"] == "I_OTHER" {
-			sawMove = true
-		}
-	}
-	if !sawMove {
-		t.Fatal("expected an updateProjectV2ItemPosition mutation with item=I_DRAFT after=I_OTHER")
-	}
-}
-
-func TestAPIMoveCardToTop(t *testing.T) {
-	srv, reqs := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPost, "/api/v1/cards/I_DRAFT/move?owner=acme&project=7", `{"afterId":null}`)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
-	}
-	sawMove := false
-	for _, r := range *reqs {
-		q, _ := r["query"].(string)
-		vars, _ := r["vars"].(map[string]any)
-		if strings.Contains(q, "updateProjectV2ItemPosition") && vars["item"] == "I_DRAFT" && vars["after"] == nil {
-			sawMove = true
-		}
-	}
-	if !sawMove {
-		t.Fatal("expected a move mutation with a nil after (move to top)")
-	}
-}
-
-func TestAPIAddNoteRequiresText(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPost, "/api/v1/cards/I_DRAFT/notes?owner=acme&project=7", `{}`)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
+		t.Fatalf("locked board should resolve from defaults: status = %d", rec.Code)
 	}
 }
 
 func TestAPIInvalidJSON(t *testing.T) {
-	srv, _ := fakeGraphQL(t, Options{}, apiRespond)
-	rec := do(t, srv, http.MethodPost, "/api/v1/cards?owner=acme&project=7", `{not json}`)
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPost, "/api/v1/cards?owner=acme&project=1", `{not json}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -80,9 +80,11 @@ func TestAPITeamView(t *testing.T) {
 
 func TestAPIMeView(t *testing.T) {
 	today := board.TodayIso()
+	// Me shows a card while its day (sprintStart) sits between the team's current
+	// sprint and the viewed day, so the no-team group needs a sprint anchor.
 	fake := boardservicetest.New([]board.Card{
 		{ItemID: "c1", Assignees: []string{"bob"}, StartDate: today, SprintStart: today},
-	}, nil)
+	}, map[string]board.SprintState{"": {Current: today}})
 	srv := apiServer(t, Options{}, fake)
 	rec := do(t, srv, http.MethodGet, "/api/v1/me?owner=acme&project=1&user=bob", "")
 	if rec.Code != http.StatusOK {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -54,6 +54,11 @@ type persistedSession struct {
 // authManager runs the GitHub OAuth web flow and keeps per-user sessions. They
 // live in memory and, when SessionFile is set, are mirrored to disk so a
 // restart doesn't force everyone to sign in again.
+//
+// It also plays the OAuth 2.0 authorization-server role for the MCP endpoint
+// (RFC 7591 dynamic client registration, the PKCE authorization-code grant and
+// token issuance). MCP access tokens ARE session ids, so an issued token is a
+// live session and the same TTL/persistence applies.
 type authManager struct {
 	cfg    OAuthConfig
 	secure bool
@@ -61,8 +66,43 @@ type authManager struct {
 	client *http.Client
 	path   string
 
+	// GitHub endpoints. They default to the real GitHub URLs and are overridden
+	// in tests to point at a stub server.
+	authorizeURL string
+	tokenURL     string
+	apiBase      string
+
 	mu       sync.Mutex
 	sessions map[string]oauthSession
+	// clients holds dynamically-registered MCP OAuth clients (RFC 7591).
+	clients map[string]oauthClient
+	// pendingAuth tracks in-flight MCP authorizations, keyed by the GitHub
+	// state we generate, so the callback can resume the right client flow.
+	pendingAuth map[string]pendingAuth
+	// authCodes holds issued single-use MCP authorization codes (5-min TTL).
+	authCodes map[string]authCode
+}
+
+// oauthClient is a dynamically-registered MCP OAuth client.
+type oauthClient struct {
+	redirectURIs []string
+}
+
+// pendingAuth is an in-flight MCP authorization, keyed by the GitHub state.
+type pendingAuth struct {
+	clientID      string
+	redirectURI   string
+	codeChallenge string
+	clientState   string
+}
+
+// authCode is an issued MCP authorization code (single-use, short-lived).
+type authCode struct {
+	sid           string
+	codeChallenge string
+	redirectURI   string
+	clientID      string
+	expiry        time.Time
 }
 
 func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
@@ -70,12 +110,18 @@ func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 		cfg.Scopes = "repo project"
 	}
 	a := &authManager{
-		cfg:      cfg,
-		secure:   strings.HasPrefix(strings.ToLower(cfg.BaseURL), "https://"),
-		log:      log,
-		client:   &http.Client{Timeout: 15 * time.Second},
-		path:     cfg.SessionFile,
-		sessions: map[string]oauthSession{},
+		cfg:          cfg,
+		secure:       strings.HasPrefix(strings.ToLower(cfg.BaseURL), "https://"),
+		log:          log,
+		client:       &http.Client{Timeout: 15 * time.Second},
+		path:         cfg.SessionFile,
+		authorizeURL: githubAuthorizeURL,
+		tokenURL:     githubTokenURL,
+		apiBase:      githubAPIBase,
+		sessions:     map[string]oauthSession{},
+		clients:      map[string]oauthClient{},
+		pendingAuth:  map[string]pendingAuth{},
+		authCodes:    map[string]authCode{},
 	}
 	a.load()
 	return a
@@ -185,10 +231,24 @@ func (a *authManager) handleLogin(w http.ResponseWriter, r *http.Request) {
 	q.Set("redirect_uri", a.redirectURI())
 	q.Set("scope", a.cfg.Scopes)
 	q.Set("state", state)
-	http.Redirect(w, r, githubAuthorizeURL+"?"+q.Encode(), http.StatusFound)
+	http.Redirect(w, r, a.authorizeURL+"?"+q.Encode(), http.StatusFound)
 }
 
 func (a *authManager) handleCallback(w http.ResponseWriter, r *http.Request) {
+	// An MCP authorization keyed by the GitHub state takes the OAuth-server
+	// branch; everything else is the cookie-session web flow below, unchanged.
+	state := r.URL.Query().Get("state")
+	a.mu.Lock()
+	p, isMCP := a.pendingAuth[state]
+	if isMCP {
+		delete(a.pendingAuth, state)
+	}
+	a.mu.Unlock()
+	if isMCP {
+		a.handleMCPCallback(w, r, p)
+		return
+	}
+
 	sc, err := r.Cookie(stateCookie)
 	if err != nil || sc.Value == "" || sc.Value != r.URL.Query().Get("state") {
 		writeJSONError(w, http.StatusBadRequest, "invalid OAuth state")
@@ -243,7 +303,7 @@ func (a *authManager) exchange(ctx context.Context, code string) (string, error)
 	form.Set("code", code)
 	form.Set("redirect_uri", a.redirectURI())
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", err
 	}
@@ -271,7 +331,7 @@ func (a *authManager) exchange(ctx context.Context, code string) (string, error)
 }
 
 func (a *authManager) fetchLogin(ctx context.Context, token string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIBase+"/user", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.apiBase+"/user", nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/aenix-org/aeman/internal/mcpserver"
+)
+
+// mcpTokenCtxKey carries the caller's GitHub token down to the tool handlers'
+// ResolveToken seam. The streamable transport delivers TokenInfo on the
+// per-request Extra (not on the handler context), so a receiving middleware
+// bridges it onto the context the tools actually run with.
+type mcpTokenCtxKey struct{}
+
+// registerMCP mounts the MCP streamable HTTP transport at /mcp, guarded by the
+// bearer-token middleware so unauthenticated callers get a 401 carrying the
+// protected-resource metadata URL. It is only mounted in OAuth mode.
+func (s *Server) registerMCP(mux *http.ServeMux) {
+	handler := mcp.NewStreamableHTTPHandler(s.mcpServerForRequest, nil)
+	protected := auth.RequireBearerToken(s.auth.verifyToken, &auth.RequireBearerTokenOptions{
+		ResourceMetadataURL: s.auth.baseURL() + "/.well-known/oauth-protected-resource",
+	})(handler)
+	mux.Handle("/mcp", protected)
+	mux.Handle("/mcp/", protected)
+}
+
+// mcpServerForRequest builds the aeman MCP server for an HTTP MCP session. The
+// ResolveToken seam pulls the caller's GitHub token from the request context, so
+// every tool call runs against GitHub with that user's own token.
+func (s *Server) mcpServerForRequest(*http.Request) *mcp.Server {
+	srv := mcpserver.New(mcpserver.Config{
+		Owner:        s.opts.DefaultOwner,
+		Project:      s.opts.DefaultProject,
+		Lock:         s.opts.LockBoard,
+		Version:      s.opts.Version,
+		Endpoint:     s.graphqlEndpoint,
+		HTTPClient:   s.httpClient,
+		ResolveToken: resolveTokenFromContext,
+	})
+	srv.AddReceivingMiddleware(injectGitHubToken)
+	return srv
+}
+
+// injectGitHubToken copies the GitHub token from the request's verified
+// TokenInfo onto the handler context, where ResolveToken can read it.
+func injectGitHubToken(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		if extra := req.GetExtra(); extra != nil && extra.TokenInfo != nil {
+			if tok, ok := extra.TokenInfo.Extra[githubTokenExtraKey].(string); ok && tok != "" {
+				ctx = context.WithValue(ctx, mcpTokenCtxKey{}, tok)
+			}
+		}
+		return next(ctx, method, req)
+	}
+}
+
+// resolveTokenFromContext is the MCP ResolveToken seam for the HTTP transport.
+func resolveTokenFromContext(ctx context.Context) (string, error) {
+	tok, _ := ctx.Value(mcpTokenCtxKey{}).(string)
+	if tok == "" {
+		return "", errors.New("no authenticated GitHub token for this MCP request")
+	}
+	return tok, nil
+}

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -1,0 +1,382 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/oauthex"
+)
+
+// authCodeTTL bounds how long an issued MCP authorization code stays redeemable.
+const authCodeTTL = 5 * time.Minute
+
+// githubTokenExtraKey is the key under which the verifier stashes the caller's
+// GitHub token in auth.TokenInfo.Extra; the /mcp token-injecting middleware
+// reads it back from the per-request TokenInfo.
+const githubTokenExtraKey = "github_token"
+
+// registerOAuthServer wires the OAuth 2.0 authorization-server endpoints that
+// front the MCP transport: metadata discovery, dynamic client registration, the
+// authorize redirect and the token endpoint. It is only mounted in OAuth mode.
+func (s *Server) registerOAuthServer(mux *http.ServeMux) {
+	a := s.auth
+	base := a.baseURL()
+	mux.Handle("/.well-known/oauth-protected-resource", auth.ProtectedResourceMetadataHandler(&oauthex.ProtectedResourceMetadata{
+		Resource:               base + "/mcp",
+		AuthorizationServers:   []string{base},
+		ScopesSupported:        a.scopeList(),
+		BearerMethodsSupported: []string{"header"},
+	}))
+	mux.HandleFunc("/.well-known/oauth-authorization-server", a.handleAuthServerMetadata)
+	mux.HandleFunc("/oauth/register", a.handleRegister)
+	mux.HandleFunc("/oauth/authorize", a.handleAuthorize)
+	mux.HandleFunc("/oauth/token", a.handleToken)
+}
+
+// baseURL is the public origin with any trailing slash trimmed.
+func (a *authManager) baseURL() string {
+	return strings.TrimRight(a.cfg.BaseURL, "/")
+}
+
+// scopeList splits the configured space-separated scopes into a slice.
+func (a *authManager) scopeList() []string {
+	return strings.Fields(a.cfg.Scopes)
+}
+
+// handleAuthServerMetadata serves RFC 8414 authorization-server metadata. It
+// advertises PKCE S256, which MCP clients (e.g. Claude Code) require.
+func (a *authManager) handleAuthServerMetadata(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	base := a.baseURL()
+	writeJSON(w, http.StatusOK, oauthex.AuthServerMeta{
+		Issuer:                            base,
+		AuthorizationEndpoint:             base + "/oauth/authorize",
+		TokenEndpoint:                     base + "/oauth/token",
+		RegistrationEndpoint:              base + "/oauth/register",
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		ScopesSupported:                   a.scopeList(),
+		CodeChallengeMethodsSupported:     []string{"S256"},
+	})
+}
+
+// handleRegister implements RFC 7591 dynamic client registration. It is public
+// (no auth) and CORS-enabled so browser-based MCP clients can self-register.
+func (a *authManager) handleRegister(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeOAuthError(w, http.StatusMethodNotAllowed, "invalid_request", "method not allowed")
+		return
+	}
+	var meta oauthex.ClientRegistrationMetadata
+	if err := json.NewDecoder(r.Body).Decode(&meta); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "invalid JSON body")
+		return
+	}
+	if len(meta.RedirectURIs) == 0 {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "redirect_uris is required")
+		return
+	}
+	clientID := randToken()
+	a.mu.Lock()
+	a.clients[clientID] = oauthClient{redirectURIs: append([]string(nil), meta.RedirectURIs...)}
+	a.mu.Unlock()
+
+	resp := oauthex.ClientRegistrationResponse{
+		ClientRegistrationMetadata: oauthex.ClientRegistrationMetadata{
+			RedirectURIs:            meta.RedirectURIs,
+			TokenEndpointAuthMethod: "none",
+			GrantTypes:              []string{"authorization_code"},
+			ResponseTypes:           []string{"code"},
+		},
+		ClientID: clientID,
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(&resp)
+}
+
+// handleAuthorize starts the MCP authorization-code flow. After validating the
+// client and PKCE parameters it stashes the request and bounces the browser to
+// GitHub; the GitHub callback resumes it in handleMCPCallback.
+func (a *authManager) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+
+	a.mu.Lock()
+	client, ok := a.clients[clientID]
+	a.mu.Unlock()
+	// A bad client or redirect_uri is a hard 400: redirecting an unverified URI
+	// would be an open redirect.
+	if !ok {
+		writeJSONError(w, http.StatusBadRequest, "unknown client_id")
+		return
+	}
+	if !slices.Contains(client.redirectURIs, redirectURI) {
+		writeJSONError(w, http.StatusBadRequest, "redirect_uri is not registered for this client")
+		return
+	}
+
+	clientState := q.Get("state")
+	if q.Get("response_type") != "code" {
+		a.redirectError(w, r, redirectURI, clientState, "unsupported_response_type", "response_type must be code")
+		return
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		a.redirectError(w, r, redirectURI, clientState, "invalid_request", "code_challenge_method must be S256")
+		return
+	}
+	challenge := q.Get("code_challenge")
+	if challenge == "" {
+		a.redirectError(w, r, redirectURI, clientState, "invalid_request", "code_challenge is required")
+		return
+	}
+
+	state := randToken()
+	a.mu.Lock()
+	a.pendingAuth[state] = pendingAuth{
+		clientID:      clientID,
+		redirectURI:   redirectURI,
+		codeChallenge: challenge,
+		clientState:   clientState,
+	}
+	a.mu.Unlock()
+
+	gh := url.Values{}
+	gh.Set("client_id", a.cfg.ClientID)
+	gh.Set("redirect_uri", a.redirectURI())
+	gh.Set("scope", a.cfg.Scopes)
+	gh.Set("state", state)
+	http.Redirect(w, r, a.authorizeURL+"?"+gh.Encode(), http.StatusFound)
+}
+
+// handleMCPCallback resumes an MCP authorization after GitHub redirects back: it
+// exchanges the GitHub code for a token, opens a session, mints a single-use MCP
+// code and bounces the browser back to the client's redirect_uri.
+func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, p pendingAuth) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		a.redirectError(w, r, p.redirectURI, p.clientState, "invalid_request", "missing authorization code")
+		return
+	}
+	ghToken, err := a.exchange(r.Context(), code)
+	if err != nil {
+		a.log.Error("mcp oauth token exchange failed", "err", err)
+		a.redirectError(w, r, p.redirectURI, p.clientState, "server_error", "token exchange failed")
+		return
+	}
+	login, err := a.fetchLogin(r.Context(), ghToken)
+	if err != nil {
+		a.log.Error("mcp oauth user lookup failed", "err", err)
+		a.redirectError(w, r, p.redirectURI, p.clientState, "server_error", "could not read GitHub user")
+		return
+	}
+
+	now := time.Now()
+	sid := randToken()
+	mcpCode := randToken()
+	a.mu.Lock()
+	a.sessions[sid] = oauthSession{token: ghToken, login: login, created: now}
+	a.saveLocked()
+	a.authCodes[mcpCode] = authCode{
+		sid:           sid,
+		codeChallenge: p.codeChallenge,
+		redirectURI:   p.redirectURI,
+		clientID:      p.clientID,
+		expiry:        now.Add(authCodeTTL),
+	}
+	a.mu.Unlock()
+	a.log.Info("mcp user signed in", "login", login)
+
+	dest, err := url.Parse(p.redirectURI)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "invalid redirect_uri")
+		return
+	}
+	rq := dest.Query()
+	rq.Set("code", mcpCode)
+	if p.clientState != "" {
+		rq.Set("state", p.clientState)
+	}
+	dest.RawQuery = rq.Encode()
+	http.Redirect(w, r, dest.String(), http.StatusFound)
+}
+
+// handleToken redeems an MCP authorization code for an access token. The token
+// is the session id, so its lifetime is the session's. Codes are single-use.
+func (a *authManager) handleToken(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeOAuthError(w, http.StatusMethodNotAllowed, "invalid_request", "method not allowed")
+		return
+	}
+
+	p := parseTokenParams(r)
+	if p.grantType != "authorization_code" {
+		writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "grant_type must be authorization_code")
+		return
+	}
+
+	// Pop the code first: a code is single-use, so any redemption attempt (even a
+	// failing one) burns it, which blocks PKCE brute-forcing and replays.
+	a.mu.Lock()
+	c, ok := a.authCodes[p.code]
+	if ok {
+		delete(a.authCodes, p.code)
+	}
+	a.mu.Unlock()
+	if !ok {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "unknown or already-used code")
+		return
+	}
+	if time.Now().After(c.expiry) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code has expired")
+		return
+	}
+	if p.redirectURI != c.redirectURI {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
+		return
+	}
+	if p.clientID != c.clientID {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "client_id mismatch")
+		return
+	}
+	if !verifyPKCE(p.codeVerifier, c.codeChallenge) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+		return
+	}
+
+	a.mu.Lock()
+	sess, live := a.sessions[c.sid]
+	a.mu.Unlock()
+	if !live || time.Since(sess.created) > sessionTTL {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "session is no longer valid")
+		return
+	}
+	expiresIn := int(time.Until(sess.created.Add(sessionTTL)).Seconds())
+	if expiresIn < 0 {
+		expiresIn = 0
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token": c.sid,
+		"token_type":   "Bearer",
+		"expires_in":   expiresIn,
+	})
+}
+
+// verifyToken is the auth.TokenVerifier backing /mcp: it maps a bearer token
+// (= session id) to its TokenInfo, carrying the user's GitHub token in Extra.
+func (a *authManager) verifyToken(_ context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+	a.mu.Lock()
+	s, ok := a.sessions[token]
+	if ok && time.Since(s.created) > sessionTTL {
+		delete(a.sessions, token)
+		a.saveLocked()
+		ok = false
+	}
+	a.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown or expired session: %w", auth.ErrInvalidToken)
+	}
+	return &auth.TokenInfo{
+		UserID:     s.login,
+		Expiration: s.created.Add(sessionTTL),
+		Extra:      map[string]any{githubTokenExtraKey: s.token},
+	}, nil
+}
+
+// tokenParams holds the fields the token endpoint reads from form or JSON.
+type tokenParams struct {
+	grantType    string
+	code         string
+	codeVerifier string
+	redirectURI  string
+	clientID     string
+}
+
+// parseTokenParams reads the token request from a JSON or form-encoded body.
+func parseTokenParams(r *http.Request) tokenParams {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var in struct {
+			GrantType    string `json:"grant_type"`
+			Code         string `json:"code"`
+			CodeVerifier string `json:"code_verifier"`
+			RedirectURI  string `json:"redirect_uri"`
+			ClientID     string `json:"client_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		return tokenParams{in.GrantType, in.Code, in.CodeVerifier, in.RedirectURI, in.ClientID}
+	}
+	_ = r.ParseForm()
+	return tokenParams{
+		grantType:    r.PostFormValue("grant_type"),
+		code:         r.PostFormValue("code"),
+		codeVerifier: r.PostFormValue("code_verifier"),
+		redirectURI:  r.PostFormValue("redirect_uri"),
+		clientID:     r.PostFormValue("client_id"),
+	}
+}
+
+// verifyPKCE checks an S256 code_verifier against the stored challenge.
+func verifyPKCE(verifier, challenge string) bool {
+	if verifier == "" || challenge == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	got := base64.RawURLEncoding.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(got), []byte(challenge)) == 1
+}
+
+// redirectError bounces an OAuth error back to a (validated) client redirect_uri.
+func (a *authManager) redirectError(w http.ResponseWriter, r *http.Request, redirectURI, state, code, desc string) {
+	dest, err := url.Parse(redirectURI)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, code+": "+desc)
+		return
+	}
+	q := dest.Query()
+	q.Set("error", code)
+	if desc != "" {
+		q.Set("error_description", desc)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	dest.RawQuery = q.Encode()
+	// redirectURI is always a redirect URI the client pre-registered (validated
+	// in handleAuthorize before this is reached), so this is not an open redirect.
+	http.Redirect(w, r, dest.String(), http.StatusFound) //nolint:gosec // redirect_uri validated against the registered client
+}
+
+// writeOAuthError writes an RFC 6749 token-endpoint error response.
+func writeOAuthError(w http.ResponseWriter, status int, code, desc string) {
+	writeJSON(w, status, map[string]string{"error": code, "error_description": desc})
+}

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -1,0 +1,440 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/oauthex"
+)
+
+const testBaseURL = "https://aeman.test"
+
+const testRedirectURI = "http://127.0.0.1:9999/callback"
+
+// newOAuthServer builds an OAuth-mode aeman server whose GitHub endpoints point
+// at a stub, so the whole authorization-code flow runs without the network.
+func newOAuthServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "gh-token-xyz"})
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]string{"login": "octocat"})
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(gh.Close)
+
+	srv, err := New(Options{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Auth: &OAuthConfig{
+			ClientID:     "gh-client",
+			ClientSecret: "gh-secret",
+			BaseURL:      testBaseURL,
+			Scopes:       "repo project",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.auth.authorizeURL = gh.URL + "/login/oauth/authorize"
+	srv.auth.tokenURL = gh.URL + "/login/oauth/access_token"
+	srv.auth.apiBase = gh.URL
+	return srv, gh
+}
+
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func postForm(t *testing.T, srv *Server, target string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, target, strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, r)
+	return rec
+}
+
+func registerClient(t *testing.T, srv *Server, redirectURI string) string {
+	t.Helper()
+	rec := do(t, srv, http.MethodPost, "/oauth/register", `{"redirect_uris":["`+redirectURI+`"]}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp oauthex.ClientRegistrationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode register: %v", err)
+	}
+	if resp.ClientID == "" {
+		t.Fatal("register returned no client_id")
+	}
+	return resp.ClientID
+}
+
+// mintCode drives register → authorize → GitHub callback and returns a fresh,
+// redeemable MCP authorization code together with its PKCE verifier.
+func mintCode(t *testing.T, srv *Server) (code, clientID, redirectURI, verifier string) {
+	t.Helper()
+	redirectURI = testRedirectURI
+	clientID = registerClient(t, srv, redirectURI)
+	verifier = "pkce-verifier-sufficiently-long-0123456789"
+	aq := url.Values{}
+	aq.Set("client_id", clientID)
+	aq.Set("redirect_uri", redirectURI)
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge(verifier))
+	aq.Set("code_challenge_method", "S256")
+	aq.Set("state", "client-state")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("authorize status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	ghLoc, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse authorize redirect: %v", err)
+	}
+	cb := do(t, srv, http.MethodGet, "/auth/callback?code=gh-code&state="+ghLoc.Query().Get("state"), "")
+	if cb.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", cb.Code, cb.Body.String())
+	}
+	cbLoc, err := url.Parse(cb.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	code = cbLoc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("callback produced no code: %s", cb.Header().Get("Location"))
+	}
+	return code, clientID, redirectURI, verifier
+}
+
+func redeemToken(t *testing.T, srv *Server, code, verifier, redirectURI, clientID string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("code_verifier", verifier)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", clientID)
+	return postForm(t, srv, "/oauth/token", form)
+}
+
+func assertOAuthError(t *testing.T, rec *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var e struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &e); err != nil {
+		t.Fatalf("decode oauth error: %v (body=%s)", err, rec.Body.String())
+	}
+	if e.Error != want {
+		t.Fatalf("error = %q, want %q", e.Error, want)
+	}
+}
+
+func TestOAuthProtectedResourceMetadata(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	rec := do(t, srv, http.MethodGet, "/.well-known/oauth-protected-resource", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var m oauthex.ProtectedResourceMetadata
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.Resource != testBaseURL+"/mcp" {
+		t.Fatalf("resource = %q", m.Resource)
+	}
+	if len(m.AuthorizationServers) != 1 || m.AuthorizationServers[0] != testBaseURL {
+		t.Fatalf("authorization_servers = %v", m.AuthorizationServers)
+	}
+	if len(m.BearerMethodsSupported) != 1 || m.BearerMethodsSupported[0] != "header" {
+		t.Fatalf("bearer_methods_supported = %v", m.BearerMethodsSupported)
+	}
+}
+
+func TestOAuthAuthServerMetadata(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	rec := do(t, srv, http.MethodGet, "/.well-known/oauth-authorization-server", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("CORS = %q, want *", got)
+	}
+	if !strings.Contains(rec.Body.String(), `"code_challenge_methods_supported":["S256"]`) {
+		t.Fatalf("body must advertise S256: %s", rec.Body.String())
+	}
+	var m oauthex.AuthServerMeta
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.Issuer != testBaseURL ||
+		m.AuthorizationEndpoint != testBaseURL+"/oauth/authorize" ||
+		m.TokenEndpoint != testBaseURL+"/oauth/token" ||
+		m.RegistrationEndpoint != testBaseURL+"/oauth/register" {
+		t.Fatalf("endpoints = %+v", m)
+	}
+	if len(m.CodeChallengeMethodsSupported) != 1 || m.CodeChallengeMethodsSupported[0] != "S256" {
+		t.Fatalf("code_challenge_methods_supported = %v", m.CodeChallengeMethodsSupported)
+	}
+	if len(m.TokenEndpointAuthMethodsSupported) != 1 || m.TokenEndpointAuthMethodsSupported[0] != "none" {
+		t.Fatalf("token_endpoint_auth_methods_supported = %v", m.TokenEndpointAuthMethodsSupported)
+	}
+}
+
+func TestOAuthRegister(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	rec := do(t, srv, http.MethodPost, "/oauth/register", `{"redirect_uris":["`+testRedirectURI+`"]}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp oauthex.ClientRegistrationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ClientID == "" {
+		t.Fatal("no client_id")
+	}
+	if resp.TokenEndpointAuthMethod != "none" {
+		t.Fatalf("token_endpoint_auth_method = %q, want none", resp.TokenEndpointAuthMethod)
+	}
+	if len(resp.RedirectURIs) != 1 || resp.RedirectURIs[0] != testRedirectURI {
+		t.Fatalf("redirect_uris = %v", resp.RedirectURIs)
+	}
+}
+
+func TestOAuthRegisterRequiresRedirectURIs(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	rec := do(t, srv, http.MethodPost, "/oauth/register", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestOAuthAuthorizeUnknownClient(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	aq := url.Values{}
+	aq.Set("client_id", "does-not-exist")
+	aq.Set("redirect_uri", testRedirectURI)
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", "x")
+	aq.Set("code_challenge_method", "S256")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestOAuthAuthorizeUnregisteredRedirect(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	clientID := registerClient(t, srv, testRedirectURI)
+	aq := url.Values{}
+	aq.Set("client_id", clientID)
+	aq.Set("redirect_uri", "http://evil.example/callback")
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", "x")
+	aq.Set("code_challenge_method", "S256")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestOAuthFullFlow(t *testing.T) {
+	srv, gh := newOAuthServer(t)
+	redirectURI := testRedirectURI
+	clientID := registerClient(t, srv, redirectURI)
+
+	verifier := "verifier-abc123-long-enough-for-pkce-000000"
+	clientState := "client-state-zzz"
+
+	aq := url.Values{}
+	aq.Set("client_id", clientID)
+	aq.Set("redirect_uri", redirectURI)
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge(verifier))
+	aq.Set("code_challenge_method", "S256")
+	aq.Set("state", clientState)
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("authorize status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, gh.URL+"/login/oauth/authorize") {
+		t.Fatalf("authorize must redirect to the stub GitHub: %s", loc)
+	}
+	ghLoc, _ := url.Parse(loc)
+	ghState := ghLoc.Query().Get("state")
+	if ghState == "" {
+		t.Fatalf("no GitHub state in %s", loc)
+	}
+	if got := ghLoc.Query().Get("redirect_uri"); got != testBaseURL+"/auth/callback" {
+		t.Fatalf("GitHub redirect_uri = %q", got)
+	}
+
+	cb := do(t, srv, http.MethodGet, "/auth/callback?code=gh-code&state="+ghState, "")
+	if cb.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body = %s", cb.Code, cb.Body.String())
+	}
+	cbLoc, err := url.Parse(cb.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	if cbLoc.Scheme+"://"+cbLoc.Host+cbLoc.Path != redirectURI {
+		t.Fatalf("callback redirect = %q, want %q", cb.Header().Get("Location"), redirectURI)
+	}
+	if cbLoc.Query().Get("state") != clientState {
+		t.Fatalf("client state = %q, want %q", cbLoc.Query().Get("state"), clientState)
+	}
+	code := cbLoc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("no MCP code in %s", cb.Header().Get("Location"))
+	}
+
+	tok := redeemToken(t, srv, code, verifier, redirectURI, clientID)
+	if tok.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tok.Code, tok.Body.String())
+	}
+	var tr struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(tok.Body.Bytes(), &tr); err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	if tr.AccessToken == "" || tr.TokenType != "Bearer" || tr.ExpiresIn <= 0 {
+		t.Fatalf("token response = %+v", tr)
+	}
+
+	ti, err := srv.auth.verifyToken(context.Background(), tr.AccessToken, nil)
+	if err != nil {
+		t.Fatalf("verifyToken: %v", err)
+	}
+	if ti.UserID != "octocat" {
+		t.Fatalf("UserID = %q, want octocat", ti.UserID)
+	}
+	if got, _ := ti.Extra[githubTokenExtraKey].(string); got != "gh-token-xyz" {
+		t.Fatalf("github token = %v, want gh-token-xyz", ti.Extra[githubTokenExtraKey])
+	}
+}
+
+func TestOAuthTokenWrongVerifier(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	code, clientID, redirectURI, _ := mintCode(t, srv)
+	rec := redeemToken(t, srv, code, "wrong-verifier", redirectURI, clientID)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+}
+
+func TestOAuthCodeSingleUse(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	code, clientID, redirectURI, verifier := mintCode(t, srv)
+	first := redeemToken(t, srv, code, verifier, redirectURI, clientID)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first redeem = %d, body = %s", first.Code, first.Body.String())
+	}
+	second := redeemToken(t, srv, code, verifier, redirectURI, clientID)
+	if second.Code != http.StatusBadRequest {
+		t.Fatalf("second redeem = %d, want 400", second.Code)
+	}
+	assertOAuthError(t, second, "invalid_grant")
+}
+
+func TestOAuthCodeExpired(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	code, clientID, redirectURI, verifier := mintCode(t, srv)
+	srv.auth.mu.Lock()
+	c := srv.auth.authCodes[code]
+	c.expiry = time.Now().Add(-time.Minute)
+	srv.auth.authCodes[code] = c
+	srv.auth.mu.Unlock()
+	rec := redeemToken(t, srv, code, verifier, redirectURI, clientID)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+}
+
+func TestVerifyTokenUnknown(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	if _, err := srv.auth.verifyToken(context.Background(), "no-such-session", nil); !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("err = %v, want ErrInvalidToken", err)
+	}
+}
+
+func TestVerifyTokenExpired(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	sid := randToken()
+	srv.auth.mu.Lock()
+	srv.auth.sessions[sid] = oauthSession{token: "x", login: "y", created: time.Now().Add(-sessionTTL - time.Hour)}
+	srv.auth.mu.Unlock()
+	if _, err := srv.auth.verifyToken(context.Background(), sid, nil); !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("err = %v, want ErrInvalidToken", err)
+	}
+}
+
+func TestMCPInitializeWithBearer(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	code, clientID, redirectURI, verifier := mintCode(t, srv)
+	tok := redeemToken(t, srv, code, verifier, redirectURI, clientID)
+	if tok.Code != http.StatusOK {
+		t.Fatalf("token status = %d, body = %s", tok.Code, tok.Body.String())
+	}
+	var tr struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tok.Body.Bytes(), &tr); err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	r := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+tr.AccessToken)
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("initialize status = %d (auth must pass and MCP must init), body = %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Mcp-Session-Id") == "" {
+		t.Fatalf("expected an Mcp-Session-Id header for a fresh session")
+	}
+}
+
+func TestMCPRequiresBearer(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	rec := do(t, srv, http.MethodPost, "/mcp", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	wa := rec.Header().Get("WWW-Authenticate")
+	if !strings.Contains(wa, "resource_metadata") {
+		t.Fatalf("WWW-Authenticate = %q, want resource_metadata", wa)
+	}
+	if !strings.Contains(wa, testBaseURL+"/.well-known/oauth-protected-resource") {
+		t.Fatalf("WWW-Authenticate = %q, missing metadata URL", wa)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aenix-org/aeman/internal/boardservice"
 	"github.com/aenix-org/aeman/internal/ghcli"
 	"github.com/aenix-org/aeman/web"
 )
@@ -64,6 +65,11 @@ type Server struct {
 	apiTokens func(*http.Request) (token, login string, err error)
 	// graphqlEndpoint overrides the GitHub GraphQL endpoint (used in tests).
 	graphqlEndpoint string
+	// newService builds the board service for an /api/v1 request. It defaults to
+	// boardservice.New over the per-request ghprojects client (apiClient resolves
+	// the OAuth-session or gh-CLI token) and is overridden in tests with a fake
+	// Backend.
+	newService func(*http.Request) (*boardservice.Service, error)
 }
 
 // New builds a Server from the given options.
@@ -87,6 +93,7 @@ func New(opts Options) (*Server, error) {
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 	s.apiTokens = s.tokenForRequest
+	s.newService = s.defaultService
 	if opts.Auth != nil {
 		s.auth = newAuthManager(*opts.Auth, opts.Logger)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,6 +106,10 @@ func New(opts Options) (*Server, error) {
 		mux.HandleFunc("/auth/login", s.auth.handleLogin)
 		mux.HandleFunc("/auth/callback", s.auth.handleCallback)
 		mux.HandleFunc("/auth/logout", s.auth.handleLogout)
+		// The OAuth authorization-server endpoints and the MCP transport are only
+		// reachable in OAuth mode, where sessions double as MCP access tokens.
+		s.registerOAuthServer(mux)
+		s.registerMCP(mux)
 	}
 	s.registerAPI(mux)
 	mux.Handle("/", spaHandler(dist))

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -216,15 +216,12 @@ export function Card({
     onSetDates?.(card, startVal || null, endVal || startVal || null);
   };
 
-  // Quick-shift the start date by N days; push the finish along if overtaken.
+  // Send the card to another day: shift its day (sprintStart) by N days, leaving
+  // startDate (the card's origin) untouched. +1 = next day, +7 = next week.
   const moveStart = (days: number) => {
-    const newStart = addDays(card.startDate ?? todayIso(), days);
-    const end =
-      card.sprintStart && card.sprintStart >= newStart
-        ? card.sprintStart
-        : newStart;
+    const newDay = addDays(card.sprintStart ?? asOf ?? todayIso(), days);
     setDatesOpen(false);
-    onSetDates?.(card, newStart, end);
+    onSetDates?.(card, card.startDate ?? null, newDay);
   };
 
   // Plan cards: shift the plan week forward, or set it by picking a date.

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -216,12 +216,13 @@ export function Card({
     onSetDates?.(card, startVal || null, endVal || startVal || null);
   };
 
-  // Send the card to another day: shift its day (sprintStart) by N days, leaving
-  // startDate (the card's origin) untouched. +1 = next day, +7 = next week.
+  // Send the card to another day: shift its scheduled day (startDate) by N days,
+  // leaving its sprint (sprintStart) untouched, so the card disappears from
+  // Me/Team until its new startDate arrives. +1 = next day, +7 = next week.
   const moveStart = (days: number) => {
-    const newDay = addDays(card.sprintStart ?? asOf ?? todayIso(), days);
+    const newStart = addDays(card.startDate ?? asOf ?? todayIso(), days);
     setDatesOpen(false);
-    onSetDates?.(card, card.startDate ?? null, newDay);
+    onSetDates?.(card, newStart, card.sprintStart ?? null);
   };
 
   // Plan cards: shift the plan week forward, or set it by picking a date.

--- a/web/src/components/ConnectDialog.tsx
+++ b/web/src/components/ConnectDialog.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+
+interface ConnectDialogProps {
+  onClose: () => void;
+}
+
+/**
+ * ConnectDialog shows how to reach aeman programmatically: the MCP endpoint for
+ * Claude Code / agents, and the REST API base URL with its catalog.
+ *
+ * The "copied" feedback is timer-free: clicking a copy button records which
+ * block was copied in local state, and the label reads "copied" until another
+ * block is copied or the dialog is reopened (the component unmounts on close,
+ * so the flag resets naturally — no setTimeout to leak).
+ */
+export function ConnectDialog({ onClose }: ConnectDialogProps) {
+  const origin = window.location.origin;
+  const mcpCmd = `claude mcp add --transport http aeman ${origin}/mcp`;
+  const apiUrl = `${origin}/api/v1`;
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copy = (key: string, text: string) => {
+    void navigator.clipboard?.writeText(text);
+    setCopied(key);
+  };
+
+  return (
+    <div
+      className="modal-backdrop"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="modal connect-dialog"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Connect to aeman"
+      >
+        <div className="modal-header">
+          <h2 className="modal-title">Connect to aeman</h2>
+          <button
+            type="button"
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          <section className="connect-section">
+            <h3 className="connect-heading">MCP — for Claude Code / agents</h3>
+            <div className="connect-row">
+              <pre className="connect-cmd">
+                <code>{mcpCmd}</code>
+              </pre>
+              <button
+                type="button"
+                className="connect-copy"
+                onClick={() => copy("mcp", mcpCmd)}
+              >
+                {copied === "mcp" ? "copied" : "copy"}
+              </button>
+            </div>
+            <p className="connect-caption">
+              Sign in with GitHub on first use (OAuth, no token stored).
+            </p>
+          </section>
+
+          <section className="connect-section">
+            <h3 className="connect-heading">REST API</h3>
+            <div className="connect-row">
+              <pre className="connect-cmd">
+                <a href={apiUrl} target="_blank" rel="noreferrer">
+                  {apiUrl}
+                </a>
+              </pre>
+              <button
+                type="button"
+                className="connect-copy"
+                onClick={() => copy("api", apiUrl)}
+              >
+                {copied === "api" ? "copied" : "copy"}
+              </button>
+            </div>
+            <p className="connect-caption">
+              Same board operations over HTTP — open the link for the endpoint
+              catalog.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -113,23 +113,23 @@ export function MeBoard({
     [board.cards, viewMe],
   );
 
-  // A card shows within its [start, sprint] range, and keeps showing on later
-  // days while it is still its team's current sprint (per the explicit state) —
-  // so in Me cards stay visible until a new sprint is started (even by someone
-  // else, or by an unassigned card advancing the team's pointer).
+  // A card lives on exactly one day — its sprintStart. In Me it shows while that
+  // day sits at or after its team's current sprint and at or before the viewed
+  // day: the lower bound drops done/old cards from past sprints, the upper bound
+  // hides future-dated cards until their day arrives. A card with no team sprint
+  // or no sprintStart never shows.
   const myCards = useMemo(
     () =>
       mine.filter((c) => {
-        const start = c.startDate ?? c.sprintStart;
-        const sprint = c.sprintStart;
-        if (!start || !sprint || selectedDate < start) {
-          return false;
-        }
         if (teamFocus && teamFilter && !teamFilter.includes(c.team ?? "")) {
           return false;
         }
-        return (
-          selectedDate <= sprint || currentSprint(board, c.team ?? null) === sprint
+        const cur = currentSprint(board, c.team ?? null);
+        return Boolean(
+          cur &&
+            c.sprintStart &&
+            cur <= c.sprintStart &&
+            c.sprintStart <= selectedDate,
         );
       }),
     [mine, board, selectedDate, teamFocus, teamFilter],
@@ -535,9 +535,8 @@ export function MeBoard({
 
   const handleCreate = (zone: ZoneKey, title: string, team?: string | null) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // sprintStart = the team's current sprint (so Carry Over carries the card);
-    // startDate (below) = the viewed day, so it sits on the day it was created.
-    const sprintStart = currentSprint(board, team ?? null) ?? selectedDate;
+    // A card lives on exactly one day: startDate (origin) and sprintStart (its
+    // day) both equal the viewed day.
     const optimistic: CardModel = {
       itemId: tempId,
       title,
@@ -546,7 +545,7 @@ export function MeBoard({
       zone,
       day: selectedDate,
       startDate: selectedDate,
-      sprintStart,
+      sprintStart: selectedDate,
       team: team ?? undefined,
       createdAt: new Date().toISOString(),
       description: "",
@@ -559,7 +558,7 @@ export function MeBoard({
         zone,
         day: selectedDate,
         start: selectedDate,
-        sprintStart,
+        sprintStart: selectedDate,
         assigneeLogin: viewMe || null,
         team: team ?? null,
       })

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -529,10 +529,11 @@ export function MeBoard({
 
   const handleCreate = (zone: ZoneKey, title: string, team?: string | null) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // Join the team's current sprint (its explicit state) instead of starting a
-    // new one, so adding a card on a later day does not look like a new sprint
-    // and hide the rest. Fall back to the selected day when the team has none.
-    const sprintStart = currentSprint(board, team ?? null) ?? selectedDate;
+    // Join the team's current sprint (its explicit state); but creating on a day
+    // past it keeps the card on the viewed day instead of back-dating it. Fall
+    // back to the selected day when the team has none.
+    const cur = currentSprint(board, team ?? null) ?? selectedDate;
+    const sprintStart = selectedDate > cur ? selectedDate : cur;
     const optimistic: CardModel = {
       itemId: tempId,
       title,

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -17,6 +17,7 @@ import { AddCard } from "./AddCard";
 import { Dropdown } from "./Dropdown";
 import { TeamChips } from "./TeamChips";
 import { NotesPanel, type DayNote } from "./NotesPanel";
+import { ConnectDialog } from "./ConnectDialog";
 import { SortableBoard, type BoardGroup, type DropResult } from "./SortableBoard";
 import { globalOrderFromGroups, afterIdFor } from "./dndOrder";
 
@@ -79,6 +80,8 @@ export function MeBoard({
   // Impersonate: view (and act on) the board as another person.
   const [impersonated, setImpersonated] = useState<string | null>(null);
   const [impOpen, setImpOpen] = useState(false);
+  // MCP / API connect dialog.
+  const [connectOpen, setConnectOpen] = useState(false);
   const impRef = useRef<HTMLDivElement | null>(null);
   const viewMe = impersonated ?? me;
   // Other people with cards — offered in the "View as" impersonate picker.
@@ -825,7 +828,15 @@ export function MeBoard({
         <span className="me-day-stat">
           nice to have: {dayStats.green.done}/{dayStats.green.total}
         </span>
+        <button
+          type="button"
+          className="connect-link"
+          onClick={() => setConnectOpen(true)}
+        >
+          MCP / API
+        </button>
       </div>
+      {connectOpen && <ConnectDialog onClose={() => setConnectOpen(false)} />}
     </div>
   );
 }

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -535,11 +535,9 @@ export function MeBoard({
 
   const handleCreate = (zone: ZoneKey, title: string, team?: string | null) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // Join the team's current sprint (its explicit state); but creating on a day
-    // past it keeps the card on the viewed day instead of back-dating it. Fall
-    // back to the selected day when the team has none.
-    const cur = currentSprint(board, team ?? null) ?? selectedDate;
-    const sprintStart = selectedDate > cur ? selectedDate : cur;
+    // sprintStart = the team's current sprint (so Carry Over carries the card);
+    // startDate (below) = the viewed day, so it sits on the day it was created.
+    const sprintStart = currentSprint(board, team ?? null) ?? selectedDate;
     const optimistic: CardModel = {
       itemId: tempId,
       title,
@@ -560,7 +558,7 @@ export function MeBoard({
         title,
         zone,
         day: selectedDate,
-        start: sprintStart,
+        start: selectedDate,
         sprintStart,
         assigneeLogin: viewMe || null,
         team: team ?? null,

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -10,7 +10,7 @@ import type {
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
 import { todayIso, localDateIso, addDays } from "../date";
-import { currentSprint } from "../sprint";
+import { activeSprint, currentSprint } from "../sprint";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
 import { AddCard } from "./AddCard";
@@ -113,23 +113,22 @@ export function MeBoard({
     [board.cards, viewMe],
   );
 
-  // A card lives on exactly one day — its sprintStart. In Me it shows while that
-  // day sits at or after its team's current sprint and at or before the viewed
-  // day: the lower bound drops done/old cards from past sprints, the upper bound
-  // hides future-dated cards until their day arrives. A card with no team sprint
-  // or no sprintStart never shows.
+  // In Me a card shows when it belongs to the sprint that was active on the viewed
+  // day (activeSprint) and its scheduled day has arrived (startDate empty or on or
+  // before the viewed day). Today shows the current sprint; rolling back into the
+  // previous sprint's days shows that sprint's cards. A team with no active sprint
+  // on the day, or a card deferred to the future, never shows.
   const myCards = useMemo(
     () =>
       mine.filter((c) => {
         if (teamFocus && teamFilter && !teamFilter.includes(c.team ?? "")) {
           return false;
         }
-        const cur = currentSprint(board, c.team ?? null);
-        return Boolean(
-          cur &&
-            c.sprintStart &&
-            cur <= c.sprintStart &&
-            c.sprintStart <= selectedDate,
+        const as = activeSprint(board, c.team ?? null, selectedDate);
+        return (
+          as !== "" &&
+          c.sprintStart === as &&
+          (!c.startDate || c.startDate <= selectedDate)
         );
       }),
     [mine, board, selectedDate, teamFocus, teamFilter],
@@ -535,8 +534,10 @@ export function MeBoard({
 
   const handleCreate = (zone: ZoneKey, title: string, team?: string | null) => {
     const tempId = `tmp-${new Date().toISOString()}`;
-    // A card lives on exactly one day: startDate (origin) and sprintStart (its
-    // day) both equal the viewed day.
+    // The card is scheduled for the viewed day (startDate = selectedDate) and joins
+    // the team's current sprint (sprintStart), falling back to the viewed day when
+    // the team has no sprint yet.
+    const sprintStart = currentSprint(board, team ?? null) ?? selectedDate;
     const optimistic: CardModel = {
       itemId: tempId,
       title,
@@ -545,7 +546,7 @@ export function MeBoard({
       zone,
       day: selectedDate,
       startDate: selectedDate,
-      sprintStart: selectedDate,
+      sprintStart,
       team: team ?? undefined,
       createdAt: new Date().toISOString(),
       description: "",
@@ -558,7 +559,7 @@ export function MeBoard({
         zone,
         day: selectedDate,
         start: selectedDate,
-        sprintStart: selectedDate,
+        sprintStart,
         assigneeLogin: viewMe || null,
         team: team ?? null,
       })

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -73,6 +73,9 @@ export function MeBoard({
 }: MeBoardProps) {
   const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  // Eye toggle by the team chips: when on, show only the selected teams' cards.
+  // Deliberately not persisted — resets to off (show all) on reload.
+  const [teamFocus, setTeamFocus] = useState(false);
   // Impersonate: view (and act on) the board as another person.
   const [impersonated, setImpersonated] = useState<string | null>(null);
   const [impOpen, setImpOpen] = useState(false);
@@ -122,11 +125,14 @@ export function MeBoard({
         if (!start || !sprint || selectedDate < start) {
           return false;
         }
+        if (teamFocus && teamFilter && !teamFilter.includes(c.team ?? "")) {
+          return false;
+        }
         return (
           selectedDate <= sprint || currentSprint(board, c.team ?? null) === sprint
         );
       }),
-    [mine, board, selectedDate],
+    [mine, board, selectedDate, teamFocus, teamFilter],
   );
 
   const byZone = useMemo(() => {
@@ -644,6 +650,7 @@ export function MeBoard({
           onRename={onRenameTeam}
           canManage={false}
           noTeamChip
+          filterToggle={{ on: teamFocus, onToggle: () => setTeamFocus((v) => !v) }}
         />
 
         <div className="field field-inline impersonate" ref={impRef}>

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1122,12 +1122,10 @@ export function TeamBoard({
         .setSprintState(board, teamKey, selectedDate, null)
         .then(() => reload())
         .catch((err: unknown) => onError(errMessage(err)));
-    } else if (selectedDate > sprint) {
-      // Creating on a day past the current sprint keeps the card on that day
-      // instead of back-dating it into the (earlier) current sprint.
-      sprint = selectedDate;
     }
-    createTeamCard(engineer, zone, title, teamKey, sprint, sprint, todayIso());
+    // startDate = the viewed day (where the card sits); sprintStart = the current
+    // sprint (so Carry Over carries it). They differ when adding on a later day.
+    createTeamCard(engineer, zone, title, teamKey, selectedDate, sprint, todayIso());
   };
 
   // Carry over: advance the team's sprint to today (the prior current becomes the
@@ -1147,7 +1145,8 @@ export function TeamBoard({
     const carry = board.cards.filter(
       (c) =>
         (team === null ? c.team == null : c.team === team) &&
-        c.sprintStart === old &&
+        c.sprintStart &&
+        c.sprintStart < today &&
         c.stage !== "done" &&
         !c.itemId.startsWith("tmp-"),
     );

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1122,6 +1122,10 @@ export function TeamBoard({
         .setSprintState(board, teamKey, selectedDate, null)
         .then(() => reload())
         .catch((err: unknown) => onError(errMessage(err)));
+    } else if (selectedDate > sprint) {
+      // Creating on a day past the current sprint keeps the card on that day
+      // instead of back-dating it into the (earlier) current sprint.
+      sprint = selectedDate;
     }
     createTeamCard(engineer, zone, title, teamKey, sprint, sprint, todayIso());
   };

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1166,6 +1166,8 @@ export function TeamBoard({
     } catch (err: unknown) {
       onError(errMessage(err));
     }
+    // Land on the day the sprint was started on, so the new sprint is in view.
+    setSelectedDate(today);
     // Re-read the advanced state (and reconcile the carried cards).
     reload();
   };

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -15,7 +15,7 @@ import type {
 } from "../providers/types";
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
-import { todayIso, addDays, activeOnDay, mondayOf } from "../date";
+import { todayIso, addDays, mondayOf } from "../date";
 import { currentSprint, previousSprint } from "../sprint";
 import { teamColor } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
@@ -190,15 +190,11 @@ export function TeamBoard({
     [board.cards, teamFilter],
   );
 
-  // A card shows on every day of its [startDate, sprintStart] span. A fresh card
-  // (start === sprintStart) shows on its one sprint day; a card carried into a
-  // later sprint (sprintStart advanced past startDate) shows in BOTH its original
-  // sprint and the new one — carry over extends the task's span, not moves it.
+  // A card lives on exactly one day — its sprintStart — so it shows on the Team
+  // grid only on that day. Carry Over moves the day forward; send-to-next-day
+  // shifts it too. (startDate is just the card's origin and no longer filters.)
   const filteredCards = useMemo(
-    () =>
-      inFilter.filter((c) =>
-        activeOnDay(c.startDate, c.sprintStart, selectedDate),
-      ),
+    () => inFilter.filter((c) => c.sprintStart === selectedDate),
     [inFilter, selectedDate],
   );
 
@@ -1102,10 +1098,10 @@ export function TeamBoard({
       });
   };
 
-  // Creating a Team card joins the team's current sprint (from its explicit
-  // state). A team with no sprint yet starts its first one off this card. Start
-  // date is the sprint's start day, so the card shows only on that day and the
-  // day after stays empty (the cue to carry over).
+  // Creating a Team card puts it on the viewed day: startDate (origin) and
+  // sprintStart (its day) both equal selectedDate, so it shows only on that day.
+  // A team with no sprint yet records its first one on the state card, anchoring
+  // the Me view's lower bound.
   const handleCreate = (
     engineer: string,
     zone: ZoneKey,
@@ -1113,19 +1109,23 @@ export function TeamBoard({
     team?: string | null,
   ) => {
     const teamKey = team ?? null;
-    let sprint = currentSprint(board, teamKey);
-    if (sprint === null) {
+    if (currentSprint(board, teamKey) === null) {
       // First sprint for this team: record it on the state card, then reload to
-      // pick up the advance (later cards then join it).
-      sprint = selectedDate;
+      // pick it up as the Me lower-bound anchor.
       void provider
         .setSprintState(board, teamKey, selectedDate, null)
         .then(() => reload())
         .catch((err: unknown) => onError(errMessage(err)));
     }
-    // startDate = the viewed day (where the card sits); sprintStart = the current
-    // sprint (so Carry Over carries it). They differ when adding on a later day.
-    createTeamCard(engineer, zone, title, teamKey, selectedDate, sprint, todayIso());
+    createTeamCard(
+      engineer,
+      zone,
+      title,
+      teamKey,
+      selectedDate,
+      selectedDate,
+      todayIso(),
+    );
   };
 
   // Carry over: advance the team's sprint to today (the prior current becomes the

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -190,11 +190,18 @@ export function TeamBoard({
     [board.cards, teamFilter],
   );
 
-  // A card lives on exactly one day — its sprintStart — so it shows on the Team
-  // grid only on that day. Carry Over moves the day forward; send-to-next-day
-  // shifts it too. (startDate is just the card's origin and no longer filters.)
+  // The Team grid places a card on its effective day: its sprint (sprintStart)
+  // once materialized, but its scheduled day (startDate) while that is still in the
+  // future. So a materialized card sits on its sprint's start date (including ones
+  // created on later days), and a deferred card shows on its own future day,
+  // rejoining the sprint day once today catches up.
   const filteredCards = useMemo(
-    () => inFilter.filter((c) => c.sprintStart === selectedDate),
+    () =>
+      inFilter.filter((c) => {
+        const eff =
+          c.startDate && c.startDate > todayIso() ? c.startDate : c.sprintStart;
+        return eff === selectedDate;
+      }),
     [inFilter, selectedDate],
   );
 
@@ -1098,10 +1105,10 @@ export function TeamBoard({
       });
   };
 
-  // Creating a Team card puts it on the viewed day: startDate (origin) and
-  // sprintStart (its day) both equal selectedDate, so it shows only on that day.
-  // A team with no sprint yet records its first one on the state card, anchoring
-  // the Me view's lower bound.
+  // Creating a Team card joins the team's current sprint (sprintStart) and is
+  // scheduled for the viewed day (startDate = selectedDate). A team with no sprint
+  // yet records its first one on the state card and the card joins it, so the Me
+  // view has a sprint anchor.
   const handleCreate = (
     engineer: string,
     zone: ZoneKey,
@@ -1109,9 +1116,11 @@ export function TeamBoard({
     team?: string | null,
   ) => {
     const teamKey = team ?? null;
-    if (currentSprint(board, teamKey) === null) {
+    const cur = currentSprint(board, teamKey);
+    const sprint = cur ?? selectedDate;
+    if (cur === null) {
       // First sprint for this team: record it on the state card, then reload to
-      // pick it up as the Me lower-bound anchor.
+      // pick it up as the Me sprint anchor.
       void provider
         .setSprintState(board, teamKey, selectedDate, null)
         .then(() => reload())
@@ -1123,7 +1132,7 @@ export function TeamBoard({
       title,
       teamKey,
       selectedDate,
-      selectedDate,
+      sprint,
       todayIso(),
     );
   };

--- a/web/src/components/TeamChips.tsx
+++ b/web/src/components/TeamChips.tsx
@@ -18,6 +18,8 @@ interface TeamChipsProps {
   canManage?: boolean;
   /** When set, show a "manage" link that opens the roster manager. */
   onManage?: () => void;
+  /** Optional eye toggle (Me board): focus the board on the selected teams. */
+  filterToggle?: { on: boolean; onToggle: () => void };
 }
 
 /** TeamChips is a single-select row of team chips with add/remove/rename. */
@@ -32,6 +34,7 @@ export function TeamChips({
   noTeamChip = false,
   canManage = true,
   onManage,
+  filterToggle,
 }: TeamChipsProps) {
   const [adding, setAdding] = useState(false);
   const [addValue, setAddValue] = useState("");
@@ -152,6 +155,34 @@ export function TeamChips({
               <span className="team-chip-name team-col-unassigned">No team</span>
             </button>
           </span>
+        )}
+        {filterToggle && (
+          <button
+            type="button"
+            className={`team-eye${filterToggle.on ? " team-eye-on" : ""}`}
+            onClick={filterToggle.onToggle}
+            aria-pressed={filterToggle.on}
+            title={
+              filterToggle.on
+                ? "Showing only the selected teams — click to show all"
+                : "Show only the selected teams"
+            }
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+          </button>
         )}
         {canManage &&
           (adding ? (

--- a/web/src/date.ts
+++ b/web/src/date.ts
@@ -15,19 +15,21 @@ export function localDateIso(iso: string): string {
   return new Date(d.getTime() - off * 60_000).toISOString().slice(0, 10);
 }
 
-/** activeOnDay is true when `day` falls within a card's [start, finish] range.
- * A missing bound collapses to the other date, so a card with a single date is
- * active only on that day; a card with neither date is never on the day board. */
+/** activeOnDay is true when `day` falls within a card's visible span. The span
+ * runs from `start` (the card's day) to the later of start/finish, so a card
+ * whose start day is past its sprint (added on a later day) still shows on its
+ * day, while a carried card shows from its origin through the current sprint. A
+ * card with neither date is never on the day board. */
 export function activeOnDay(
   start: string | undefined,
   finish: string | undefined,
   day: string,
 ): boolean {
-  const from = start ?? finish;
-  const to = finish ?? start;
-  if (!from || !to) {
+  const from = start || finish;
+  if (!from) {
     return false;
   }
+  const to = finish && finish > from ? finish : from;
   return from <= day && day <= to;
 }
 

--- a/web/src/sprint.ts
+++ b/web/src/sprint.ts
@@ -17,6 +17,27 @@ export function previousSprint(
   return board.sprintStates[team ?? ""]?.previous ?? null;
 }
 
+/** activeSprint returns which sprint was current for a team on a given day: the
+ * team's current sprint when day is on or after it, else the previous sprint when
+ * day is on or after that, else "" (only the last two sprints are tracked). The
+ * Me view groups a day's cards by this. It mirrors ActiveSprint in
+ * internal/board/sprint.go. team = null is the no-team group. */
+export function activeSprint(
+  board: Board,
+  team: string | null,
+  day: string,
+): string {
+  const cur = currentSprint(board, team);
+  const prev = previousSprint(board, team);
+  if (cur && day >= cur) {
+    return cur;
+  }
+  if (prev && day >= prev) {
+    return prev;
+  }
+  return "";
+}
+
 /** currentSprintByTeam maps each team key (team name, or "" for no team) to its
  * current sprint date: the latest sprintStart on or before `asOf`. */
 export function currentSprintByTeam(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -647,6 +647,29 @@ button {
   background: var(--bg-soft);
 }
 
+/* eye toggle by the team chips (Me board): focus on the selected teams */
+.team-eye {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 4px;
+  border-radius: 10px;
+  line-height: 0;
+}
+
+.team-eye:hover {
+  color: var(--fg);
+}
+
+.team-eye-on {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--bg-soft);
+}
+
 .team-chips .team-add-input {
   width: 110px;
   flex: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -310,6 +310,22 @@ button {
   color: var(--muted);
 }
 
+/* "MCP / API" connect button at the right edge of the day status bar. */
+.connect-link {
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: auto;
+  padding: 0;
+}
+
+.connect-link:hover {
+  color: var(--fg);
+}
+
 /* ---- colour zone areas with a rotated label on the left spine ---- */
 /* A flex row [spine | cards]: the spine's vertical text sets a natural height,
    so the zone never shrinks below its label. */
@@ -1848,6 +1864,80 @@ button.card-age {
   gap: 8px;
   padding: 12px 16px;
   border-top: 1px solid var(--line-soft);
+}
+
+/* ---- connect (MCP / API) dialog ---- */
+.connect-dialog {
+  width: 520px;
+}
+
+.connect-section {
+  margin-bottom: 18px;
+}
+
+.connect-section:last-child {
+  margin-bottom: 0;
+}
+
+.connect-heading {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.connect-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.connect-cmd {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  color: var(--fg);
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.connect-cmd a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.connect-cmd a:hover {
+  text-decoration: underline;
+}
+
+.connect-copy {
+  flex: none;
+  align-self: flex-start;
+  font: inherit;
+  font-size: 12px;
+  padding: 6px 10px;
+  color: var(--muted);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.connect-copy:hover {
+  color: var(--fg);
+  background: var(--bg-soft);
+}
+
+.connect-caption {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  color: var(--muted);
 }
 
 /* ---- manage teams modal ---- */


### PR DESCRIPTION
## Why

aeman's value is its **custom board logic** — sprints, review cards, the day/sprint visibility rules — layered **over** the storage backend, not baked into it. This branch moves that logic out of the React frontend into the Go core, so the native API and the MCP server behave exactly like the UI, and so the backend (GitHub Projects v2 today) becomes a **swappable** detail behind one interface — a future git-based backend would be a new adapter, with the sprint/review/filter logic untouched.

## What changed

**Backend-agnostic board core**
- `internal/board` — pure logic ported from the frontend: the two-date model, the Team / Me / Weekly view filters, sprint pointers, and the status/progress rules. No backend dependency.
- `internal/boardservice` — a `Backend` interface (mirrors the frontend `Provider`) and a `Service` that performs the same actions the UI does (create, carry over, send-to-review + reassign/remove, set stage / in-progress / progress, set team/assignee, plan, move, delete cascade, …), computing each change with `internal/board` and applying it through the `Backend`.
- `internal/ghprojects` now implements `Backend` (maps the GraphQL into the board domain, all setters, sprint-state) and **paginates** the board load (previously only the first 100 items were fetched).

**API and MCP over the core**
- The native `/api/v1` API is rewritten over `boardservice` (board / team / me / weekly views + the action endpoints), plus a public `GET /api/v1` catalog.
- The MCP server's tools are rewritten over `boardservice` — the same operations. The old thin-proxy implementations are removed.

**Hosted MCP with GitHub OAuth**
- The MCP server is served over HTTP at `/mcp` (StreamableHTTP), with an OAuth 2.0 authorization layer (protected-resource + authorization-server metadata, dynamic client registration, `/oauth/authorize` + `/oauth/token` with PKCE) reusing aeman's existing GitHub OAuth. Each MCP request runs with the caller's own GitHub token. The stdio `aeman mcp` command still works.

**Two-field date model**
- A card carries `sprintStart` (the sprint it belongs to) and `startDate` (its scheduled day). Team shows a card on its *effective day* — the sprint day once materialized, its scheduled day while still in the future; Me shows the sprint that was current on the viewed day (rolling back shows the previous sprint). Documented in `docs/dates.md`, kept in sync with the code.

**UI**
- A **"MCP / API"** connect dialog in the Me status bar — the `claude mcp add` command and the `/api/v1` catalog link, with copy buttons.
- Plus: lock a card without a reason comment, a team-focus "eye" toggle in Me, Carry Over jumps the view to today, the create/visibility fixes that drove the date model, and a couple of smaller board tweaks.

## Notes

- All gates pass: `go build` / `go test ./...`, `golangci-lint` (0 issues), `gofmt`, frontend `tsc` + build.
- The web app uses the `/api/github` GraphQL proxy (not `/api/v1`), so the API rewrite does not affect it.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein
