### PR TITLE
fix(web): clear the review link when cancelling a review by demote

### DIFF
--- a/internal/boardservice/service.go
+++ b/internal/boardservice/service.go
@@ -528,6 +528,17 @@ func (s *Service) SetWeek(ctx context.Context, owner string, project int, itemID
 	return s.backend.SetWeek(ctx, b, card, week)
 }
 
+// SetReviewOf sets (or clears, when reviewOf is empty) the link that marks a
+// card as the review of another. Cancelling a review clears it so the original
+// stops showing "On review".
+func (s *Service) SetReviewOf(ctx context.Context, owner string, project int, itemID, reviewOf string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	return s.backend.SetReviewOf(ctx, b, card, reviewOf)
+}
+
 // SetSprintState sets a team's sprint pointer directly (current/previous sprint
 // start dates; "" clears them). team = "" is the no-team group. It backs the
 // frontend's client-side Carry Over, which advances the pointer then re-dates the

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -87,6 +87,7 @@ func (s *Server) registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/cards/{id}/notes/{noteId}", s.handleEditNote)
 	mux.HandleFunc("DELETE /api/v1/cards/{id}/notes/{noteId}", s.handleDeleteNote)
 	mux.HandleFunc("POST /api/v1/cards/{id}/description", s.handleSetDescription)
+	mux.HandleFunc("POST /api/v1/cards/{id}/review-of", s.handleSetReviewOf)
 	mux.HandleFunc("POST /api/v1/cards/{id}/rename", s.handleRename)
 	mux.HandleFunc("POST /api/v1/cards/{id}/review", s.handleSendToReview)
 	mux.HandleFunc("POST /api/v1/cards/{id}/review/reassign", s.handleReassignReviewer)
@@ -146,6 +147,7 @@ func (s *Server) handleAPIIndex(w http.ResponseWriter, _ *http.Request) {
 			{"PATCH", "/api/v1/cards/{id}/notes/{noteId}", "Edit a work note"},
 			{"DELETE", "/api/v1/cards/{id}/notes/{noteId}", "Delete a work note"},
 			{"POST", "/api/v1/cards/{id}/description", "Set the free-form description"},
+			{"POST", "/api/v1/cards/{id}/review-of", "Set or clear the review link"},
 			{"POST", "/api/v1/cards/{id}/rename", "Rename a card"},
 			{"POST", "/api/v1/cards/{id}/review", "Send to review (creates a review card)"},
 			{"POST", "/api/v1/cards/{id}/review/reassign", "Point the review at another reviewer"},
@@ -597,6 +599,25 @@ func (s *Server) handleDeleteNote(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	if err := svc.DeleteNote(r.Context(), owner, project, id, r.PathValue("noteId")); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	s.cardResponse(w, r, svc, owner, project, id)
+}
+
+func (s *Server) handleSetReviewOf(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		ReviewOf string `json:"reviewOf"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	id := r.PathValue("id")
+	if err := svc.SetReviewOf(r.Context(), owner, project, id, in.ReviewOf); err != nil {
 		s.apiError(w, err)
 		return
 	}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -324,16 +324,20 @@ export function MeBoard({
         startDate: review.startDate,
         sprintStart: review.sprintStart,
         day: review.day,
+        reviewOf: review.reviewOf,
       };
+      // Break the review link too, or the original keeps showing "On review".
       patchCard(review.itemId, {
         startDate: prevS,
         sprintStart: prevS,
+        reviewOf: undefined,
         ...(review.day ? { day: prevS } : {}),
       });
       void (async () => {
         try {
           await provider.setStart(board, review, prevS);
           await provider.setSprintStart(board, review, prevS);
+          await provider.setReviewOf(board, review, null);
           if (review.day && review.day !== prevS) {
             await provider.setDay(board, review, prevS);
           }

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -832,16 +832,20 @@ export function TeamBoard({
         startDate: review.startDate,
         sprintStart: review.sprintStart,
         day: review.day,
+        reviewOf: review.reviewOf,
       };
+      // Break the review link too, or the original keeps showing "On review".
       patchCard(review.itemId, {
         startDate: prevS,
         sprintStart: prevS,
+        reviewOf: undefined,
         ...(review.day ? { day: prevS } : {}),
       });
       void (async () => {
         try {
           await provider.setStart(board, review, prevS);
           await provider.setSprintStart(board, review, prevS);
+          await provider.setReviewOf(board, review, null);
           if (review.day && review.day !== prevS) {
             await provider.setDay(board, review, prevS);
           }

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -187,6 +187,16 @@ export const apiProvider: Provider = {
     });
   },
 
+  async setReviewOf(
+    board: Board,
+    card: Card,
+    reviewOf: string | null,
+  ): Promise<void> {
+    await api<Card>(board, "POST", `/cards/${card.itemId}/review-of`, {
+      reviewOf: reviewOf ?? "",
+    });
+  },
+
   async createCard(board: Board, input: NewCardInput): Promise<Card> {
     return api<Card>(board, "POST", "/cards", {
       title: input.title,

--- a/web/src/providers/github/githubProvider.ts
+++ b/web/src/providers/github/githubProvider.ts
@@ -934,6 +934,28 @@ export const githubProvider: Provider = {
     await graphql(UPDATE_ISSUE_BODY, { id: card.contentId, body: description });
   },
 
+  async setReviewOf(
+    board: Board,
+    card: Card,
+    reviewOf: string | null,
+  ): Promise<void> {
+    const field = await ensureField(board, "reviewOf", "Review Of");
+    if (reviewOf === null) {
+      await graphql(CLEAR_FIELD, {
+        project: board.id,
+        item: card.itemId,
+        field: field.id,
+      });
+      return;
+    }
+    await graphql(SET_TEXT, {
+      project: board.id,
+      item: card.itemId,
+      field: field.id,
+      value: reviewOf,
+    });
+  },
+
   async createCard(board: Board, input: NewCardInput): Promise<Card> {
     const assigneeIds = input.assigneeLogin
       ? [await resolveUserId(input.assigneeLogin)]

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -179,6 +179,8 @@ export interface Provider {
   setTeam(board: Board, card: Card, team: string | null): Promise<void>;
   renameCard(board: Board, card: Card, title: string): Promise<void>;
   setDescription(board: Board, card: Card, description: string): Promise<void>;
+  /** Set (or clear, with null) the link marking card as the review of another. */
+  setReviewOf(board: Board, card: Card, reviewOf: string | null): Promise<void>;
   createCard(board: Board, input: NewCardInput): Promise<Card>;
   deleteCard(board: Board, card: Card): Promise<void>;
   /** Reposition card after afterItemId in the project order (null = top). */


### PR DESCRIPTION
Taking a card off review demoted the linked review card but kept its reviewOf link, so the original kept showing "On review: X". The demote path now clears the link (new POST /cards/{id}/review-of + setReviewOf in both providers). Verified: go build/vet/test, lint 0, tsc + vite build.