### PR TITLE
feat(web): show the card's creator in the assign menu

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -588,6 +588,11 @@ export function Card({
             onClose={() => setAssignOpen(false)}
             className="card-stage-menu card-assign-menu"
           >
+            {card.author && (
+              <div className="card-counterpart-head">
+                Created by: {displayName(card.author, users?.[card.author])}
+              </div>
+            )}
             {counterpartAssignees && counterpartAssignees.length > 0 && (
               <div className="card-counterpart-head">
                 {card.reviewOf ? "In implementation" : "On review"}:{" "}

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -83,6 +83,9 @@ interface RawContent {
   url?: string;
   state?: string;
   body?: string;
+  /** Creator of a draft issue; issues/PRs expose the same person as `author`. */
+  creator?: { login: string } | null;
+  author?: { login: string } | null;
   repository?: { nameWithOwner: string };
   assignees?: { nodes: { login: string }[] };
   comments?: { nodes: RawComment[] };
@@ -214,6 +217,7 @@ function mapItem(item: RawItem, roles: FieldRoles): Card {
     repository: content?.repository?.nameWithOwner,
     state: content?.state,
     assignees: content?.assignees?.nodes.map((n) => n.login) ?? [],
+    author: content?.creator?.login ?? content?.author?.login,
     createdAt: item.createdAt,
     description,
     notes,

--- a/web/src/providers/github/queries.ts
+++ b/web/src/providers/github/queries.ts
@@ -24,16 +24,19 @@ const PROJECT_BODY = `
         __typename
         ... on DraftIssue {
           id title body
+          creator { login }
           assignees(first: 10) { nodes { login } }
         }
         ... on Issue {
           id number title body url state
+          author { login }
           repository { nameWithOwner }
           assignees(first: 10) { nodes { login } }
           comments(last: 20) { nodes { id body createdAt author { login } } }
         }
         ... on PullRequest {
           id number title body url state
+          author { login }
           repository { nameWithOwner }
           assignees(first: 10) { nodes { login } }
           comments(last: 20) { nodes { id body createdAt author { login } } }

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -53,6 +53,8 @@ export interface Card {
   repository?: string;
   state?: string;
   assignees: string[];
+  /** GitHub login of the card's creator (draft-issue creator or issue author). */
+  author?: string;
   /** ISO timestamp the item was added to the project (its age on the board). */
   createdAt?: string;
   zoneOptionId?: string;


### PR DESCRIPTION
## Summary

The card's assign menu now shows who created the card. The GitHub provider fetches the draft-issue creator (or the issue/PR author) and exposes it as the card's `author`; a "Created by: <name>" line appears at the top of the assign menu, above the review counterpart, so a card's origin is always visible.

Frontend-only — the query change goes through the existing `/api/github/graphql` proxy; no Go changes.

## Testing

- `npm run build` (tsc + vite) — passes
- `go build ./...` — builds
- `golangci-lint run` — 0 issues
