### PR TITLE
feat(web): rework card status flag, fold notes on mobile, shuffle/order toggle

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -298,7 +298,7 @@ export function Card({
       <span className="card-actions" aria-hidden={false}>
         <button
           type="button"
-          className="card-action"
+          className="card-action card-hoveronly"
           onClick={startEdit}
           aria-label="Rename card"
           title="Rename"
@@ -307,26 +307,70 @@ export function Card({
         </button>
         <button
           type="button"
-          className="card-action card-action-delete"
+          className="card-action card-hoveronly card-action-delete"
           onClick={handleDelete}
           aria-label="Delete card"
           title="Delete"
         >
           ×
         </button>
-        <div className="card-stage" ref={menuRef}>
+        <div
+          className={`card-stage${card.stage === "review" || card.stage === "locked" ? "" : " card-hoveronly"}`}
+          ref={menuRef}
+        >
           <button
             type="button"
-            className="card-action"
+            className="card-action card-status-btn"
             onClick={(e) => {
               e.stopPropagation();
               setMenuOpen((o) => !o);
             }}
             aria-label="Set status"
-            title="Status"
+            title={
+              card.stage === "review"
+                ? "On review"
+                : card.stage === "locked"
+                  ? "Locked"
+                  : "Status"
+            }
             style={card.stage ? { color: STAGES[card.stage].color } : undefined}
           >
-            ⚑
+            {card.stage === "review" ? (
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 2v6h-6" />
+                <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                <path d="M3 22v-6h6" />
+                <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+              </svg>
+            ) : card.stage === "locked" ? (
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 3 2 21h20L12 3z" />
+                <line x1="12" y1="10" x2="12" y2="15" />
+                <line x1="12" y1="18" x2="12.01" y2="18" />
+              </svg>
+            ) : (
+              "⚑"
+            )}
           </button>
           <Dropdown
             open={menuOpen}
@@ -365,54 +409,6 @@ export function Card({
           </Dropdown>
         </div>
       </span>
-
-      {card.stage === "review" && (
-        <span
-          className="card-status-badge card-review-badge"
-          style={{ color: STAGES.review.color }}
-          title="On review"
-        >
-          <svg
-            width="11"
-            height="11"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M21 2v6h-6" />
-            <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-            <path d="M3 22v-6h6" />
-            <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-          </svg>
-        </span>
-      )}
-      {card.stage === "locked" && (
-        <span
-          className="card-status-badge card-locked-badge"
-          style={{ color: STAGES.locked.color }}
-          title="Locked"
-        >
-          <svg
-            width="11"
-            height="11"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M12 3 2 21h20L12 3z" />
-            <line x1="12" y1="10" x2="12" y2="15" />
-            <line x1="12" y1="18" x2="12.01" y2="18" />
-          </svg>
-        </span>
-      )}
 
       {card.createdAt && (
         <div

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type Ref } from "react";
+import { useEffect, useMemo, useRef, useState, type Ref } from "react";
 import type {
   Board,
   Card as CardModel,
@@ -82,6 +82,18 @@ export function MeBoard({
   const [impOpen, setImpOpen] = useState(false);
   // MCP / API connect dialog.
   const [connectOpen, setConnectOpen] = useState(false);
+
+  // Notes fold to a header bar on narrow screens (like the Team weekly plan) and
+  // stay open as a side pane on wide ones; the breakpoint matches .me-panes.
+  const [notesCollapsed, setNotesCollapsed] = useState(
+    () => window.matchMedia("(max-width: 820px)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 820px)");
+    const onChange = (e: MediaQueryListEvent) => setNotesCollapsed(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
   const impRef = useRef<HTMLDivElement | null>(null);
   const viewMe = impersonated ?? me;
   // Other people with cards — offered in the "View as" impersonate picker.
@@ -804,6 +816,8 @@ export function MeBoard({
           onAddNote={handleAddNote}
           onEditNote={handleEditNote}
           onDeleteNote={handleDeleteNote}
+          collapsed={notesCollapsed}
+          onToggleCollapse={() => setNotesCollapsed((c) => !c)}
         />
       </div>
       <div className="me-day-progress" title={`${dayProgress}% done today`}>

--- a/web/src/components/NotesPanel.tsx
+++ b/web/src/components/NotesPanel.tsx
@@ -19,6 +19,9 @@ interface NotesPanelProps {
   onAddNote: (text: string) => void;
   onEditNote: (note: Note, card: CardModel, text: string) => void;
   onDeleteNote: (note: Note, card: CardModel) => void;
+  /** Fold to just the header bar (used on narrow screens). */
+  collapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 /** localTime formats an ISO timestamp as a local HH:MM string. */
@@ -40,6 +43,8 @@ export function NotesPanel({
   onAddNote,
   onEditNote,
   onDeleteNote,
+  collapsed,
+  onToggleCollapse,
 }: NotesPanelProps) {
   const [draft, setDraft] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -161,29 +166,40 @@ export function NotesPanel({
   );
 
   return (
-    <aside className="notes">
+    <aside className={`notes${collapsed ? " notes-collapsed" : ""}`}>
       <header className="notes-header">
         <span>Notes — {selectedDate}</span>
-        <div className="notes-group-toggle" role="tablist" aria-label="Group notes">
+        <div className="notes-header-right">
+          <div className="notes-group-toggle" role="tablist" aria-label="Group notes">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={group === "time"}
+              className={`notes-group-btn${group === "time" ? " notes-group-btn-on" : ""}`}
+              onClick={() => setGroup("time")}
+              title="Group by timeline"
+            >
+              Time
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={group === "card"}
+              className={`notes-group-btn${group === "card" ? " notes-group-btn-on" : ""}`}
+              onClick={() => setGroup("card")}
+              title="Group by card"
+            >
+              Card
+            </button>
+          </div>
           <button
             type="button"
-            role="tab"
-            aria-selected={group === "time"}
-            className={`notes-group-btn${group === "time" ? " notes-group-btn-on" : ""}`}
-            onClick={() => setGroup("time")}
-            title="Group by timeline"
+            className="notes-toggle"
+            onClick={onToggleCollapse}
+            aria-label={collapsed ? "Expand notes" : "Collapse notes"}
+            title={collapsed ? "Expand" : "Collapse"}
           >
-            Time
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={group === "card"}
-            className={`notes-group-btn${group === "card" ? " notes-group-btn-on" : ""}`}
-            onClick={() => setGroup("card")}
-            title="Group by card"
-          >
-            Card
+            {collapsed ? "▲" : "▼"}
           </button>
         </div>
       </header>

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -495,6 +495,14 @@ export function TeamBoard({
     setColumnOrder(people);
   };
 
+  // The Shuffle button flips to "Ordered" once the columns differ from the
+  // default order (you first, then the rest); clicking "Ordered" restores it.
+  const isDefaultOrder = useMemo(() => {
+    const def = engineers.filter((e) => e !== UNASSIGNED);
+    const cur = orderedEngineers.filter((e) => e !== UNASSIGNED);
+    return cur.length === def.length && cur.every((e, i) => e === def[i]);
+  }, [engineers, orderedEngineers]);
+
   // New cards default to the filtered team; null = all (show picker), "" = no team.
   const forcedTeam = useMemo(
     () => (teamFilter?.length === 1 ? teamFilter[0] || null : undefined),
@@ -1229,11 +1237,52 @@ export function TeamBoard({
         <button
           type="button"
           className="btn shuffle-btn"
-          onClick={shuffleColumns}
-          title="Shuffle columns"
-          aria-label="Shuffle columns"
+          onClick={isDefaultOrder ? shuffleColumns : () => setColumnOrder([])}
+          title={
+            isDefaultOrder
+              ? "Shuffle columns"
+              : "Restore default order (you first)"
+          }
+          aria-label={
+            isDefaultOrder ? "Shuffle columns" : "Restore default order"
+          }
         >
-          ⇄
+          {isDefaultOrder ? (
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22" />
+              <path d="m18 2 4 4-4 4" />
+              <path d="M2 6h1.9c1.5 0 2.9.9 3.6 2.2" />
+              <path d="M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8" />
+              <path d="m18 14 4 4-4 4" />
+            </svg>
+          ) : (
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M2 8h16" />
+              <path d="m18 4 4 4-4 4" />
+              <path d="M2 16h16" />
+              <path d="m18 12 4 4-4 4" />
+            </svg>
+          )}
         </button>
         <button
           type="button"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -885,6 +885,10 @@ button.team-avatar {
 
 .shuffle-btn {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
 }
 
 .sprint-wrap {
@@ -1172,21 +1176,6 @@ button.card-age {
   white-space: nowrap;
 }
 
-/* Status indicator shown before the day counter: a two-arrow cycle for a review
-   with no reviewer, a warning sign for locked. Hidden on hover, where the card's
-   actions take its place. */
-.card-status-badge {
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 0;
-}
-
-.card:hover .card-status-badge {
-  display: none;
-}
-
 .card-bar {
   position: absolute;
   left: 6px;
@@ -1255,15 +1244,6 @@ button.card-age {
   align-items: center;
   gap: 1px;
   flex: none;
-  opacity: 0;
-  width: 0;
-  overflow: hidden;
-  transition: opacity 0.1s;
-}
-
-.card:hover .card-actions {
-  opacity: 1;
-  width: auto;
 }
 
 .card-action {
@@ -1277,6 +1257,9 @@ button.card-age {
   line-height: 1;
   cursor: pointer;
   border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .card-action:hover {
@@ -1286,6 +1269,24 @@ button.card-age {
 
 .card-stage {
   position: relative;
+  display: inline-flex;
+  /* The status button sits last in the actions group, right before the day
+     counter; a small negative margin pulls its icon to the tight gap the
+     review/locked indicators read at (the 18px hit area is otherwise looser). */
+  margin-right: -3px;
+}
+
+/* Rename, delete, and the status flag (only on cards without a review/locked
+   state) appear on hover. Touch devices have no hover, so they stay hidden there
+   and such cards are managed from the popup. The review/locked indicators carry
+   no .card-hoveronly, so they always show. */
+.card-action.card-hoveronly,
+.card-stage.card-hoveronly {
+  display: none;
+}
+
+.card:hover .card-action.card-hoveronly,
+.card:hover .card-stage.card-hoveronly {
   display: inline-flex;
 }
 
@@ -1414,6 +1415,41 @@ button.card-age {
   display: flex;
   gap: 2px;
   flex: none;
+}
+
+.notes-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* The notes fold to just their header on narrow screens (where they stack under
+   the board), like the Team weekly plan. The toggle is hidden on wide screens,
+   where notes stay open as a side pane. */
+.notes-toggle {
+  display: none;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 8px;
+  color: var(--muted);
+  flex: none;
+}
+
+.notes-collapsed .notes-list,
+.notes-collapsed .notes-composer,
+.notes-collapsed .notes-group-toggle {
+  display: none;
+}
+
+@media (max-width: 820px) {
+  .notes-toggle {
+    display: inline-flex;
+    align-items: center;
+  }
 }
 
 .notes-group-btn {
@@ -2082,14 +2118,6 @@ button.card-age {
     border-left: none;
     border-top: 1px solid var(--line);
     max-height: 40%;
-  }
-}
-
-/* Touch devices have no hover, so a card's actions must stay visible. */
-@media (hover: none) {
-  .card-actions {
-    opacity: 1;
-    width: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Three preview-reviewed UI refinements to the board cards and toolbars.

- **Card status flag** — the status control is one icon just before the day counter. The review (two-arrow) and locked (warning) indicators stay visible at all times; the plain flag, like rename and delete, appears only on hover, freeing that space for the title otherwise. The three hover actions form one tight group (rename, delete, status) and are hidden on touch devices.
- **Notes on narrow screens** — notes fold to a header bar (like the Team weekly plan) on narrow/mobile layouts and stay open as a side pane on wide ones, tracking the 820px breakpoint.
- **Shuffle / Order toggle** — the Team shuffle control toggles between shuffling the people columns and restoring the default order (you first), with crossed-arrow and parallel-arrow icons for the two states.

## Testing

- `npm run build` (tsc + vite) — passes
- `go build`, `go vet`, `go test ./...` — pass
- `golangci-lint run` — 0 issues
