### PR TITLE
feat(board): keep carried-over cards in their origin sprint; refine team pickers

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -56,6 +56,10 @@ its sprint, or deferred with send-to-next-day.
 - A card shows on its **effective day**: its sprint (`sprintStart`) once it has
   materialized (`startDate <= today`), but its scheduled day (`startDate`) while
   that is still in the future. Show iff `effectiveDay === selectedDate`.
+- It **also** shows on the **previous** sprint's start day when it was carried
+  over from there (`sprintStart > previousSprint` and its origin sprint,
+  `activeSprint(team, startDate)`, is on or before it) — so navigating back to the
+  previous sprint shows it complete, carried-over cards included.
 - A **materialized** card therefore sits on its sprint's start date, so the team
   lead navigates there to see **all** that sprint's cards, including ones created
   on later days of the sprint.
@@ -64,13 +68,14 @@ its sprint, or deferred with send-to-next-day.
   to its `startDate`.
 
 ### Me view — a personal day (`selectedDate`)
-- A card (assigned to the viewer) shows when its scheduled day has arrived and it
-  belongs to the sprint that was current on the viewed day:
-  `startDate <= selectedDate` **AND** `sprintStart === activeSprint(team, selectedDate)`.
-- So **today** shows the current sprint's cards (everything from the sprint's
-  start up to today). Rolling **back** into the previous sprint's days shows that
-  sprint's cards — e.g. a card you completed in the previous sprint reappears when
-  you scroll to a day that fell inside it.
+- A card (assigned to the viewer) shows when its scheduled day has arrived and the
+  viewed day falls in a sprint the card **spans** — from the one it started in up
+  to the sprint it now belongs to: `startDate <= selectedDate` **AND**
+  `activeSprint(team, selectedDate) <= sprintStart`.
+- So **today** shows the current sprint's cards. Rolling **back** into the
+  previous sprint's days shows that sprint's cards — including the **carried-over**
+  ones, which stay visible on the days of the sprint they came from (not only the
+  cards that were completed there).
 - A deferred card (`startDate` in the future) is not shown until that day.
 - The team-focus "eye" toggle further narrows to the selected teams (not
   persisted, off by default).
@@ -80,6 +85,9 @@ its sprint, or deferred with send-to-next-day.
 - Else: sets sprint-state to (current = today, previous = old current), and for
   every **unfinished** card with `sprintStart < today`, sets `sprintStart = today`.
   Future-dated and **done** cards stay put. Then the view jumps to today.
+- A carried card keeps its `startDate`, so it stays visible on the days of the
+  sprint it came from (see the Team / Me rules): Carry Over adds it to the new
+  sprint without removing it from the previous one.
 
 ### Send to next day
 - The per-card "+1 day" / "-1 day" control moves **`startDate`** by a day
@@ -91,9 +99,11 @@ its sprint, or deferred with send-to-next-day.
 
 1. **Two fields.** `sprintStart` = sprint, `startDate` = scheduled day. (The
    one-field "single-day" model is dropped.)
-2. **Me by the active sprint on the viewed day** (current, or previous when
-   scrolled back), gated by `startDate <= selectedDate`.
+2. **Me by the sprints a card spans on the viewed day** —
+   `activeSprint(team, day) <= sprintStart`, gated by `startDate <= selectedDate`,
+   so a carried-over card stays visible in the previous sprint it came from.
 3. **Team by a card's effective day** — `sprintStart` once materialized, else the
-   future `startDate`; a deferred card shows on its own day, not the sprint day.
+   future `startDate`; plus the previous sprint's start day when the card was
+   carried over from there.
 4. **Send-to-next-day moves `startDate`** (not the sprint).
 5. The existing telemetry card is left as-is (the owner will move it).

--- a/internal/board/filters.go
+++ b/internal/board/filters.go
@@ -17,11 +17,29 @@ func TeamGrid(b Board, team, day string) []Card {
 		if c.Team != team {
 			continue
 		}
+		future := c.StartDate != "" && c.StartDate > today
 		eff := c.SprintStart
-		if c.StartDate != "" && c.StartDate > today {
+		if future {
 			eff = c.StartDate
 		}
 		if eff == day {
+			out = append(out, c)
+			continue
+		}
+		// A carried-over card also shows on the previous sprint's start day —
+		// its origin — so scrolling back shows that sprint in full.
+		if future {
+			continue
+		}
+		prev := PreviousSprint(b, team)
+		if prev == "" || day != prev || c.SprintStart == "" || c.SprintStart <= prev {
+			continue
+		}
+		start := c.StartDate
+		if start == "" {
+			start = c.SprintStart
+		}
+		if ActiveSprint(b, team, start) <= prev {
 			out = append(out, c)
 		}
 	}
@@ -42,7 +60,10 @@ func MeView(b Board, user, day string) []Card {
 			continue
 		}
 		as := ActiveSprint(b, c.Team, day)
-		if as != "" && c.SprintStart == as && (c.StartDate == "" || c.StartDate <= day) {
+		// A card shows on every day of the sprints it spans — from the one it
+		// started in up to the sprint it now belongs to — so a carried-over card
+		// still appears on the previous sprint's days it came from.
+		if as != "" && as <= c.SprintStart && (c.StartDate == "" || c.StartDate <= day) {
 			out = append(out, c)
 		}
 	}

--- a/web/src/components/AddCard.tsx
+++ b/web/src/components/AddCard.tsx
@@ -8,6 +8,9 @@ interface AddCardProps {
   teams?: string[];
   /** When set, skip the picker and always create with this team. */
   forcedTeam?: string | null;
+  /** Offer the "no team" option; when false, the picker defaults to the first
+   *  team instead of "no team". */
+  allowNoTeam?: boolean;
 }
 
 /** AddCard expands into a title input with an integrated team picker. */
@@ -16,10 +19,15 @@ export function AddCard({
   placeholder = "Add a card…",
   teams,
   forcedTeam,
+  allowNoTeam = true,
 }: AddCardProps) {
+  // With "no team" disabled the picker starts on the first team, so a filtered
+  // create lands on a real team by default instead of "no team".
+  const defaultTeam =
+    allowNoTeam || !teams || teams.length === 0 ? null : teams[0];
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
-  const [team, setTeam] = useState<string | null>(null);
+  const [team, setTeam] = useState<string | null>(defaultTeam);
   const [menuOpen, setMenuOpen] = useState(false);
   const formRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -30,7 +38,7 @@ export function AddCard({
   const close = () => {
     setOpen(false);
     setValue("");
-    setTeam(null);
+    setTeam(defaultTeam);
     setMenuOpen(false);
   };
 
@@ -70,7 +78,14 @@ export function AddCard({
 
   if (!open) {
     return (
-      <button type="button" className="add-card" onClick={() => setOpen(true)}>
+      <button
+        type="button"
+        className="add-card"
+        onClick={() => {
+          setTeam(defaultTeam);
+          setOpen(true);
+        }}
+      >
         + add
       </button>
     );
@@ -110,13 +125,15 @@ export function AddCard({
           </button>
           {menuOpen && (
             <div className="add-card-team-menu">
-              <button
-                type="button"
-                className="add-card-team-item"
-                onClick={() => pickTeam(null)}
-              >
-                no team
-              </button>
+              {allowNoTeam && (
+                <button
+                  type="button"
+                  className="add-card-team-item"
+                  onClick={() => pickTeam(null)}
+                >
+                  no team
+                </button>
+              )}
               {(teams ?? []).map((t) => (
                 <button
                   key={t}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -140,9 +140,14 @@ export function MeBoard({
           return false;
         }
         const as = activeSprint(board, c.team ?? null, selectedDate);
+        const ss = c.sprintStart;
+        // A card shows on every day of the sprints it spans — from the one it
+        // started in up to the sprint it now belongs to — so a carried-over card
+        // still appears on the previous sprint's days it came from.
         return (
           as !== "" &&
-          c.sprintStart === as &&
+          ss !== undefined &&
+          as <= ss &&
           (!c.startDate || c.startDate <= selectedDate)
         );
       }),

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -16,7 +16,7 @@ import type {
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
 import { todayIso, addDays, mondayOf } from "../date";
-import { currentSprint, previousSprint } from "../sprint";
+import { activeSprint, currentSprint, previousSprint } from "../sprint";
 import { teamColor } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
@@ -200,9 +200,32 @@ export function TeamBoard({
       inFilter.filter((c) => {
         const eff =
           c.startDate && c.startDate > todayIso() ? c.startDate : c.sprintStart;
-        return eff === selectedDate;
+        if (eff === selectedDate) {
+          return true;
+        }
+        // A future-deferred card only lives on its own day.
+        if (c.startDate && c.startDate > todayIso()) {
+          return false;
+        }
+        // A carried-over card also shows on the previous sprint's start day —
+        // its origin — so scrolling back shows that sprint in full.
+        const prev = previousSprint(board, c.team ?? null);
+        if (
+          !prev ||
+          selectedDate !== prev ||
+          !c.sprintStart ||
+          c.sprintStart <= prev
+        ) {
+          return false;
+        }
+        const origin = activeSprint(
+          board,
+          c.team ?? null,
+          c.startDate ?? c.sprintStart,
+        );
+        return origin <= prev;
       }),
-    [inFilter, selectedDate],
+    [inFilter, selectedDate, board],
   );
 
   // The sprint-jump button. Standing on the current sprint, it offers the
@@ -508,6 +531,20 @@ export function TeamBoard({
     () => (teamFilter?.length === 1 ? teamFilter[0] || null : undefined),
     [teamFilter],
   );
+
+  // When several teams are filtered, the create picker and the Carry Over menu
+  // offer just those (a single filtered team is forced above; no filter → all).
+  const pickerTeams = useMemo(
+    () =>
+      teamFilter && teamFilter.length > 0
+        ? roster.filter((t) => teamFilter.includes(t))
+        : roster,
+    [teamFilter, roster],
+  );
+
+  // "No team" is offered like any other team: only when it is explicitly
+  // filtered in (or nothing is filtered at all).
+  const pickerNoTeam = teamFilter === null || teamFilter.includes("");
 
   // People to offer when reassigning a card: everyone seen on the board, me first.
   const people = useMemo(() => {
@@ -1317,7 +1354,7 @@ export function TeamBoard({
           </button>
           {teamFilter?.length !== 1 && sprintMenuOpen && (
             <div className="card-stage-menu sprint-menu">
-              {roster.map((t) => (
+              {pickerTeams.map((t) => (
                 <button
                   key={t}
                   type="button"
@@ -1328,13 +1365,15 @@ export function TeamBoard({
                   {t}
                 </button>
               ))}
-              <button
-                type="button"
-                className="card-stage-item card-stage-clear"
-                onClick={() => void startSprint(null)}
-              >
-                no team
-              </button>
+              {pickerNoTeam && (
+                <button
+                  type="button"
+                  className="card-stage-item card-stage-clear"
+                  onClick={() => void startSprint(null)}
+                >
+                  no team
+                </button>
+              )}
             </div>
           )}
         </div>
@@ -1423,7 +1462,8 @@ export function TeamBoard({
                   {body}
                   <AddCard
                     forcedTeam={forcedTeam}
-                    teams={roster}
+                    teams={pickerTeams}
+                    allowNoTeam={pickerNoTeam}
                     placeholder="Plan task…"
                     onCreate={(title, team) =>
                       handleCreatePlan(band, title, team)
@@ -1446,8 +1486,9 @@ export function TeamBoard({
                 <div className="zone-cards">
                   {body}
                   <AddCard
-                    teams={forcedTeam === undefined ? roster : undefined}
+                    teams={forcedTeam === undefined ? pickerTeams : undefined}
                     forcedTeam={forcedTeam}
+                    allowNoTeam={pickerNoTeam}
                     onCreate={(title, team) =>
                       handleCreate(engineer, zone, title, team)
                     }
@@ -1583,7 +1624,7 @@ export function TeamBoard({
                                   {t}
                                 </button>
                               ))}
-                              {carryable.noTeam && (
+                              {pickerNoTeam && (
                                 <button
                                   type="button"
                                   className="card-stage-item card-stage-clear"
@@ -1593,7 +1634,7 @@ export function TeamBoard({
                                 </button>
                               )}
                               {carryable.teams.length === 0 &&
-                                !carryable.noTeam && (
+                                !pickerNoTeam && (
                                   <div className="sprint-empty">
                                     Nothing to carry
                                   </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1635,6 +1635,7 @@ button.card-age {
   flex: 1;
   min-height: 0;
   display: flex;
+  align-items: flex-start;
   gap: 8px;
   padding: 8px;
   overflow: auto;


### PR DESCRIPTION
## Summary

- **Carried-over cards stay in their origin sprint** — Carry Over used to remove an unfinished card from the previous sprint when moving it to today. Now a card shows across every sprint it spans (from where it started up to `sprintStart`), so scrolling back shows the previous sprint in full. Me view: `activeSprint(day) <= sprintStart`; Team view: also on the previous sprint's start day. Mirrored in the Go filters (MCP/API) and documented in `docs/dates.md`.
- **Team pickers reflect the selection** — the create picker and the Carry Over / Carry over week menus offer only the filtered teams. "No team" is treated like any team (offered only when explicitly selected); the create picker defaults to the first team instead of "no team".
- **Fix Team layout on small windows** — cards could overlap with no vertical scroll; the team grid now aligns its columns to the top so a tall column scrolls instead of compressing.

## Testing

- `npm run build` (tsc + vite) — passes
- `go build`, `go vet`, `go test ./...` — pass
- `golangci-lint run` — 0 issues
- Verified the Team scroll fix in the browser
