### PR TITLE
feat(web): refine card status badges, zone separators, and hover actions

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -275,6 +275,7 @@ export function Card({
           autoFocus
           value={draft}
           onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
             e.stopPropagation();
@@ -303,6 +304,15 @@ export function Card({
           title="Rename"
         >
           ✎
+        </button>
+        <button
+          type="button"
+          className="card-action card-action-delete"
+          onClick={handleDelete}
+          aria-label="Delete card"
+          title="Delete"
+        >
+          ×
         </button>
         <div className="card-stage" ref={menuRef}>
           <button
@@ -354,16 +364,55 @@ export function Card({
             )}
           </Dropdown>
         </div>
-        <button
-          type="button"
-          className="card-action card-action-delete"
-          onClick={handleDelete}
-          aria-label="Delete card"
-          title="Delete"
-        >
-          ×
-        </button>
       </span>
+
+      {card.stage === "review" && (
+        <span
+          className="card-status-badge card-review-badge"
+          style={{ color: STAGES.review.color }}
+          title="On review"
+        >
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 2v6h-6" />
+            <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+            <path d="M3 22v-6h6" />
+            <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+          </svg>
+        </span>
+      )}
+      {card.stage === "locked" && (
+        <span
+          className="card-status-badge card-locked-badge"
+          style={{ color: STAGES.locked.color }}
+          title="Locked"
+        >
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 3 2 21h20L12 3z" />
+            <line x1="12" y1="10" x2="12" y2="15" />
+            <line x1="12" y1="18" x2="12.01" y2="18" />
+          </svg>
+        </span>
+      )}
 
       {card.createdAt && (
         <div

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1391,6 +1391,9 @@ export function TeamBoard({
                 className={`zone-area${isOver ? " zone-area-dragover" : ""}`}
                 style={{ background: def.background, borderLeftColor: def.accent }}
               >
+                <span className="zone-spine" style={{ color: def.accent }}>
+                  {def.spine}
+                </span>
                 <div className="zone-cards">
                   {body}
                   <AddCard

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -284,7 +284,7 @@ button {
   align-items: flex-start;
 }
 
-/* The colour bands form one continuous block with rounded outer corners. */
+/* The colour bands form one rounded block; zones are split by a dashed line. */
 .me-zones {
   display: flex;
   flex-direction: column;
@@ -344,6 +344,11 @@ button {
   outline-offset: -2px;
 }
 
+/* A light dashed separator between stacked zones, like the weekly plan. */
+.zone-area + .zone-area {
+  border-top: 1px dashed var(--line);
+}
+
 /* The zone's name set vertically on the left (rotated 270°, reading bottom-to-
    top) like a book spine. As a flex item its vertical text length is the zone's
    natural height, so the area never becomes shorter than the label. */
@@ -396,6 +401,14 @@ button {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  padding-top: 4px;
+}
+
+/* Keep "+ add" at the bottom of the zone when there is free space (e.g. an
+   empty zone made tall by its spine label), without a gap when cards fill it. */
+.zone-cards > .add-card,
+.zone-cards > .add-card-form {
+  margin-top: auto;
 }
 
 /* ---- compact card (fixed 500 × 37) ---- */
@@ -945,7 +958,6 @@ button.team-avatar {
 
 .card-age {
   flex: none;
-  width: 24px;
   text-align: right;
   font-size: 10px;
   font-weight: 700;
@@ -1158,6 +1170,21 @@ button.card-age {
   color: var(--faint);
   border-bottom: 1px solid var(--line);
   white-space: nowrap;
+}
+
+/* Status indicator shown before the day counter: a two-arrow cycle for a review
+   with no reviewer, a warning sign for locked. Hidden on hover, where the card's
+   actions take its place. */
+.card-status-badge {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.card:hover .card-status-badge {
+  display: none;
 }
 
 .card-bar {


### PR DESCRIPTION
## Summary

UI refinements to the card and zone presentation from a round of preview-driven tweaks.

- **Zone separators** — stacked colour zones are split by a light dashed line (like the weekly plan) instead of a gap, with their rounded corners restored. The "+ add" button stays pinned to the bottom of a zone, and the zone spine labels now show in the Team view too.
- **Card status indicators** — a small indicator sits just before the day counter: a two-arrow cycle for cards on review and a warning sign for locked cards. On hover it gives way to the card's actions.
- **Hover actions** — reordered to rename, delete, status, so the status flag lands where the indicator was.
- **Bugfix** — a double-click inside the title editor no longer opens the card popup.

## Testing

- `npm run build` (tsc + vite) — passes
- `go build`, `go vet`, `go test ./...` — pass
- `golangci-lint run` — 0 issues
