### PR TITLE
feat(board): Carry Over moves only the closing sprint's cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Two complementary views — a personal day board and a team board:
   - **Red** — must be resolved before the end of the day.
 - **Team** — the team board: a people × zones grid for the selected day, filtered by team. Columns are people (with their GitHub avatar and name), rows are the same colour zones. Columns can be dragged or shuffled, and a person keeps a column even on days they have no cards.
 
-Each card carries a **readiness slider** (0–100%), a **stage** (Locked / Review / Done) that recolours the bar, an optional **team**, an age counter, and links back to its source issue. Click a card's avatar to reassign its team or person, or the day counter to edit its dates. There is intentionally no built-in time tracker.
+Each card carries a **readiness slider** (0–100%), a **stage** (Locked / Review / Recurrent / Done) that recolours the bar, an optional **team**, an age counter, and links back to its source issue. Click a card's avatar to reassign its team or person, or the day counter to edit its dates. There is intentionally no built-in time tracker.
 
 Every open board is **live**: edits made by teammates — or by AI agents over MCP — appear on everyone's screen in about a second, without reloading.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ Base path: `/api/v1`. All requests and responses are JSON. Errors are returned a
 | `POST /api/v1/carry-week` | `{team, week}` | Pull unfinished plan cards from earlier weeks into the week. |
 | `POST /api/v1/sprint-state` | `{team, current, previous}` | Set a team's sprint pointer directly. |
 | `DELETE /api/v1/cards/{id}` | — | Delete a card (cascades to its linked review card). |
-| `POST /api/v1/cards/{id}/stage` | `{stage}` | Set the stage: `locked`, `review`, `done`, or `""` to clear. |
+| `POST /api/v1/cards/{id}/stage` | `{stage}` | Set the stage: `locked`, `review`, `recurrent`, `done`, or `""` to clear. |
 | `POST /api/v1/cards/{id}/in-progress` | `{}` | Move to the implicit In Progress status. |
 | `POST /api/v1/cards/{id}/progress` | `{progress}` | Set readiness (0–100), running the done auto-link. |
 | `POST /api/v1/cards/{id}/zone` | `{zone}` | Set the colour zone (`gray`/`green`/`yellow`/`red`, `""` clears). |

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -122,8 +122,8 @@ today while the card stays in its sprint).
 - **Carry over week**: the same rule for plan cards — a finished recurrent plan
   card stays in its week and a fresh copy is created in the target week, unless
   a plan card with the same title is already there (re-running is idempotent).
-- In the weekly progress bar a recurrent card counts as its current % like any
-  card; the reseeded copy naturally resets its contribution each week.
+- Recurrent plan cards are **excluded from the weekly progress bar**: it
+  describes the week's one-off work only.
 
 ### Calendar (explicit dates)
 - The date picker on a card moves its **real dates**: `startDate = start` and

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -89,8 +89,12 @@ today while the card stays in its sprint).
 ### Carry Over
 - No-op if the team's sprint is already today.
 - Else: sets sprint-state to (current = today, previous = old current), and for
-  every **unfinished** card with `sprintStart < today`, sets `sprintStart = today`.
-  Future-dated and **done** cards stay put. Then the view jumps to today.
+  every **unfinished** card of the **closing sprint** (`sprintStart == old
+  current`), sets `sprintStart = today`. A card that is **not on today's
+  sprint** — demoted back, or simply older — stays where it is, so removing a
+  card from the current sprint is final and it never boomerangs back. Complete
+  cards (done, or 100% with no stage) stay put too. Then the view jumps to
+  today.
 - A carried card keeps its `startDate`, so it stays visible on the days of the
   sprint it came from (see the Team / Me rules): Carry Over adds it to the new
   sprint without removing it from the previous one.

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -112,6 +112,19 @@ today while the card stays in its sprint).
 - Carry Over still sweeps a deferred card's sprint forward (its `sprintStart` is
   in the past), but the future `startDate` keeps hiding it until its day comes.
 
+### Recurrent cards
+- The **recurrent** stage marks a repeating task. Unlike review/locked its
+  progress spans the full 0–100% (no clamp), and 100% counts as **complete**.
+- **Carry Over**: an unfinished recurrent card carries like any other card; a
+  **finished** one (100%) stays behind and is **reseeded** — a fresh copy is
+  created in the new sprint with the same title and description, no notes,
+  at 0%, recurrent again.
+- **Carry over week**: the same rule for plan cards — a finished recurrent plan
+  card stays in its week and a fresh copy is created in the target week, unless
+  a plan card with the same title is already there (re-running is idempotent).
+- In the weekly progress bar a recurrent card counts as its current % like any
+  card; the reseeded copy naturally resets its contribution each week.
+
 ### Calendar (explicit dates)
 - The date picker on a card moves its **real dates**: `startDate = start` and
   `day = end` — a genuine relocation (no history kept, unlike defer). The card

--- a/internal/board/stages.go
+++ b/internal/board/stages.go
@@ -10,14 +10,15 @@ type StageKey string
 // The explicit stages a card can carry, mirroring web/src/stages.ts. StageNone
 // ("") is the absence of a stage (the implicit In Progress / not-started state).
 const (
-	StageNone   StageKey = ""
-	StageLocked StageKey = "locked"
-	StageReview StageKey = "review"
-	StageDone   StageKey = "done"
+	StageNone      StageKey = ""
+	StageLocked    StageKey = "locked"
+	StageReview    StageKey = "review"
+	StageRecurrent StageKey = "recurrent"
+	StageDone      StageKey = "done"
 )
 
 // StageOrder is the canonical stage ordering, mirroring STAGE_ORDER.
-var StageOrder = []StageKey{StageLocked, StageReview, StageDone}
+var StageOrder = []StageKey{StageLocked, StageReview, StageRecurrent, StageDone}
 
 // DefaultBarColor is the progress-bar colour for a card with no stage, mirroring
 // DEFAULT_BAR_COLOR.
@@ -34,7 +35,10 @@ type StageDef struct {
 var Stages = map[StageKey]StageDef{
 	StageLocked: {Key: StageLocked, Label: "Locked", Color: "#cf222e"},
 	StageReview: {Key: StageReview, Label: "Review", Color: "#d4a72c"},
-	StageDone:   {Key: StageDone, Label: "Done", Color: "#1f883d"},
+	// Recurrent marks a repeating task: unlike review/locked its progress spans
+	// the full 0–100%, and Carry Over reseeds a finished one as a fresh copy.
+	StageRecurrent: {Key: StageRecurrent, Label: "Recurrent", Color: "#58a6ff"},
+	StageDone:      {Key: StageDone, Label: "Done", Color: "#1f883d"},
 }
 
 // StageFromName maps a Stage single-select option name onto a StageKey, mirroring
@@ -45,6 +49,8 @@ func StageFromName(name string) StageKey {
 		return StageLocked
 	case "review":
 		return StageReview
+	case "recurrent":
+		return StageRecurrent
 	case "done":
 		return StageDone
 	default:

--- a/internal/board/stages_test.go
+++ b/internal/board/stages_test.go
@@ -47,7 +47,7 @@ func TestStageFromName(t *testing.T) {
 }
 
 func TestStageOrderAndDefs(t *testing.T) {
-	want := []StageKey{StageLocked, StageReview, StageDone}
+	want := []StageKey{StageLocked, StageReview, StageRecurrent, StageDone}
 	if len(StageOrder) != len(want) {
 		t.Fatalf("StageOrder = %v, want %v", StageOrder, want)
 	}

--- a/internal/board/status.go
+++ b/internal/board/status.go
@@ -17,12 +17,16 @@ func ClampProgress(stage StageKey, value int) int {
 }
 
 // Complete reports whether a card counts as finished — an explicit done stage,
-// or 100% readiness with no stage (100% + StageNone is the done auto-link, and
-// can arrive straight from GitHub without going through ApplyProgress). A 100%
-// card that is on review or locked is still unfinished, so it is NOT complete.
-// Carry Over and Carry Week use this so finished cards are not dragged forward.
+// or 100% readiness with no stage (done is derived) or on the recurrent stage
+// (a finished recurrent card stays behind; Carry Over reseeds a fresh copy). A
+// 100% card that is on review or locked is still unfinished, so it is NOT
+// complete. Carry Over and Carry Week use this so finished cards are not
+// dragged forward.
 func Complete(stage StageKey, progress int) bool {
-	return stage == StageDone || (progress >= 100 && stage == StageNone)
+	if stage == StageDone {
+		return true
+	}
+	return progress >= 100 && (stage == StageNone || stage == StageRecurrent)
 }
 
 // ApplyProgress computes the (stage, progress) resulting from setting a card's

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -238,12 +238,13 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 	if err := s.backend.SetSprintState(ctx, b, team, today, old); err != nil {
 		return err
 	}
-	// Carry every unfinished card whose sprint is before the new day — not just
-	// the previous sprint — so cards added on an in-between day (or made directly
-	// on the backend) are picked up too. Future-dated cards stay.
+	// Carry only the unfinished cards of the sprint being closed (sprintStart ==
+	// the old current pointer). A card that is NOT on today's sprint — demoted
+	// back to an earlier one, or simply old — stays where it is, so removing a
+	// card from the current sprint is final and it never boomerangs back.
 	var carry []board.Card
 	for _, c := range b.Cards {
-		if c.Team != team || c.SprintStart == "" || c.SprintStart >= today || board.Complete(c.Stage, c.Progress) {
+		if c.Team != team || old == "" || c.SprintStart != old || board.Complete(c.Stage, c.Progress) {
 			continue
 		}
 		carry = append(carry, c)

--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -276,9 +276,55 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		}(c)
 	}
 	wg.Wait()
+	// A finished recurrent card of the closing sprint stays behind and seeds the
+	// new sprint with a fresh copy: same title/description/team/zone/assignee at
+	// 0%, recurrent again, without the old notes.
+	for _, c := range b.Cards {
+		if c.Team != team || old == "" || c.SprintStart != old {
+			continue
+		}
+		if c.Stage != board.StageRecurrent || c.Progress < 100 {
+			continue
+		}
+		if err := s.reseedRecurrent(ctx, b, c, board.CreateInput{
+			Title:       c.Title,
+			Zone:        c.Zone,
+			Day:         today,
+			Start:       today,
+			SprintStart: today,
+			Team:        c.Team,
+		}); err != nil {
+			mu.Lock()
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
+			mu.Unlock()
+		}
+	}
 	if firstErr != nil {
 		return fmt.Errorf("carried over %d of %d cards, %d failed: %w",
 			len(carry)-failed, len(carry), failed, firstErr)
+	}
+	return nil
+}
+
+// reseedRecurrent creates the fresh copy of a finished recurrent card: the given
+// create input plus the original's first assignee, the recurrent stage and the
+// original's description (notes are deliberately not copied).
+func (s *Service) reseedRecurrent(ctx context.Context, b board.Board, c board.Card, in board.CreateInput) error {
+	if len(c.Assignees) > 0 {
+		in.Assignee = c.Assignees[0]
+	}
+	created, err := s.backend.CreateCard(ctx, b, in)
+	if err != nil {
+		return err
+	}
+	if err := s.backend.SetStage(ctx, b, created, board.StageRecurrent); err != nil {
+		return err
+	}
+	if c.Description != "" {
+		return s.backend.SetDescription(ctx, b, created, c.Description)
 	}
 	return nil
 }
@@ -316,12 +362,38 @@ func (s *Service) CarryWeek(ctx context.Context, owner string, project int, team
 	if week == "" {
 		week = board.MondayOf(board.TodayIso())
 	}
+	// Titles already planned in the target week, for the recurrent reseed dedup:
+	// re-running carry-week must not create a second copy.
+	inTarget := map[string]bool{}
+	for _, c := range b.Cards {
+		if c.Plan != board.PlanNone && c.Week == week && c.Team == team {
+			inTarget[c.Title] = true
+		}
+	}
 	var carried []board.Card
 	for _, c := range b.Cards {
-		if c.Plan == board.PlanNone || c.Week == "" || c.Week >= week {
+		if c.Plan == board.PlanNone || c.Week == "" || c.Week >= week || c.Team != team {
 			continue
 		}
-		if board.Complete(c.Stage, c.Progress) || c.Team != team {
+		// A finished recurrent plan card stays in its week and seeds the target
+		// week with a fresh copy (unless one with the same title is already there).
+		if c.Stage == board.StageRecurrent && c.Progress >= 100 {
+			if inTarget[c.Title] {
+				continue
+			}
+			if err := s.reseedRecurrent(ctx, b, c, board.CreateInput{
+				Title: c.Title,
+				Zone:  c.Zone,
+				Plan:  c.Plan,
+				Week:  week,
+				Team:  c.Team,
+			}); err != nil {
+				return carried, err
+			}
+			inTarget[c.Title] = true
+			continue
+		}
+		if board.Complete(c.Stage, c.Progress) {
 			continue
 		}
 		if err := s.backend.SetWeek(ctx, b, c, week); err != nil {

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -749,3 +749,70 @@ func TestWeeklyPlanView(t *testing.T) {
 
 // f2svc wraps a fake backend in a Service.
 func f2svc(f *fakeBackend) *Service { return New(f) }
+
+func TestCarryOverReseedsFinishedRecurrent(t *testing.T) {
+	old := "2026-01-01"
+	f := newFake([]board.Card{
+		{ItemID: "r1", Team: "alpha", SprintStart: old, Stage: board.StageRecurrent, Progress: 100,
+			Title: "standup", Description: "daily sync", Assignees: []string{"bob"}, Zone: board.ZoneGray},
+		{ItemID: "r2", Team: "alpha", SprintStart: old, Stage: board.StageRecurrent, Progress: 40},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	today := board.TodayIso()
+	if err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	// The unfinished recurrent r2 carries like any card; the finished r1 stays.
+	if !f.saw(fmt.Sprintf("SetSprintStart r2 %s", today)) {
+		t.Fatalf("unfinished recurrent should carry; log=%v", f.log)
+	}
+	if f.get("r1").SprintStart != old {
+		t.Fatalf("finished recurrent should stay behind: %+v", f.get("r1"))
+	}
+	// The finished one seeds a fresh copy in the new sprint: same title and
+	// description, recurrent again, assignee kept, on today's dates.
+	if len(f.creates) != 1 {
+		t.Fatalf("expected one reseed create; creates=%v log=%v", f.creates, f.log)
+	}
+	in := f.creates[0]
+	if in.Title != "standup" || in.Team != "alpha" || in.Assignee != "bob" ||
+		in.SprintStart != today || in.Start != today || in.Day != today {
+		t.Fatalf("reseed input = %+v", in)
+	}
+	if f.count("SetStage") != 1 || !f.saw("SetStage new2 recurrent") {
+		t.Fatalf("reseed should be recurrent; log=%v", f.log)
+	}
+	if !f.saw("SetDescription new2 daily sync") {
+		t.Fatalf("reseed should copy the description; log=%v", f.log)
+	}
+}
+
+func TestCarryWeekReseedsFinishedRecurrent(t *testing.T) {
+	week := board.MondayOf(board.TodayIso())
+	prev := board.AddDays(week, -7)
+	f := newFake([]board.Card{
+		{ItemID: "p1", Team: "alpha", Plan: board.PlanWed, Week: prev, Stage: board.StageRecurrent, Progress: 100, Title: "weekly report"},
+		{ItemID: "p2", Team: "alpha", Plan: board.PlanFri, Week: prev, Progress: 20, Title: "feature"},
+	}, nil)
+	carried, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", week)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// p2 moves into the week; p1 stays and seeds a fresh recurrent copy.
+	if len(carried) != 1 || carried[0].ItemID != "p2" {
+		t.Fatalf("carried = %+v", carried)
+	}
+	if f.get("p1").Week != prev {
+		t.Fatalf("finished recurrent plan card should stay: %+v", f.get("p1"))
+	}
+	if len(f.creates) != 1 || f.creates[0].Title != "weekly report" ||
+		f.creates[0].Week != week || f.creates[0].Plan != board.PlanWed {
+		t.Fatalf("reseed create = %+v", f.creates)
+	}
+	// Re-running is idempotent: the copy already sits in the target week.
+	if _, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", week); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.creates) != 1 {
+		t.Fatalf("reseed must not duplicate; creates=%v", f.creates)
+	}
+}

--- a/internal/boardservice/service_test.go
+++ b/internal/boardservice/service_test.go
@@ -336,15 +336,18 @@ func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
 	if !f.saw(fmt.Sprintf("SetSprintState alpha cur=%s prev=%s", today, old)) {
 		t.Fatalf("expected advance; log=%v", f.log)
 	}
-	// c1 (previous sprint) and the in-between c3 both carry; c2 is done, c4 is
-	// another team, and c5 is future-dated — none of those move.
-	if f.count("SetSprintStart") != 2 ||
-		!f.saw(fmt.Sprintf("SetSprintStart c1 %s", today)) ||
-		!f.saw(fmt.Sprintf("SetSprintStart c3 %s", today)) {
-		t.Fatalf("c1 and the in-between c3 should carry; log=%v", f.log)
+	// Only c1 (the current sprint being closed) carries; c2 is done, c3 is not on
+	// the current sprint, c4 is another team, and c5 is future-dated — none move,
+	// so a card removed from the current sprint never boomerangs back.
+	if f.count("SetSprintStart") != 1 ||
+		!f.saw(fmt.Sprintf("SetSprintStart c1 %s", today)) {
+		t.Fatalf("only c1 should carry; log=%v", f.log)
 	}
-	if f.get("c1").SprintStart != today || f.get("c3").SprintStart != today {
-		t.Fatalf("c1/c3 not carried: %+v %+v", f.get("c1"), f.get("c3"))
+	if f.get("c1").SprintStart != today {
+		t.Fatalf("c1 not carried: %+v", f.get("c1"))
+	}
+	if f.get("c3").SprintStart != "2026-02-01" {
+		t.Fatalf("off-sprint c3 should stay: %+v", f.get("c3"))
 	}
 	if f.get("c5").SprintStart != "2027-01-01" {
 		t.Fatalf("future-dated c5 should not carry: %+v", f.get("c5"))

--- a/internal/ghprojects/queries.go
+++ b/internal/ghprojects/queries.go
@@ -183,6 +183,18 @@ const createSelectFieldMutation = `mutation($project: ID!, $name: String!, $opti
   }
 }`
 
+const selectFieldOptionsQuery = `query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2SingleSelectField { options { id name color description } }
+  }
+}`
+
+const updateSelectFieldOptionsMutation = `mutation($field: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+  updateProjectV2Field(input: { fieldId: $field, singleSelectOptions: $options }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { id name dataType options { id name color } } }
+  }
+}`
+
 const deleteItemMutation = `mutation($project: ID!, $item: ID!) {
   deleteProjectV2Item(input: { projectId: $project, itemId: $item }) { deletedItemId }
 }`

--- a/internal/ghprojects/setters.go
+++ b/internal/ghprojects/setters.go
@@ -277,10 +277,11 @@ func (c *Client) SetStage(ctx context.Context, b board.Board, card board.Card, s
 	return c.setSingleSelect(ctx, b.ID, card.ItemID, field.ID, option)
 }
 
-// ensureStageOption adds a missing stage option to an existing Stage field. The
-// GitHub API replaces the whole option list on update, so the current options
-// are re-sent verbatim (name, colour, description — matching names keep their
-// ids and the values already set on cards) plus the missing one from the spec.
+// ensureStageOption adds a missing stage option to an existing Stage field.
+// The GitHub API replaces the whole option list on update and RECREATES every
+// option with a new id — even for unchanged names — which wipes the stage
+// values stored on cards. So the current values are snapshotted from the board
+// first and re-applied against the new option ids right after the update.
 func (c *Client) ensureStageOption(ctx context.Context, b board.Board, field board.ProjectField, stage board.StageKey) (board.ProjectField, error) {
 	var spec *domainSelectOption
 	for i := range domainFieldSpecs["stage"].options {
@@ -314,6 +315,13 @@ func (c *Client) ensureStageOption(ctx context.Context, b board.Board, field boa
 		}
 	}
 	options = append(options, map[string]any{"name": spec.name, "color": spec.color, "description": spec.description})
+	// Snapshot every card's current stage before the update wipes the values.
+	staged := map[string]board.StageKey{}
+	for _, card := range b.Cards {
+		if card.Stage != board.StageNone {
+			staged[card.ItemID] = card.Stage
+		}
+	}
 	var data struct {
 		UpdateProjectV2Field struct {
 			ProjectV2Field createdFieldRaw `json:"projectV2Field"`
@@ -325,6 +333,26 @@ func (c *Client) ensureStageOption(ctx context.Context, b board.Board, field boa
 	}
 	updated := data.UpdateProjectV2Field.ProjectV2Field.toDomain()
 	c.fieldCache.store(b.ID+"\x00stage", updated)
+	// Re-apply the wiped values against the new option ids.
+	var restoreErr error
+	restored := 0
+	for itemID, s := range staged {
+		opt := domainOptionForStage(updated, s)
+		if opt == "" {
+			continue
+		}
+		if err := c.setSingleSelect(ctx, b.ID, itemID, updated.ID, opt); err != nil {
+			if restoreErr == nil {
+				restoreErr = err
+			}
+			continue
+		}
+		restored++
+	}
+	if restoreErr != nil {
+		return updated, fmt.Errorf("stage option %q added, but only %d of %d stage values were restored: %w",
+			spec.name, restored, len(staged), restoreErr)
+	}
 	return updated, nil
 }
 

--- a/internal/ghprojects/setters.go
+++ b/internal/ghprojects/setters.go
@@ -60,6 +60,7 @@ var domainFieldSpecs = map[string]domainFieldSpec{
 	"stage": {name: "Stage", options: []domainSelectOption{
 		{"Locked", "RED", "Locked"},
 		{"Review", "YELLOW", "Review"},
+		{"Recurrent", "BLUE", "Recurrent"},
 		{"Done", "GREEN", "Done"},
 	}},
 	"progress":    {name: "Progress", dataType: "NUMBER"},
@@ -262,9 +263,69 @@ func (c *Client) SetStage(ctx context.Context, b board.Board, card board.Card, s
 	}
 	option := domainOptionForStage(field, stage)
 	if option == "" {
+		// A Stage field provisioned before this stage existed (e.g. Recurrent)
+		// lacks its option: add it to the field in place, then retry.
+		field, err = c.ensureStageOption(ctx, b, field, stage)
+		if err != nil {
+			return err
+		}
+		option = domainOptionForStage(field, stage)
+	}
+	if option == "" {
 		return fmt.Errorf("stage %q has no matching option on field %q", stage, field.Name)
 	}
 	return c.setSingleSelect(ctx, b.ID, card.ItemID, field.ID, option)
+}
+
+// ensureStageOption adds a missing stage option to an existing Stage field. The
+// GitHub API replaces the whole option list on update, so the current options
+// are re-sent verbatim (name, colour, description — matching names keep their
+// ids and the values already set on cards) plus the missing one from the spec.
+func (c *Client) ensureStageOption(ctx context.Context, b board.Board, field board.ProjectField, stage board.StageKey) (board.ProjectField, error) {
+	var spec *domainSelectOption
+	for i := range domainFieldSpecs["stage"].options {
+		o := &domainFieldSpecs["stage"].options[i]
+		if board.StageFromName(o.name) == stage {
+			spec = o
+			break
+		}
+	}
+	if spec == nil {
+		return field, fmt.Errorf("stage %q has no option spec", stage)
+	}
+	// Fetch the live options with their descriptions — the update input requires
+	// a description per option, and wiping existing ones would lose data.
+	var cur struct {
+		Node *struct {
+			Options []struct {
+				Name        string `json:"name"`
+				Color       string `json:"color"`
+				Description string `json:"description"`
+			} `json:"options"`
+		} `json:"node"`
+	}
+	if err := c.graphql(ctx, selectFieldOptionsQuery, map[string]any{"id": field.ID}, &cur); err != nil {
+		return field, err
+	}
+	options := []map[string]any{}
+	if cur.Node != nil {
+		for _, o := range cur.Node.Options {
+			options = append(options, map[string]any{"name": o.Name, "color": o.Color, "description": o.Description})
+		}
+	}
+	options = append(options, map[string]any{"name": spec.name, "color": spec.color, "description": spec.description})
+	var data struct {
+		UpdateProjectV2Field struct {
+			ProjectV2Field createdFieldRaw `json:"projectV2Field"`
+		} `json:"updateProjectV2Field"`
+	}
+	if err := c.graphql(ctx, updateSelectFieldOptionsMutation,
+		map[string]any{"field": field.ID, "options": options}, &data); err != nil {
+		return field, err
+	}
+	updated := data.UpdateProjectV2Field.ProjectV2Field.toDomain()
+	c.fieldCache.store(b.ID+"\x00stage", updated)
+	return updated, nil
 }
 
 // SetProgress sets the readiness percentage.

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -69,7 +69,7 @@ func (h *server) mcpServer() *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{Name: "create_card", Description: "Create a card that joins (or starts) its team's sprint."}, h.createCard)
 	mcp.AddTool(s, &mcp.Tool{Name: "carry_over", Description: "Advance a team's sprint to today and carry its unfinished cards forward."}, h.carryOver)
 	mcp.AddTool(s, &mcp.Tool{Name: "carry_week", Description: "Pull a team's unfinished plan cards from earlier weeks into the target week."}, h.carryWeek)
-	mcp.AddTool(s, &mcp.Tool{Name: "set_stage", Description: "Set a card's stage: locked, review, done, or empty to clear it."}, h.setStage)
+	mcp.AddTool(s, &mcp.Tool{Name: "set_stage", Description: "Set a card's stage: locked, review, recurrent, done, or empty to clear it."}, h.setStage)
 	mcp.AddTool(s, &mcp.Tool{Name: "set_in_progress", Description: "Move a card to the implicit In Progress status (clears the stage)."}, h.setInProgress)
 	mcp.AddTool(s, &mcp.Tool{Name: "set_progress", Description: "Set a card's readiness percentage (0..100), running the done auto-link."}, h.setProgress)
 	mcp.AddTool(s, &mcp.Tool{Name: "send_to_review", Description: "Create a linked review card for a reviewer and put the card on review."}, h.sendToReview)

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -350,8 +350,8 @@ export function Card({
           >
             {card.stage === "review" ? (
               <svg
-                width="13"
-                height="13"
+                width="15"
+                height="15"
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 aria-hidden="true"

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -353,14 +353,11 @@ export function Card({
                 width="13"
                 height="13"
                 viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="3.6"
-                strokeLinecap="round"
+                fill="currentColor"
                 aria-hidden="true"
               >
-                <line x1="9" y1="7" x2="9" y2="17" />
-                <line x1="15" y1="7" x2="15" y2="17" />
+                <rect x="7" y="7" width="3.6" height="10" rx="1.4" />
+                <rect x="13.4" y="7" width="3.6" height="10" rx="1.4" />
               </svg>
             ) : card.stage === "recurrent" ? (
               <svg

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -326,7 +326,7 @@ export function Card({
           ×
         </button>
         <div
-          className={`card-stage${card.stage === "review" || card.stage === "locked" ? "" : " card-hoveronly"}`}
+          className={`card-stage${card.stage === "review" || card.stage === "locked" || card.stage === "recurrent" ? "" : " card-hoveronly"}`}
           ref={menuRef}
         >
           <button
@@ -340,13 +340,29 @@ export function Card({
             title={
               card.stage === "review"
                 ? "On review"
-                : card.stage === "locked"
-                  ? "Locked"
-                  : "Status"
+                : card.stage === "recurrent"
+                  ? "Recurrent"
+                  : card.stage === "locked"
+                    ? "Locked"
+                    : "Status"
             }
             style={card.stage ? { color: STAGES[card.stage].color } : undefined}
           >
             {card.stage === "review" ? (
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.8"
+                strokeLinecap="round"
+                aria-hidden="true"
+              >
+                <line x1="9" y1="5" x2="9" y2="19" />
+                <line x1="15" y1="5" x2="15" y2="19" />
+              </svg>
+            ) : card.stage === "recurrent" ? (
               <svg
                 width="13"
                 height="13"

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -355,12 +355,12 @@ export function Card({
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="2.8"
+                strokeWidth="3.6"
                 strokeLinecap="round"
                 aria-hidden="true"
               >
-                <line x1="9" y1="5" x2="9" y2="19" />
-                <line x1="15" y1="5" x2="15" y2="19" />
+                <line x1="9" y1="7" x2="9" y2="17" />
+                <line x1="15" y1="7" x2="15" y2="17" />
               </svg>
             ) : card.stage === "recurrent" ? (
               <svg

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -10,7 +10,7 @@ import type {
 import { ZONES, ZONE_ORDER, optionIdForZone } from "../zones";
 import { fieldRoles } from "../providers/fields";
 import { todayIso, localDateIso, addDays } from "../date";
-import { activeSprint, currentSprint } from "../sprint";
+import { activeSprint, currentSprint, previousSprint } from "../sprint";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
 import { AddCard } from "./AddCard";
@@ -303,7 +303,61 @@ export function MeBoard({
     }
   };
 
+  // Taking a card off review cancels its linked unfinished review card,
+  // mirroring the × logic: still on the team's current sprint → demoted to the
+  // previous one; otherwise deleted. A finished review card stays as a record.
+  const cancelLinkedReview = (original: CardModel) => {
+    const review = board.cards.find(
+      (c) =>
+        c.reviewOf === original.itemId &&
+        c.stage !== "done" &&
+        !(!c.stage && (c.progress ?? 0) >= 100) &&
+        !c.itemId.startsWith("tmp-"),
+    );
+    if (!review) {
+      return;
+    }
+    const cur = currentSprint(board, review.team ?? null);
+    const prevS = previousSprint(board, review.team ?? null);
+    if (review.sprintStart && cur && review.sprintStart === cur && prevS && prevS < cur) {
+      const rollback: Partial<CardModel> = {
+        startDate: review.startDate,
+        sprintStart: review.sprintStart,
+        day: review.day,
+      };
+      patchCard(review.itemId, {
+        startDate: prevS,
+        sprintStart: prevS,
+        ...(review.day ? { day: prevS } : {}),
+      });
+      void (async () => {
+        try {
+          await provider.setStart(board, review, prevS);
+          await provider.setSprintStart(board, review, prevS);
+          if (review.day && review.day !== prevS) {
+            await provider.setDay(board, review, prevS);
+          }
+        } catch (err: unknown) {
+          patchCard(review.itemId, rollback);
+          onError(errMessage(err));
+        }
+      })();
+      return;
+    }
+    removeCard(review.itemId);
+    void provider.deleteCard(board, review).catch((err: unknown) => {
+      if (isGone(err)) {
+        return;
+      }
+      addCard(review);
+      onError(errMessage(err));
+    });
+  };
+
   const handleStage = (card: CardModel, stage: StageKey | null) => {
+    if (card.stage === "review" && stage !== "review") {
+      cancelLinkedReview(card);
+    }
     const prev: Partial<CardModel> = {
       stage: card.stage,
       progress: card.progress,
@@ -340,6 +394,9 @@ export function MeBoard({
   // Picking it clears any stage and clamps progress into that band: under 10
   // becomes 10, a done/full card drops to 90, otherwise the value is kept.
   const handleInProgress = (card: CardModel) => {
+    if (card.stage === "review") {
+      cancelLinkedReview(card);
+    }
     const cur = card.progress ?? 0;
     let value = cur;
     if (cur < 10) {

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -66,6 +66,13 @@ const errMessage = (err: unknown) =>
 // resurrect a phantom copy).
 const isGone = (err: unknown) => errMessage(err).includes("card not found");
 
+// isComplete mirrors board.Complete: an explicit done, or 100% with no stage
+// (derived done) or on the recurrent stage (a finished recurrent card stays
+// behind — Carry Over/Week reseed a fresh copy instead of dragging it).
+const isComplete = (c: CardModel) =>
+  c.stage === "done" ||
+  ((!c.stage || c.stage === "recurrent") && (c.progress ?? 0) >= 100);
+
 /** TeamBoard is the team as a people × zones grid for one day, filtered by team. */
 export function TeamBoard({
   board,
@@ -374,18 +381,31 @@ export function TeamBoard({
   const handleCarryWeek = (team: string | null) => {
     setCarryWeekOpen(false);
     const label = team ?? "no team";
-    const carry = board.cards.filter(
+    const fromEarlier = board.cards.filter(
       (c) =>
         c.plan &&
         c.week != null &&
         c.week < currentWeek &&
-        c.stage !== "done" &&
-        !(!c.stage && (c.progress ?? 0) >= 100) &&
         // Skip not-yet-persisted optimistic cards (temporary ids).
         !c.itemId.startsWith("tmp-") &&
         (team === null ? c.team == null : c.team === team),
     );
-    if (carry.length === 0) {
+    const carry = fromEarlier.filter((c) => !isComplete(c));
+    // Finished recurrent plan cards stay behind; the backend reseeds a fresh
+    // copy into the week (skipping titles already planned there).
+    const reseed = fromEarlier.filter(
+      (c) =>
+        c.stage === "recurrent" &&
+        (c.progress ?? 0) >= 100 &&
+        !board.cards.some(
+          (t) =>
+            t.plan &&
+            t.week === currentWeek &&
+            (t.team ?? "") === (c.team ?? "") &&
+            t.title === c.title,
+        ),
+    );
+    if (carry.length === 0 && reseed.length === 0) {
       onError(
         `No unfinished plan cards from earlier weeks for "${label}" to carry into the week of ${currentWeek}.`,
       );
@@ -393,19 +413,26 @@ export function TeamBoard({
     }
     if (
       !window.confirm(
-        `Carry over ${carry.length} unfinished plan card(s) for "${label}" into the week of ${currentWeek}?`,
+        `Carry over ${carry.length} unfinished plan card(s) for "${label}" into the week of ${currentWeek}?` +
+          (reseed.length > 0
+            ? ` ${reseed.length} recurrent card(s) will restart at 0%.`
+            : ""),
       )
     ) {
       return;
     }
-    for (const card of carry) {
-      const prev = card.week;
-      patchCard(card.itemId, { week: currentWeek });
-      void provider.setWeek(board, card, currentWeek).catch((err: unknown) => {
-        patchCard(card.itemId, { week: prev });
+    carry.forEach((card) => patchCard(card.itemId, { week: currentWeek }));
+    void (async () => {
+      try {
+        // One server-side call: it moves the unfinished cards and reseeds the
+        // finished recurrent ones.
+        await provider.carryWeek(board, team, currentWeek);
+      } catch (err: unknown) {
         onError(errMessage(err));
-      });
-    }
+      }
+      // Pick up the reseeded copies (and reconcile the moves).
+      reload();
+    })();
   };
 
   // Move a plan card between the two bands (changes its Wed/Fri deadline).
@@ -1360,8 +1387,7 @@ export function TeamBoard({
         (team === null ? c.team == null : c.team === team) &&
         !!old &&
         c.sprintStart === old &&
-        c.stage !== "done" &&
-        !(!c.stage && (c.progress ?? 0) >= 100) &&
+        !isComplete(c) &&
         !c.itemId.startsWith("tmp-"),
     );
     if (

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -780,7 +780,61 @@ export function TeamBoard({
     }
   };
 
+  // Taking a card off review cancels its linked unfinished review card,
+  // mirroring the × logic: still on the team's current sprint → demoted to the
+  // previous one; otherwise deleted. A finished review card stays as a record.
+  const cancelLinkedReview = (original: CardModel) => {
+    const review = board.cards.find(
+      (c) =>
+        c.reviewOf === original.itemId &&
+        c.stage !== "done" &&
+        !(!c.stage && (c.progress ?? 0) >= 100) &&
+        !c.itemId.startsWith("tmp-"),
+    );
+    if (!review) {
+      return;
+    }
+    const cur = currentSprint(board, review.team ?? null);
+    const prevS = previousSprint(board, review.team ?? null);
+    if (review.sprintStart && cur && review.sprintStart === cur && prevS && prevS < cur) {
+      const rollback: Partial<CardModel> = {
+        startDate: review.startDate,
+        sprintStart: review.sprintStart,
+        day: review.day,
+      };
+      patchCard(review.itemId, {
+        startDate: prevS,
+        sprintStart: prevS,
+        ...(review.day ? { day: prevS } : {}),
+      });
+      void (async () => {
+        try {
+          await provider.setStart(board, review, prevS);
+          await provider.setSprintStart(board, review, prevS);
+          if (review.day && review.day !== prevS) {
+            await provider.setDay(board, review, prevS);
+          }
+        } catch (err: unknown) {
+          patchCard(review.itemId, rollback);
+          onError(errMessage(err));
+        }
+      })();
+      return;
+    }
+    removeCard(review.itemId);
+    void provider.deleteCard(board, review).catch((err: unknown) => {
+      if (isGone(err)) {
+        return;
+      }
+      addCard(review);
+      onError(errMessage(err));
+    });
+  };
+
   const handleStage = (card: CardModel, stage: StageKey | null) => {
+    if (card.stage === "review" && stage !== "review") {
+      cancelLinkedReview(card);
+    }
     const prev: Partial<CardModel> = {
       stage: card.stage,
       progress: card.progress,
@@ -817,6 +871,9 @@ export function TeamBoard({
   // Picking it clears any stage and clamps progress into that band: under 10
   // becomes 10, a done/full card drops to 90, otherwise the value is kept.
   const handleInProgress = (card: CardModel) => {
+    if (card.stage === "review") {
+      cancelLinkedReview(card);
+    }
     const cur = card.progress ?? 0;
     let value = cur;
     if (cur < 10) {

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1295,11 +1295,14 @@ export function TeamBoard({
       onError(`«${label}» is already on today's sprint.`);
       return;
     }
+    // Only the closing (current) sprint's unfinished cards carry — a card that
+    // is not on today's sprint stays put, so removing it from the sprint is
+    // final. Mirrors boardservice.CarryOver.
     const carry = board.cards.filter(
       (c) =>
         (team === null ? c.team == null : c.team === team) &&
-        c.sprintStart &&
-        c.sprintStart < today &&
+        !!old &&
+        c.sprintStart === old &&
         c.stage !== "done" &&
         !(!c.stage && (c.progress ?? 0) >= 100) &&
         !c.itemId.startsWith("tmp-"),

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -315,7 +315,11 @@ export function TeamBoard({
 
   // Overall completion across all plan cards (a done card counts as 100%).
   const planProgress = useMemo(() => {
-    const all = [...weekly.wed, ...weekly.fri];
+    // Recurrent plan cards are excluded: the bar describes the week's one-off
+    // work, while recurrent tasks restart every week and would skew it.
+    const all = [...weekly.wed, ...weekly.fri].filter(
+      (c) => c.stage !== "recurrent",
+    );
     if (all.length === 0) {
       return 0;
     }

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -243,4 +243,14 @@ export const apiProvider: Provider = {
     // the unfinished cards concurrently, emitting watch events per card.
     await api(board, "POST", "/carry-over", { team: team ?? "" });
   },
+
+  async carryWeek(
+    board: Board,
+    team: string | null,
+    week: string,
+  ): Promise<void> {
+    // One server-side call: the backend moves the unfinished plan cards and
+    // reseeds finished recurrent ones as fresh copies in the target week.
+    await api(board, "POST", "/carry-week", { team: team ?? "", week });
+  },
 };

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -398,6 +398,7 @@ interface FieldSpec {
 const STAGE_GH_COLOR: Record<StageKey, string> = {
   locked: "RED",
   review: "YELLOW",
+  recurrent: "BLUE",
   done: "GREEN",
 };
 
@@ -721,18 +722,93 @@ export const githubProvider: Provider = {
       return;
     }
     // Only the closing (current) sprint's unfinished cards carry, mirroring
-    // boardservice.CarryOver.
+    // boardservice.CarryOver (recurrent at 100% counts as complete).
     const carry = board.cards.filter(
       (c) =>
         (c.team ?? "") === key &&
         old !== null &&
         c.sprintStart === old &&
         c.stage !== "done" &&
-        !(!c.stage && (c.progress ?? 0) >= 100) &&
+        !((!c.stage || c.stage === "recurrent") && (c.progress ?? 0) >= 100) &&
         !c.itemId.startsWith("tmp-"),
     );
     await githubProvider.setSprintState(board, team, today, old);
     await githubProvider.setSprintStartMany(board, carry, today);
+    // Finished recurrent cards of the closing sprint stay behind and seed the
+    // new sprint with fresh copies, mirroring boardservice.CarryOver.
+    const reseed = board.cards.filter(
+      (c) =>
+        (c.team ?? "") === key &&
+        old !== null &&
+        c.sprintStart === old &&
+        c.stage === "recurrent" &&
+        (c.progress ?? 0) >= 100 &&
+        !c.itemId.startsWith("tmp-"),
+    );
+    for (const c of reseed) {
+      const created = await githubProvider.createCard(board, {
+        title: c.title,
+        zone: c.zone,
+        day: today,
+        start: today,
+        sprintStart: today,
+        assigneeLogin: c.assignees[0] ?? null,
+        team: team,
+      });
+      await githubProvider.setStage(board, created, "recurrent");
+      if (c.description) {
+        await githubProvider.setDescription(board, created, c.description);
+      }
+    }
+  },
+
+  async carryWeek(
+    board: Board,
+    team: string | null,
+    week: string,
+  ): Promise<void> {
+    // Client-side reference implementation, mirroring boardservice.CarryWeek:
+    // move the unfinished plan cards, reseed finished recurrent ones (skipping
+    // titles already planned in the target week).
+    const key = team ?? "";
+    const inTarget = new Set(
+      board.cards
+        .filter((c) => c.plan && c.week === week && (c.team ?? "") === key)
+        .map((c) => c.title),
+    );
+    for (const c of board.cards) {
+      if (!c.plan || !c.week || c.week >= week || (c.team ?? "") !== key) {
+        continue;
+      }
+      if (c.itemId.startsWith("tmp-")) {
+        continue;
+      }
+      if (c.stage === "recurrent" && (c.progress ?? 0) >= 100) {
+        if (inTarget.has(c.title)) {
+          continue;
+        }
+        const created = await githubProvider.createCard(board, {
+          title: c.title,
+          zone: c.zone,
+          plan: c.plan,
+          week,
+          team: team,
+        });
+        await githubProvider.setStage(board, created, "recurrent");
+        if (c.description) {
+          await githubProvider.setDescription(board, created, c.description);
+        }
+        inTarget.add(c.title);
+        continue;
+      }
+      if (
+        c.stage === "done" ||
+        ((!c.stage || c.stage === "recurrent") && (c.progress ?? 0) >= 100)
+      ) {
+        continue;
+      }
+      await githubProvider.setWeek(board, c, week);
+    }
   },
 
   async setPlan(board: Board, card: Card, plan: "wed" | "fri" | null): Promise<void> {

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -720,12 +720,13 @@ export const githubProvider: Provider = {
     if (old === today) {
       return;
     }
+    // Only the closing (current) sprint's unfinished cards carry, mirroring
+    // boardservice.CarryOver.
     const carry = board.cards.filter(
       (c) =>
         (c.team ?? "") === key &&
-        c.sprintStart !== undefined &&
-        c.sprintStart !== "" &&
-        c.sprintStart < today &&
+        old !== null &&
+        c.sprintStart === old &&
         c.stage !== "done" &&
         !(!c.stage && (c.progress ?? 0) >= 100) &&
         !c.itemId.startsWith("tmp-"),

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -8,7 +8,7 @@ export type ProviderId = "github";
 export type ZoneKey = "gray" | "green" | "yellow" | "red";
 
 /** StageKey is an explicit per-card status that recolours the progress bar. */
-export type StageKey = "locked" | "review" | "done";
+export type StageKey = "locked" | "review" | "recurrent" | "done";
 
 export interface SingleSelectOption {
   id: string;
@@ -160,6 +160,10 @@ export interface Provider {
    *  (a no-op when the sprint is already today's). team = null is the no-team
    *  group. */
   carryOver(board: Board, team: string | null): Promise<void>;
+  /** Pull a team's unfinished plan cards from earlier weeks into the target
+   *  week; a finished recurrent plan card stays and is reseeded as a fresh
+   *  copy in that week instead. */
+  carryWeek(board: Board, team: string | null, week: string): Promise<void>;
   /** Set a team's sprint pointer (current/previous start dates), creating the
    * hidden state card if the team has none yet. team = null is the no-team group. */
   setSprintState(

--- a/web/src/stages.ts
+++ b/web/src/stages.ts
@@ -12,10 +12,13 @@ export interface StageDef {
 export const STAGES: Record<StageKey, StageDef> = {
   locked: { key: "locked", label: "Locked", color: "#cf222e" },
   review: { key: "review", label: "Review", color: "#d4a72c" },
+  // Recurrent marks a repeating task: unlike review/locked its progress spans
+  // the full 0–100%, and Carry Over reseeds a finished one as a fresh copy.
+  recurrent: { key: "recurrent", label: "Recurrent", color: "#58a6ff" },
   done: { key: "done", label: "Done", color: "#1f883d" },
 };
 
-export const STAGE_ORDER: StageKey[] = ["locked", "review", "done"];
+export const STAGE_ORDER: StageKey[] = ["locked", "review", "recurrent", "done"];
 
 /** Progress bar colour for a stage; the default (no stage) bar is green. */
 export const DEFAULT_BAR_COLOR = "#3fb950";
@@ -38,6 +41,8 @@ export function stageFromName(name?: string): StageKey | undefined {
       return "locked";
     case "review":
       return "review";
+    case "recurrent":
+      return "recurrent";
     case "done":
       return "done";
     default:


### PR DESCRIPTION
Sprint-hygiene rules and the new recurrent stage.

- **Carry Over moves only the closing sprint's cards** — a card demoted out of the current sprint no longer boomerangs back; its removal is final.
- **Leaving review cancels the linked review card** — same demote-then-delete logic as the ×; a finished review card stays as a record.
- **Recurrent stage** (light blue, takes over the circling-arrows icon; review gets a pause glyph) — progress spans the full 0–100%; 100% counts as complete. At Carry Over a finished recurrent card stays behind and a fresh copy (same title/description, no notes, 0%) is seeded into the new sprint; carry-week applies the same rule to plan cards with a same-title dedup. In the weekly progress bar it counts as its current %, reset naturally by the weekly reseed. Existing Stage fields gain the Recurrent option in place on first use.
- Carry-week becomes one server-side call behind the provider.

dates.md/api.md/README updated. Verified: go build/vet/test, golangci-lint 0, tsc + vite build.