### PR TITLE
feat(review): never auto-remove worked-on review cards; carry only live reviews

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -144,3 +144,11 @@ plan progress (V2). Each is pinned by the 🆕 tests above.
 | L2 | Create-by-URL: a title that is only a GitHub issue/PR URL resolves to that item's title, the link moves into the description; unresolvable keeps the URL title | boardservice.CreateCard | ✅ TestCreateCardFromGitHubURL / FromURLUnresolved |
 | L3 | UI: hashtag icon (link icon when only plain links) before the stage icon; one menu, refs-with-titles first, plain links as-is; click opens a new tab | Card.tsx + links.ts mirror | manual |
 | L4 | Send-to-review copies the description; afterwards it LIVE-SYNCS across the review link both ways (notes stay per-card) | boardservice.SendToReview / SetDescription | ✅ TestSendToReviewCopiesDescription, TestSetDescriptionSyncsAcrossReviewLink |
+
+## Review-card lifecycle (2026-07-02)
+
+| # | Rule | Lives in | Test |
+| --- | --- | --- | --- |
+| R1 | A review card the reviewer worked on (progress > 0) is never auto-removed: leaving review / done keeps it untouched, link intact | boardservice.cancelLinkedReview | ✅ TestStageOffReviewKeepsWorkedReviewCard |
+| R2 | Reassigning a reviewer who worked keeps their card (released from the link, stays behind on the next carry) and spawns a fresh review card; an untouched card is handed over in place | boardservice.ReassignReviewer | ✅ TestReassignWorkedReviewerSpawnsNewCard / InPlace |
+| R3 | Carry-over moves a review card only while the review is still required: original unfinished on the review stage + a reviewer assigned; stale review work stays behind | boardservice.CarryOver | ✅ TestCarryOverReviewCardsOnlyWhileRequired |

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -289,6 +289,13 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		if board.Complete(c.Stage, c.Progress) {
 			continue
 		}
+		// A review card crosses sprints only while its review is still on: the
+		// original must still sit on the review stage unfinished, and the card
+		// must still be the assigned reviewer's. Stale review work (original
+		// done, reviewer swapped, link severed) stays behind.
+		if c.ReviewOf != "" && !reviewStillRequired(b, c) {
+			continue
+		}
 		carry = append(carry, c)
 	}
 	rep := CarryReport{Carried: len(carry), Reseeded: len(reseed)}
@@ -611,6 +618,12 @@ func (s *Service) cancelLinkedReview(ctx context.Context, b board.Board, origina
 	if !ok || board.Complete(review.Stage, review.Progress) {
 		return nil
 	}
+	// The reviewer already put work into it (progress > 0): never auto-remove
+	// that work. The card stays in place, link intact — the next carry-over
+	// decides its fate (it only travels while the review is still required).
+	if review.Progress > 0 {
+		return nil
+	}
 	cur := board.CurrentSprint(b, review.Team)
 	prev := board.PreviousSprint(b, review.Team)
 	if review.SprintStart != "" && cur != "" && review.SprintStart == cur && prev != "" && prev < cur {
@@ -868,7 +881,34 @@ func (s *Service) ReassignReviewer(ctx context.Context, owner string, project in
 		_, err := s.sendToReview(ctx, b, card, reviewer, day)
 		return err
 	}
-	return s.backend.SetAssignee(ctx, b, reviewCard, reviewer)
+	// An untouched review card is simply handed to the new reviewer. One the
+	// old reviewer already worked on (progress > 0) keeps their work: it is
+	// released from the link (a standalone card now — the next carry-over
+	// leaves it behind) and a fresh review card is created for the new
+	// reviewer.
+	if reviewCard.Progress == 0 {
+		return s.backend.SetAssignee(ctx, b, reviewCard, reviewer)
+	}
+	if err := s.backend.SetReviewOf(ctx, b, reviewCard, ""); err != nil {
+		return err
+	}
+	_, err = s.sendToReview(ctx, b, card, reviewer, day)
+	return err
+}
+
+// reviewStillRequired reports whether a review card's review is still on: its
+// original is on the board, unfinished, on the review stage, and the review
+// card still has a reviewer assigned.
+func reviewStillRequired(b board.Board, review board.Card) bool {
+	if len(review.Assignees) == 0 {
+		return false
+	}
+	for _, c := range b.Cards {
+		if c.ItemID == review.ReviewOf {
+			return c.Stage == board.StageReview && !board.Complete(c.Stage, c.Progress)
+		}
+	}
+	return false
 }
 
 // RemoveReviewer deletes a card's linked review card (a no-op when there is

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1046,7 +1046,7 @@ func TestRemovePlanDeletesWithoutEarlierWeek(t *testing.T) {
 func TestStageOffReviewDemotesLinkedReview(t *testing.T) {
 	f := newFake([]board.Card{
 		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
-		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40,
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig",
 			StartDate: "2026-01-10", SprintStart: "2026-01-10", Day: "2026-01-10"},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", Previous: "2026-01-03"}})
 	if err := f2svc(f).SetStage(ctx, "acme", 1, "orig", board.StageNone); err != nil {
@@ -1064,7 +1064,7 @@ func TestStageOffReviewDemotesLinkedReview(t *testing.T) {
 func TestStageOffReviewDeletesLinkedOutsideCurrentSprint(t *testing.T) {
 	f := newFake([]board.Card{
 		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
-		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40, SprintStart: "2026-01-03"},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", SprintStart: "2026-01-03"},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", Previous: "2026-01-03"}})
 	if err := f2svc(f).SetStage(ctx, "acme", 1, "orig", board.StageLocked); err != nil {
 		t.Fatal(err)
@@ -1090,7 +1090,7 @@ func TestStageOffReviewKeepsFinishedReview(t *testing.T) {
 func TestInProgressCancelsLinkedReview(t *testing.T) {
 	f := newFake([]board.Card{
 		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
-		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40, SprintStart: "2026-01-03"},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", SprintStart: "2026-01-03"},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", Previous: "2026-01-03"}})
 	if err := f2svc(f).SetInProgress(ctx, "acme", 1, "orig"); err != nil {
 		t.Fatal(err)
@@ -1286,5 +1286,86 @@ func TestSetDescriptionSyncsAcrossReviewLink(t *testing.T) {
 	}
 	if fake2.count("SetDescription") != 1 {
 		t.Fatal("no counterpart, no extra write")
+	}
+}
+
+// --- Worked-on review cards are never auto-removed (lifecycle rules) ---------
+
+// A review card the reviewer already put progress into stays untouched when
+// the original leaves review (done, locked, in-progress) — link intact.
+func TestStageOffReviewKeepsWorkedReviewCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40,
+			StartDate: "2026-01-10", SprintStart: "2026-01-10"},
+	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", Previous: "2026-01-03"}})
+	if err := f2svc(f).SetStage(ctx, "acme", 1, "orig", board.StageDone); err != nil {
+		t.Fatal(err)
+	}
+	r := f.get("rev")
+	if r == nil || r.SprintStart != "2026-01-10" || r.ReviewOf != "orig" || r.Progress != 40 {
+		t.Fatalf("a worked-on review card must stay untouched: %+v", r)
+	}
+}
+
+// Reassigning a reviewer who already worked keeps their card (released from
+// the link) and spawns a fresh review card for the new reviewer.
+func TestReassignWorkedReviewerSpawnsNewCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Team: "alpha", Title: "Work", Stage: board.StageReview, Progress: 50},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40, Assignees: []string{"old"}},
+	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("SetReviewOf rev ") {
+		t.Fatal("the worked-on card must be released from the link")
+	}
+	if len(f.creates) != 1 || f.creates[0].Assignee != "new" || f.creates[0].ReviewOf != "orig" {
+		t.Fatalf("a fresh review card for the new reviewer: %+v", f.creates)
+	}
+	if r := f.get("rev"); r == nil || r.Progress != 40 {
+		t.Fatalf("the old reviewer's work stays: %+v", r)
+	}
+}
+
+// An untouched (0%) review card is still simply handed over.
+func TestReassignUntouchedReviewerInPlace(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Assignees: []string{"old"}},
+	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10"); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.creates) != 0 || !f.saw("SetAssignee rev new") {
+		t.Fatalf("an untouched review card is reassigned in place; creates=%v", f.creates)
+	}
+}
+
+// Carry-over moves a review card only while its review is still required: the
+// original unfinished on the review stage and a reviewer assigned.
+func TestCarryOverReviewCardsOnlyWhileRequired(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "origDone", Team: "alpha", Progress: 100, SprintStart: "2026-01-01"},
+		{ItemID: "revStale", Team: "alpha", ReviewOf: "origDone", Progress: 40,
+			Assignees: []string{"bob"}, SprintStart: "2026-01-01"},
+		{ItemID: "origLive", Team: "alpha", Stage: board.StageReview, Progress: 50, SprintStart: "2026-01-01"},
+		{ItemID: "revLive", Team: "alpha", ReviewOf: "origLive", Progress: 40,
+			Assignees: []string{"bob"}, SprintStart: "2026-01-01"},
+	}, map[string]board.SprintState{"alpha": {Current: "2026-01-01", ItemID: "s1"}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// origLive + revLive carry; origDone finished; revStale left behind.
+	if rep.Carried != 2 {
+		t.Fatalf("carried = %d, want 2 (the stale review card stays)", rep.Carried)
+	}
+	if f.get("revStale").SprintStart != "2026-01-01" {
+		t.Fatal("stale review card must not be dragged forward")
+	}
+	if f.get("revLive").SprintStart == "2026-01-01" {
+		t.Fatal("a still-required review card carries")
 	}
 }


### PR DESCRIPTION
A review card whose reviewer already put progress into it (progress > 0) represents real work and is never auto-removed anymore. Taking the original off review — done, locked or back to In Progress — leaves it untouched, link intact. Reassigning such a reviewer keeps their card as well: it is released from the review link (becoming a standalone record of the work) and a fresh 0% review card is created for the new reviewer. An untouched (0%) review card keeps today's behaviour on both paths: cancel demotes-or-deletes it, reassign hands it over in place.

Carry-over gains the matching lifecycle check: a review card crosses into the next sprint only while its review is still required — its original still sits unfinished on the review stage and the card still has a reviewer assigned. Stale review work (original finished, reviewer swapped, link severed) stays behind in the closing sprint.

Covered by service tests on all branches (kept-when-worked, reassign spawn vs in-place, carry required-vs-stale) with the pre-existing cancel tests re-pinned to untouched cards; the behaviour matrix documents the rules (R1-R3).

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein