### PR TITLE
feat(web): Today button on both boards

### DIFF
--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -721,6 +721,16 @@ export function MeBoard({
           filterToggle={{ on: teamFocus, onToggle: () => setTeamFocus((v) => !v) }}
         />
 
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setSelectedDate(todayIso())}
+          disabled={selectedDate === todayIso()}
+          title="Jump to today"
+        >
+          Today
+        </button>
+
         <div className="field field-inline impersonate" ref={impRef}>
           <button
             type="button"

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1476,6 +1476,15 @@ export function TeamBoard({
             ? `${sprintJump.label} »`
             : `« ${sprintJump?.label ?? "Last sprint"}`}
         </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setSelectedDate(todayIso())}
+          disabled={selectedDate === todayIso()}
+          title="Jump to today"
+        >
+          Today
+        </button>
         <div className="sprint-wrap" ref={sprintRef}>
           <button
             type="button"


### PR DESCRIPTION
Browsing history (a previous sprint, an arbitrary day) currently leaves no one-click way back to the present. Both boards gain a Today button that jumps the day selector straight back to today: on the Team board it sits to the right of the Last/Current sprint button, on the Me board right before View as. The button is disabled while the board is already showing today.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein