### PR TITLE
fix(oauth): persist dynamic MCP client registrations across restarts

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -44,6 +44,20 @@ type oauthSession struct {
 	created time.Time
 }
 
+// persistedState is the on-disk envelope: user sessions plus the dynamically
+// registered MCP OAuth clients (RFC 7591), which must survive restarts — MCP
+// clients cache their client_id and a wiped registry strands them on
+// "unknown client_id" until they re-register.
+type persistedState struct {
+	Sessions map[string]persistedSession `json:"sessions"`
+	Clients  map[string]persistedClient  `json:"clients,omitempty"`
+}
+
+// persistedClient is the on-disk form of an oauthClient.
+type persistedClient struct {
+	RedirectURIs []string `json:"redirectUris"`
+}
+
 // persistedSession is the on-disk form of an oauthSession.
 type persistedSession struct {
 	Token   string    `json:"token"`
@@ -140,19 +154,27 @@ func (a *authManager) load() {
 		}
 		return
 	}
-	var in map[string]persistedSession
-	if err := json.Unmarshal(data, &in); err != nil {
-		a.log.Error("session load: parse failed", "err", err)
-		return
+	var in persistedState
+	if err := json.Unmarshal(data, &in); err != nil || in.Sessions == nil {
+		// Legacy format: a bare map of sessions with no envelope.
+		var legacy map[string]persistedSession
+		if err := json.Unmarshal(data, &legacy); err != nil {
+			a.log.Error("session load: parse failed", "err", err)
+			return
+		}
+		in = persistedState{Sessions: legacy}
 	}
 	now := time.Now()
-	for sid, s := range in {
+	for sid, s := range in.Sessions {
 		if now.Sub(s.Created) > sessionTTL {
 			continue
 		}
 		a.sessions[sid] = oauthSession{token: s.Token, login: s.Login, created: s.Created}
 	}
-	a.log.Info("sessions restored", "count", len(a.sessions))
+	for id, c := range in.Clients {
+		a.clients[id] = oauthClient{redirectURIs: append([]string(nil), c.RedirectURIs...)}
+	}
+	a.log.Info("sessions restored", "count", len(a.sessions), "clients", len(a.clients))
 }
 
 // saveLocked writes the current sessions to disk. Callers must hold a.mu.
@@ -160,9 +182,15 @@ func (a *authManager) saveLocked() {
 	if a.path == "" {
 		return
 	}
-	out := make(map[string]persistedSession, len(a.sessions))
+	out := persistedState{
+		Sessions: make(map[string]persistedSession, len(a.sessions)),
+		Clients:  make(map[string]persistedClient, len(a.clients)),
+	}
 	for sid, s := range a.sessions {
-		out[sid] = persistedSession{Token: s.token, Login: s.login, Created: s.created}
+		out.Sessions[sid] = persistedSession{Token: s.token, Login: s.login, Created: s.created}
+	}
+	for id, c := range a.clients {
+		out.Clients[id] = persistedClient{RedirectURIs: append([]string(nil), c.redirectURIs...)}
 	}
 	data, err := json.Marshal(out)
 	if err != nil {

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -101,6 +101,7 @@ func (a *authManager) handleRegister(w http.ResponseWriter, r *http.Request) {
 	clientID := randToken()
 	a.mu.Lock()
 	a.clients[clientID] = oauthClient{redirectURIs: append([]string(nil), meta.RedirectURIs...)}
+	a.saveLocked()
 	a.mu.Unlock()
 
 	resp := oauthex.ClientRegistrationResponse{
@@ -131,7 +132,8 @@ func (a *authManager) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// A bad client or redirect_uri is a hard 400: redirecting an unverified URI
 	// would be an open redirect.
 	if !ok {
-		writeJSONError(w, http.StatusBadRequest, "unknown client_id")
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client",
+			"unknown client_id — register via /oauth/register")
 		return
 	}
 	if !slices.Contains(client.redirectURIs, redirectURI) {

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -436,5 +437,75 @@ func TestMCPRequiresBearer(t *testing.T) {
 	}
 	if !strings.Contains(wa, testBaseURL+"/.well-known/oauth-protected-resource") {
 		t.Fatalf("WWW-Authenticate = %q, missing metadata URL", wa)
+	}
+}
+
+// A dynamically-registered MCP client must survive a server restart: MCP
+// clients cache their client_id, and a wiped registry would strand them on
+// invalid_client until a manual re-registration.
+func TestOAuthClientRegistrationPersists(t *testing.T) {
+	path := t.TempDir() + "/sessions.json"
+	mk := func() *Server {
+		srv, err := New(Options{
+			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			Auth: &OAuthConfig{
+				ClientID:     "gh-client",
+				ClientSecret: "gh-secret",
+				BaseURL:      testBaseURL,
+				SessionFile:  path,
+			},
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return srv
+	}
+	srv := mk()
+	rec := do(t, srv, http.MethodPost, "/oauth/register", `{"redirect_uris":["`+testRedirectURI+`"]}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register status = %d", rec.Code)
+	}
+	var resp oauthex.ClientRegistrationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh server over the same file must know the client: /oauth/authorize
+	// gets past client validation (302 to GitHub, not a 400 invalid_client).
+	srv2 := mk()
+	aq := url.Values{}
+	aq.Set("client_id", resp.ClientID)
+	aq.Set("redirect_uri", testRedirectURI)
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge("v"))
+	aq.Set("code_challenge_method", "S256")
+	rec = do(t, srv2, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("authorize after restart = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The pre-envelope session file (a bare map of sessions) still loads.
+func TestSessionFileLegacyFormat(t *testing.T) {
+	path := t.TempDir() + "/sessions.json"
+	legacy := `{"sid1":{"token":"gh-tok","login":"octocat","created":"` +
+		time.Now().Format(time.RFC3339Nano) + `"}}`
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Options{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Auth: &OAuthConfig{
+			ClientID:     "gh-client",
+			ClientSecret: "gh-secret",
+			BaseURL:      testBaseURL,
+			SessionFile:  path,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := srv.auth.sessions["sid1"]; !ok {
+		t.Fatal("legacy session not restored")
 	}
 }


### PR DESCRIPTION
Dynamically registered MCP OAuth clients (RFC 7591) lived only in memory: every restart wiped the registry while MCP clients kept their cached client_id, stranding them on {"error":"unknown client_id"} at /oauth/authorize until a manual re-registration. This surfaced right after the last deploy.

Registrations are now persisted alongside sessions in the session file. The file gains an envelope ({sessions, clients}); the legacy bare session map still loads, so existing production sessions survive the upgrade. The unknown-client response is now a proper OAuth invalid_client error, letting spec-following clients recover by re-registering on their own.

Verified with new tests: a registered client survives a server restart over the same session file, and the legacy file format still restores sessions.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein