### PR TITLE
fix(team): deletable cards, reliable Carry Over

### DIFF
--- a/internal/board/status.go
+++ b/internal/board/status.go
@@ -16,34 +16,40 @@ func ClampProgress(stage StageKey, value int) int {
 	return value
 }
 
+// Complete reports whether a card counts as finished — an explicit done stage,
+// or 100% readiness with no stage (100% + StageNone is the done auto-link, and
+// can arrive straight from GitHub without going through ApplyProgress). A 100%
+// card that is on review or locked is still unfinished, so it is NOT complete.
+// Carry Over and Carry Week use this so finished cards are not dragged forward.
+func Complete(stage StageKey, progress int) bool {
+	return stage == StageDone || (progress >= 100 && stage == StageNone)
+}
+
 // ApplyProgress computes the (stage, progress) resulting from setting a card's
-// progress to raw. The value is first clamped for the current stage, then the
-// done auto-link runs: reaching 100% with no stage moves the card to done, and
-// dropping below 100% clears a done stage. review/locked stages are left as-is.
-// It mirrors handleProgress (the done-link assumes the board has a Stage field,
-// the `if (roles.stage)` guard there; aeman boards always do).
+// progress to raw. The value is first clamped for the current stage. Done is
+// derived (no stage + 100%, see Complete), never stored: reaching 100% with no
+// stage simply stays stage-less, and a legacy stored done clears itself when
+// progress drops below full. review/locked stages are left as-is. It mirrors
+// handleProgress.
 func ApplyProgress(stage StageKey, raw int) (StageKey, int) {
 	value := ClampProgress(stage, raw)
-	switch {
-	case value == 100 && stage == StageNone:
-		return StageDone, value
-	case value < 100 && stage == StageDone:
+	if value < 100 && stage == StageDone {
 		return StageNone, value
-	default:
-		return stage, value
 	}
+	return stage, value
 }
 
 // ApplyStage computes the (stage, progress) resulting from moving a card to the
-// given stage. Choosing done fills progress to 100%; choosing review or locked
-// knocks a full (100%) card down to 90%, since those stages can never sit at
-// full. Clearing the stage (StageNone) or any other case keeps progress. It
-// mirrors handleStage.
+// given stage. Done is derived, never stored: choosing it clears the stage and
+// fills progress to 100% (Complete then reports the card finished). Choosing
+// review or locked knocks a full (100%) card down to 90%, since those stages can
+// never sit at full. Clearing the stage (StageNone) or any other case keeps
+// progress. It mirrors handleStage.
 func ApplyStage(stage StageKey, currentProgress int) (StageKey, int) {
 	progress := currentProgress
 	switch {
 	case stage == StageDone:
-		progress = 100
+		return StageNone, 100
 	case (stage == StageReview || stage == StageLocked) && currentProgress == 100:
 		progress = 90
 	}

--- a/internal/board/status_test.go
+++ b/internal/board/status_test.go
@@ -37,7 +37,7 @@ func TestApplyProgress(t *testing.T) {
 		wantStage StageKey
 		wantValue int
 	}{
-		{"full with no stage links done", StageNone, 100, StageDone, 100},
+		{"full with no stage stays stage-less (done is derived)", StageNone, 100, StageNone, 100},
 		{"below full clears done", StageDone, 50, StageNone, 50},
 		{"mid with no stage unchanged", StageNone, 50, StageNone, 50},
 		{"review clamps full to 90, no link", StageReview, 100, StageReview, 90},
@@ -64,7 +64,7 @@ func TestApplyStage(t *testing.T) {
 		wantStage StageKey
 		wantValue int
 	}{
-		{"done fills to full", StageDone, 50, StageDone, 100},
+		{"done clears the stage and fills to full (derived)", StageDone, 50, StageNone, 100},
 		{"review drops full to 90", StageReview, 100, StageReview, 90},
 		{"locked drops full to 90", StageLocked, 100, StageLocked, 90},
 		{"review below full kept", StageReview, 50, StageReview, 50},
@@ -105,5 +105,26 @@ func TestApplyInProgress(t *testing.T) {
 					c.stage, c.progress, gotStage, gotValue, StageNone, c.wantValue)
 			}
 		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	cases := []struct {
+		name     string
+		stage    StageKey
+		progress int
+		want     bool
+	}{
+		{"explicit done", StageDone, 100, true},
+		{"100% with no stage is the done auto-link", StageNone, 100, true},
+		{"100% on review is still unfinished", StageReview, 100, false},
+		{"100% locked is still unfinished", StageLocked, 100, false},
+		{"in progress", StageNone, 40, false},
+		{"review below full", StageReview, 90, false},
+	}
+	for _, c := range cases {
+		if got := Complete(c.stage, c.progress); got != c.want {
+			t.Errorf("%s: Complete(%q,%d) = %v, want %v", c.name, c.stage, c.progress, got, c.want)
+		}
 	}
 }

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -175,13 +175,18 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 			ReviewOf: args.ReviewOf,
 		})
 	}
+	// Start and Day (the end/due date) default to each other so a create with
+	// only one of them yields a one-day range — a backdated create must NOT get
+	// day = today, or the [start…day] range would stretch it onto today's board.
 	day := args.Day
-	if day == "" {
-		day = board.TodayIso()
-	}
 	start := args.Start
 	if start == "" {
+		if day == "" {
+			day = board.TodayIso()
+		}
 		start = day
+	} else if day == "" {
+		day = start
 	}
 	cur := board.CurrentSprint(b, args.Team)
 	startNew := cur == ""
@@ -238,7 +243,7 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 	// on the backend) are picked up too. Future-dated cards stay.
 	var carry []board.Card
 	for _, c := range b.Cards {
-		if c.Team != team || c.SprintStart == "" || c.SprintStart >= today || c.Stage == board.StageDone {
+		if c.Team != team || c.SprintStart == "" || c.SprintStart >= today || board.Complete(c.Stage, c.Progress) {
 			continue
 		}
 		carry = append(carry, c)
@@ -315,7 +320,7 @@ func (s *Service) CarryWeek(ctx context.Context, owner string, project int, team
 		if c.Plan == board.PlanNone || c.Week == "" || c.Week >= week {
 			continue
 		}
-		if c.Stage == board.StageDone || c.Team != team {
+		if board.Complete(c.Stage, c.Progress) || c.Team != team {
 			continue
 		}
 		if err := s.backend.SetWeek(ctx, b, c, week); err != nil {

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/aenix-org/aeman/internal/board"
 )
@@ -242,11 +243,15 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		}
 		carry = append(carry, c)
 	}
-	// The per-card writes are independent; run them concurrently (bounded) so a
-	// full sprint carries in a few round-trips' time instead of one per card.
-	sem := make(chan struct{}, 8)
+	// The per-card writes are independent, but a burst of concurrent Projects v2
+	// mutations trips GitHub's secondary rate limit, so run them at a modest
+	// concurrency, retry transient failures, and — crucially — do NOT stop at the
+	// first error: a partial carry-over that silently drops a card is worse than
+	// a slow one. Only cards that still fail after retries surface as an error.
+	sem := make(chan struct{}, 3)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
+	var failed int
 	var firstErr error
 	for _, c := range carry {
 		wg.Add(1)
@@ -254,8 +259,9 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		go func(c board.Card) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if err := s.backend.SetSprintStart(ctx, b, c, today); err != nil {
+			if err := s.setSprintStartRetry(ctx, b, c, today); err != nil {
 				mu.Lock()
+				failed++
 				if firstErr == nil {
 					firstErr = err
 				}
@@ -264,7 +270,32 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		}(c)
 	}
 	wg.Wait()
-	return firstErr
+	if firstErr != nil {
+		return fmt.Errorf("carried over %d of %d cards, %d failed: %w",
+			len(carry)-failed, len(carry), failed, firstErr)
+	}
+	return nil
+}
+
+// setSprintStartRetry sets a card's Sprint Start, retrying a few times with
+// backoff. Carry Over touches many cards at once, and a transient GitHub hiccup
+// (secondary rate limit, 502, a token refreshed mid-flight) on one of them must
+// not silently leave it behind. The write is idempotent, so retrying is safe.
+func (s *Service) setSprintStartRetry(ctx context.Context, b board.Board, c board.Card, date string) error {
+	var err error
+	for attempt := 0; attempt < 4; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(attempt) * 400 * time.Millisecond):
+			}
+		}
+		if err = s.backend.SetSprintStart(ctx, b, c, date); err == nil {
+			return nil
+		}
+	}
+	return err
 }
 
 // CarryWeek pulls a team's unfinished plan cards from earlier weeks into the

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -385,8 +385,13 @@ func TestSetStageDoneFillsProgress(t *testing.T) {
 	if err := f2svc(f).SetStage(ctx, "acme", 1, "c1", board.StageDone); err != nil {
 		t.Fatal(err)
 	}
-	if f.get("c1").Stage != board.StageDone || f.get("c1").Progress != 100 {
+	// Done is derived, never stored: picking it clears the stage and fills the
+	// bar, and Complete reports the card finished.
+	if f.get("c1").Stage != board.StageNone || f.get("c1").Progress != 100 {
 		t.Fatalf("card = %+v", f.get("c1"))
+	}
+	if !board.Complete(f.get("c1").Stage, f.get("c1").Progress) {
+		t.Fatalf("a stage-less 100%% card should be complete: %+v", f.get("c1"))
 	}
 }
 
@@ -405,15 +410,17 @@ func TestSetProgressDoneLink(t *testing.T) {
 	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 100); err != nil {
 		t.Fatal(err)
 	}
-	if f.get("c1").Progress != 100 || f.get("c1").Stage != board.StageDone {
-		t.Fatalf("100%% should auto-set done: %+v", f.get("c1"))
+	// Done is derived (no stage + 100%), never stored.
+	if f.get("c1").Progress != 100 || f.get("c1").Stage != board.StageNone {
+		t.Fatalf("100%% should stay stage-less: %+v", f.get("c1"))
 	}
-	// Dropping below 100 clears done.
+	// A legacy stored done clears itself when progress drops below full.
+	f.get("c1").Stage = board.StageDone
 	if err := f2svc(f).SetProgress(ctx, "acme", 1, "c1", 80); err != nil {
 		t.Fatal(err)
 	}
 	if f.get("c1").Progress != 80 || f.get("c1").Stage != board.StageNone {
-		t.Fatalf("below 100 should clear done: %+v", f.get("c1"))
+		t.Fatalf("below 100 should clear a stored done: %+v", f.get("c1"))
 	}
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -151,8 +151,13 @@ func TestAPISetProgressDoneLink(t *testing.T) {
 	}
 	var card board.Card
 	_ = json.Unmarshal(rec.Body.Bytes(), &card)
-	if card.Progress != 100 || card.Stage != board.StageDone {
-		t.Fatalf("100%% should auto-set done: %+v", card)
+	// Done is derived (no stage + 100%), never stored: full progress leaves the
+	// stage empty and the card counts as complete.
+	if card.Progress != 100 || card.Stage != board.StageNone {
+		t.Fatalf("100%% should stay stage-less: %+v", card)
+	}
+	if !board.Complete(card.Stage, card.Progress) {
+		t.Fatalf("a stage-less 100%% card should be complete: %+v", card)
 	}
 }
 

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -98,14 +98,18 @@ export function Card({
   onSetWeek,
   dimAvatar,
 }: CardProps) {
-  const rawValue = card.stage === "done" ? 100 : card.progress ?? 0;
+  // Done is derived, not stored: a card with no stage at 100% renders as done
+  // (legacy cards with a stored Done option still count too).
+  const doneish =
+    card.stage === "done" || (!card.stage && (card.progress ?? 0) >= 100);
+  const rawValue = doneish ? 100 : card.progress ?? 0;
   // Locked / on-review cards are clamped to a 10–90% band, so they always show
   // the stage colour and never read as complete.
   const value =
     card.stage === "locked" || card.stage === "review"
       ? Math.min(90, Math.max(10, rawValue))
       : rawValue;
-  const fill = barColor(card.stage);
+  const fill = barColor(doneish ? "done" : card.stage);
   const ref = ticket(card);
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -402,7 +406,7 @@ export function Card({
                 <button
                   key={stage}
                   type="button"
-                  className={`card-stage-item${card.stage === stage ? " card-stage-item-active" : ""}`}
+                  className={`card-stage-item${(stage === "done" ? doneish : card.stage === stage) ? " card-stage-item-active" : ""}`}
                   onClick={(e) => pickStage(e, stage)}
                 >
                   <span

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -272,15 +272,11 @@ export function MeBoard({
         : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
-    // Auto-link progress and "done": 100% sets done (unless review/locked is on),
-    // dropping below 100% clears done. review/locked are left untouched.
+    // Done is derived (no stage + 100%), never stored: reaching full needs no
+    // stage write; only a legacy stored done clears itself below full.
     let stageChange: StageKey | null | undefined;
-    if (roles.stage) {
-      if (value === 100 && card.stage == null) {
-        stageChange = "done";
-      } else if (value < 100 && card.stage === "done") {
-        stageChange = null;
-      }
+    if (roles.stage && value < 100 && card.stage === "done") {
+      stageChange = null;
     }
     if (stageChange !== undefined) {
       patch.stage = stageChange ?? undefined;
@@ -312,7 +308,11 @@ export function MeBoard({
       stage: card.stage,
       progress: card.progress,
     };
-    const patch: Partial<CardModel> = { stage: stage ?? undefined };
+    // Done is derived (no stage + 100%), never stored: picking it clears the
+    // stage and fills the bar instead of writing a Done option.
+    const storedStage = stage === "done" ? null : stage;
+    const patch: Partial<CardModel> = { stage: storedStage ?? undefined };
+    const fillTo100 = stage === "done" && card.progress !== 100;
     if (stage === "done") {
       patch.progress = 100;
     }
@@ -323,12 +323,13 @@ export function MeBoard({
       patch.progress = 90;
     }
     patchCard(card.itemId, patch);
-    void provider.setStage(board, card, stage).catch((err: unknown) => {
+    void provider.setStage(board, card, storedStage).catch((err: unknown) => {
       patchCard(card.itemId, prev);
       onError(errMessage(err));
     });
-    if (dropTo90) {
-      void provider.setProgress(board, card, 90).catch((err: unknown) => {
+    if (fillTo100 || dropTo90) {
+      const target = dropTo90 ? 90 : 100;
+      void provider.setProgress(board, card, target).catch((err: unknown) => {
         patchCard(card.itemId, { progress: prev.progress });
         onError(errMessage(err));
       });

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -380,6 +380,7 @@ export function TeamBoard({
         c.week != null &&
         c.week < currentWeek &&
         c.stage !== "done" &&
+        !(!c.stage && (c.progress ?? 0) >= 100) &&
         // Skip not-yet-persisted optimistic cards (temporary ids).
         !c.itemId.startsWith("tmp-") &&
         (team === null ? c.team == null : c.team === team),
@@ -748,15 +749,11 @@ export function TeamBoard({
         : raw;
     const prev: Partial<CardModel> = { progress: card.progress, stage: card.stage };
     const patch: Partial<CardModel> = { progress: value };
-    // Auto-link progress and "done": 100% sets done (unless review/locked is on),
-    // dropping below 100% clears done. review/locked are left untouched.
+    // Done is derived (no stage + 100%), never stored: reaching full needs no
+    // stage write; only a legacy stored done clears itself below full.
     let stageChange: StageKey | null | undefined;
-    if (roles.stage) {
-      if (value === 100 && card.stage == null) {
-        stageChange = "done";
-      } else if (value < 100 && card.stage === "done") {
-        stageChange = null;
-      }
+    if (roles.stage && value < 100 && card.stage === "done") {
+      stageChange = null;
     }
     if (stageChange !== undefined) {
       patch.stage = stageChange ?? undefined;
@@ -788,7 +785,11 @@ export function TeamBoard({
       stage: card.stage,
       progress: card.progress,
     };
-    const patch: Partial<CardModel> = { stage: stage ?? undefined };
+    // Done is derived (no stage + 100%), never stored: picking it clears the
+    // stage and fills the bar instead of writing a Done option.
+    const storedStage = stage === "done" ? null : stage;
+    const patch: Partial<CardModel> = { stage: storedStage ?? undefined };
+    const fillTo100 = stage === "done" && card.progress !== 100;
     if (stage === "done") {
       patch.progress = 100;
     }
@@ -799,12 +800,13 @@ export function TeamBoard({
       patch.progress = 90;
     }
     patchCard(card.itemId, patch);
-    void provider.setStage(board, card, stage).catch((err: unknown) => {
+    void provider.setStage(board, card, storedStage).catch((err: unknown) => {
       patchCard(card.itemId, prev);
       onError(errMessage(err));
     });
-    if (dropTo90) {
-      void provider.setProgress(board, card, 90).catch((err: unknown) => {
+    if (fillTo100 || dropTo90) {
+      const target = dropTo90 ? 90 : 100;
+      void provider.setProgress(board, card, target).catch((err: unknown) => {
         patchCard(card.itemId, { progress: prev.progress });
         onError(errMessage(err));
       });
@@ -1271,7 +1273,9 @@ export function TeamBoard({
       teamKey,
       selectedDate,
       sprint,
-      todayIso(),
+      // The end (due) date starts as the card's own day — a one-day range. A
+      // backdated create with day = today would stretch onto today's board.
+      selectedDate,
     );
   };
 
@@ -1297,6 +1301,7 @@ export function TeamBoard({
         c.sprintStart &&
         c.sprintStart < today &&
         c.stage !== "done" &&
+        !(!c.stage && (c.progress ?? 0) >= 100) &&
         !c.itemId.startsWith("tmp-"),
     );
     if (

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -914,24 +914,33 @@ export function TeamBoard({
   // grid card is demoted to its previous sprint (if any) rather than deleted.
   const handleGridDelete = (card: CardModel) => {
     if (!card.plan) {
-      // A card created today never lived in a previous sprint — delete it for
-      // real instead of demoting it there.
-      const createdToday =
-        !!card.createdAt && localDateIso(card.createdAt) === todayIso();
-      const prevSprint = createdToday ? null : previousSprintFor(card);
-      if (prevSprint) {
+      // Demote-then-delete: the first × on a card still in the team's current
+      // sprint moves it (and all its dates) back to the previous sprint; once it
+      // is no longer in the current sprint — already demoted, older, or the team
+      // has no earlier sprint — × deletes it for real.
+      const cur = currentSprint(board, card.team ?? null);
+      const prevSprint = previousSprintFor(card);
+      const inCurrent = !!card.sprintStart && !!cur && card.sprintStart === cur;
+      if (inCurrent && prevSprint && prevSprint < cur) {
         const prev: Partial<CardModel> = {
           startDate: card.startDate,
           sprintStart: card.sprintStart,
+          day: card.day,
         };
         patchCard(card.itemId, {
           startDate: prevSprint,
           sprintStart: prevSprint,
+          // Pull the end date back too, or the [start…end] range would keep the
+          // card on its old day and the demote would look like a no-op.
+          ...(card.day ? { day: prevSprint } : {}),
         });
         void (async () => {
           try {
             await provider.setStart(board, card, prevSprint);
             await provider.setSprintStart(board, card, prevSprint);
+            if (card.day && card.day !== prevSprint) {
+              await provider.setDay(board, card, prevSprint);
+            }
           } catch (err: unknown) {
             patchCard(card.itemId, prev);
             onError(errMessage(err));

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -727,6 +727,7 @@ export const githubProvider: Provider = {
         c.sprintStart !== "" &&
         c.sprintStart < today &&
         c.stage !== "done" &&
+        !(!c.stage && (c.progress ?? 0) >= 100) &&
         !c.itemId.startsWith("tmp-"),
     );
     await githubProvider.setSprintState(board, team, today, old);


### PR DESCRIPTION
Follow-up fixes on top of #10.

- **Delete in Team** — the × demoted a grid card to the previous sprint whenever one existed, so cards in the current sprint could never be deleted (and a card with an end date didn't even move — the start…end range pinned it). Now × demotes only while the card is still in the current sprint, then deletes for real. First click archives, second deletes.
- **Carry Over reliability** — it ran 8 concurrent sprint writes and stopped at the first error, so a transient GitHub hiccup silently left cards behind. Lowered concurrency, retry each card with backoff (idempotent), never abort on the first failure, and report "carried N of M, K failed" only for the truly stuck ones.
- **Done is derived, never stored** — Carry Over dragged 100%-ready cards forward because only a stored Done stage counted as finished. A card with no stage at 100% is now complete; reaching 100% writes no stage, picking Done clears the stage and fills the bar, review/locked at 100% remain unfinished. Legacy stored Done still reads as complete.
- **Create end-date default** — a create without an explicit end date defaulted it to today, so backdated cards got an unintended [start…today] range and appeared on today's board. Start and Day now default to each other (a one-day range).

Verified: go build/vet/test, golangci-lint 0, tsc + vite build.