### PR TITLE
fix(oauth): auto-register unknown loopback clients on authorize

### DIFF
--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -132,9 +132,23 @@ func (a *authManager) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// A bad client or redirect_uri is a hard 400: redirecting an unverified URI
 	// would be an open redirect.
 	if !ok {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client",
-			"unknown client_id — register via /oauth/register")
-		return
+		// Self-heal a stale registration. The authorize step runs in the user's
+		// browser, so the MCP client never sees this error and cannot re-register
+		// on its own. For loopback redirect URIs re-registering on the fly is
+		// safe (RFC 8252): the authorization code can only land on the
+		// initiator's own machine, so there is nothing for a remote attacker to
+		// phish. Anything else keeps the hard error.
+		if clientID == "" || !isLoopbackRedirect(redirectURI) {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_client",
+				"unknown client_id — register via /oauth/register")
+			return
+		}
+		client = oauthClient{redirectURIs: []string{redirectURI}}
+		a.mu.Lock()
+		a.clients[clientID] = client
+		a.saveLocked()
+		a.mu.Unlock()
+		a.log.Info("oauth: auto-registered unknown loopback client", "client_id", clientID)
 	}
 	if !slices.Contains(client.redirectURIs, redirectURI) {
 		writeJSONError(w, http.StatusBadRequest, "redirect_uri is not registered for this client")
@@ -381,4 +395,16 @@ func (a *authManager) redirectError(w http.ResponseWriter, r *http.Request, redi
 // writeOAuthError writes an RFC 6749 token-endpoint error response.
 func writeOAuthError(w http.ResponseWriter, status int, code, desc string) {
 	writeJSON(w, status, map[string]string{"error": code, "error_description": desc})
+}
+
+// isLoopbackRedirect reports whether a redirect URI points at the local
+// machine (http://localhost, 127.0.0.1 or [::1], any port/path) — the only
+// redirect targets an unknown client may auto-register with.
+func isLoopbackRedirect(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "http" {
+		return false
+	}
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -230,20 +230,6 @@ func TestOAuthRegisterRequiresRedirectURIs(t *testing.T) {
 	}
 }
 
-func TestOAuthAuthorizeUnknownClient(t *testing.T) {
-	srv, _ := newOAuthServer(t)
-	aq := url.Values{}
-	aq.Set("client_id", "does-not-exist")
-	aq.Set("redirect_uri", testRedirectURI)
-	aq.Set("response_type", "code")
-	aq.Set("code_challenge", "x")
-	aq.Set("code_challenge_method", "S256")
-	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
-	}
-}
-
 func TestOAuthAuthorizeUnregisteredRedirect(t *testing.T) {
 	srv, _ := newOAuthServer(t)
 	clientID := registerClient(t, srv, testRedirectURI)
@@ -507,5 +493,46 @@ func TestSessionFileLegacyFormat(t *testing.T) {
 	}
 	if _, ok := srv.auth.sessions["sid1"]; !ok {
 		t.Fatal("legacy session not restored")
+	}
+}
+
+// An unknown client with a loopback redirect self-heals: the authorize step
+// runs in the browser, so the MCP client cannot see the error and re-register
+// on its own — the server registers it on the fly instead (safe per RFC 8252:
+// the code can only land on the initiator's own machine).
+func TestOAuthAuthorizeAutoRegistersLoopbackClient(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	aq := url.Values{}
+	aq.Set("client_id", "stale-cached-client")
+	aq.Set("redirect_uri", "http://localhost:3118/callback")
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge("v"))
+	aq.Set("code_challenge_method", "S256")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, body = %s (loopback client must auto-register)", rec.Code, rec.Body.String())
+	}
+	srv.auth.mu.Lock()
+	_, ok := srv.auth.clients["stale-cached-client"]
+	srv.auth.mu.Unlock()
+	if !ok {
+		t.Fatal("client not persisted in the registry")
+	}
+}
+
+// A non-loopback redirect for an unknown client keeps the hard error: blindly
+// registering a remote redirect target would hand authorization codes to
+// whoever crafted the link.
+func TestOAuthAuthorizeUnknownClientRemoteRedirect(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	aq := url.Values{}
+	aq.Set("client_id", "stale-cached-client")
+	aq.Set("redirect_uri", "https://evil.example/callback")
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge("v"))
+	aq.Set("code_challenge_method", "S256")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 }


### PR DESCRIPTION
Persisting registrations (#16) protects future restarts, but a client whose registration was already lost still dead-ends: the authorize step runs in the user's browser, so the MCP client never sees the invalid_client error and cannot re-register on its own — it just waits for a callback that never comes.

When the redirect URI is loopback (http://localhost, 127.0.0.1 or [::1]), the server now registers the unknown client on the fly and continues the flow. This is safe per RFC 8252 native-app reasoning: the authorization code can only be delivered to a listener on the initiator's own machine, so there is nothing for a remote attacker to phish, and PKCE still binds the code to the initiator. Unknown clients with remote redirect URIs keep the hard invalid_client error.

Covered by tests on both sides of the boundary: a loopback client auto-registers (and lands in the persisted registry), a remote redirect stays a 400.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein