### PR TITLE
feat(presence): live shared selection + Me-view keyboard navigation

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -76,6 +76,7 @@ func (s *Server) registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/sprints/actions/carry-over", s.handleCarryOver)
 	mux.HandleFunc("POST /api/v1/sprints/actions/carry-week", s.handleCarryWeek)
 	mux.HandleFunc("GET /api/v1/ordering", s.handleGetOrdering)
+	mux.HandleFunc("POST /api/v1/presence", s.handleSetPresence)
 	mux.HandleFunc("GET /api/v1/watch", s.handleWatch)
 }
 
@@ -127,6 +128,7 @@ func (s *Server) handleAPIIndex(w http.ResponseWriter, _ *http.Request) {
 			{"POST", "/api/v1/sprints/actions/carry-over", "Advance a team's sprint to today, carry unfinished ({team, dryRun})"},
 			{"POST", "/api/v1/sprints/actions/carry-week", "Pull unfinished plan cards into the week ({team, week, dryRun})"},
 			{"GET", "/api/v1/ordering", "The board-level manual card order"},
+			{"POST", "/api/v1/presence", "Share the caller's live card selection ({login, card}; empty card clears)"},
 			{"GET", "/api/v1/watch", "WebSocket stream of Card/Sprint/Ordering events; selector-scoped with view params"},
 		},
 	})
@@ -873,6 +875,30 @@ func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Shared helpers ----------------------------------------------------------------
+
+// handleSetPresence records the caller's live Me-view selection — ephemeral
+// shared-cursor state broadcast over the watch, never persisted. The client id
+// (X-Aeman-Client) keys it, so a closed tab clears its own mark.
+func (s *Server) handleSetPresence(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Login string `json:"login"`
+		Card  string `json:"card"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	owner, project, err := s.boardRef(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, err := s.newService(r); err != nil {
+		writeJSONError(w, http.StatusUnauthorized, "not authenticated: "+err.Error())
+		return
+	}
+	s.store.SetPresence(storeKey(owner, project), clientIDFrom(r.Context()), in.Login, in.Card)
+	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
+}
 
 // cardResponse loads the (post-mutation) card and writes it as the resource —
 // mutations echo the card exactly as a fresh GET would return it.

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -78,6 +78,10 @@ type boardEntry struct {
 	// watchers is the subscription set; each carries its own scope and echo
 	// suppression id.
 	watchers map[*subscription]struct{}
+	// presence maps a client id to the card its user has selected in the Me
+	// view — ephemeral shared-cursor state, never persisted, cleared when the
+	// client's watch connection goes away.
+	presence map[string]presenceEntry
 	// recentCards / recentGone guard the cache against GitHub's eventually
 	// consistent item list: a card created (or deleted) through aeman seconds
 	// ago may still be missing from (or present in) a fresh full load, and a
@@ -262,6 +266,58 @@ func (e *boardEntry) orderingChanged(origin string) {
 	}
 }
 
+// presenceEntry is one user's live selection: the card their Me view has
+// selected right now.
+type presenceEntry struct {
+	Login string `json:"login"`
+	Card  string `json:"card"`
+}
+
+// presenceChanged announces one user's selection to every subscription that
+// wants presence, skipping the originator (their own tab already shows it).
+// The caller holds e.mu.
+func (e *boardEntry) presenceChanged(origin string, entry presenceEntry) {
+	for sub := range e.watchers {
+		if !sub.resources["presence"] || (origin != "" && sub.clientID == origin) {
+			continue
+		}
+		sub.send(watchFrame{Type: "MODIFIED", Kind: "Presence", Object: entry})
+	}
+}
+
+// SetPresence records (card != "") or clears (card == "") the selection of the
+// client's user and broadcasts it.
+func (s *boardStore) SetPresence(key, clientID, login, card string) {
+	if clientID == "" {
+		return
+	}
+	e := s.entry(key)
+	e.mu.Lock()
+	if card == "" {
+		delete(e.presence, clientID)
+	} else {
+		e.presence[clientID] = presenceEntry{Login: login, Card: card}
+	}
+	e.presenceChanged(clientID, presenceEntry{Login: login, Card: card})
+	e.mu.Unlock()
+}
+
+// ClearPresence drops a departing client's selection (the watch connection
+// closed) and tells everyone.
+func (s *boardStore) ClearPresence(key, clientID string) {
+	if clientID == "" {
+		return
+	}
+	e := s.entry(key)
+	e.mu.Lock()
+	entry, ok := e.presence[clientID]
+	if ok {
+		delete(e.presence, clientID)
+		e.presenceChanged(clientID, presenceEntry{Login: entry.Login, Card: ""})
+	}
+	e.mu.Unlock()
+}
+
 // moveCardTo reorders the cached card to sit after afterID ("" = the top), so
 // snapshots keep serving the board in its real order after a move.
 func (e *boardEntry) moveCardTo(itemID, afterID string) {
@@ -339,7 +395,10 @@ func (s *boardStore) entry(key string) *boardEntry {
 	defer s.mu.Unlock()
 	e, ok := s.entries[key]
 	if !ok {
-		e = &boardEntry{watchers: map[*subscription]struct{}{}}
+		e = &boardEntry{
+			watchers: map[*subscription]struct{}{},
+			presence: map[string]presenceEntry{},
+		}
 		s.entries[key] = e
 	}
 	return e
@@ -366,6 +425,11 @@ func (s *boardStore) subscribe(key, clientID string, sel *apiserver.Selector, re
 		}
 	}
 	e.watchers[sub] = struct{}{}
+	if resources["presence"] {
+		for _, entry := range e.presence {
+			sub.send(watchFrame{Type: "MODIFIED", Kind: "Presence", Object: entry})
+		}
+	}
 	e.mu.Unlock()
 	return sub, func() {
 		e.mu.Lock()

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -51,7 +51,7 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	resources := map[string]bool{"cards": true, "sprints": true, "ordering": true}
+	resources := map[string]bool{"cards": true, "sprints": true, "ordering": true, "presence": true}
 	if raw := q.Get("resources"); raw != "" {
 		resources = map[string]bool{}
 		for _, kind := range strings.Split(raw, ",") {
@@ -77,8 +77,11 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 	ctx := conn.CloseRead(r.Context())
 
 	key := storeKey(owner, project)
-	sub, cancel := s.store.subscribe(key, q.Get("client"), sel, resources)
+	clientID := q.Get("client")
+	sub, cancel := s.store.subscribe(key, clientID, sel, resources)
 	defer cancel()
+	// A closed tab takes its live selection with it.
+	defer s.store.ClearPresence(key, clientID)
 
 	ping := time.NewTicker(30 * time.Second)
 	defer ping.Stop()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   type OrderingResource,
   type SprintResource,
   type WatchFrame,
+  type PresenceResource,
 } from "./api/resources";
 import type { Board, Card as CardModel } from "./providers/types";
 import { MeBoard } from "./components/MeBoard";
@@ -71,6 +72,9 @@ export function App() {
   const fetchedUsers = useRef<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Live selections of other users (login -> card uid), fed by Presence
+  // watch frames; purely ephemeral shared-cursor state.
+  const [presence, setPresenceMap] = useState<Record<string, string>>({});
   const [detailCard, setDetailCard] = useState<CardModel | null>(null);
 
   // Team roster + filter, persisted in localStorage. The roster is the union of
@@ -385,9 +389,27 @@ export function App() {
       }
       if (frame.kind === "Ordering") {
         reorderCards((frame.object as OrderingResource).spec.uids);
+        return;
+      }
+      if (frame.kind === "Presence") {
+        const { login, card } = frame.object as PresenceResource;
+        if (!login) {
+          return;
+        }
+        setPresenceMap((cur) => {
+          const next = { ...cur };
+          if (card) {
+            next[login] = card;
+          } else {
+            delete next[login];
+          }
+          return next;
+        });
       }
     };
     const connect = () => {
+      // A fresh connection replays the presence snapshot; drop stale marks.
+      setPresenceMap({});
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       // No selector params: an unscoped watch streams every Card/Sprint/Ordering
       // change; ?client= keeps our own mutations from echoing back.
@@ -637,6 +659,13 @@ export function App() {
             reload={reload}
             onError={onError}
             onOpen={(c) => setDetailCard(c)}
+            onPresence={(card) => {
+              if (board && config?.login) {
+                void provider
+                  .setPresence(board, config.login, card)
+                  .catch(() => {});
+              }
+            }}
           />
         )}
         {board && view === "team" && (
@@ -656,6 +685,7 @@ export function App() {
             addCard={addCard}
             removeCard={removeCard}
             reorderCards={reorderCards}
+            presence={presence}
             reload={reload}
             onError={onError}
             onOpen={(c) => setDetailCard(c)}

--- a/web/src/api/resources.ts
+++ b/web/src/api/resources.ts
@@ -116,6 +116,13 @@ export interface NoteListResource {
   items: NoteResource[] | null;
 }
 
+/** PresenceResource is one user's live Me-view selection, broadcast over the
+ * watch ("" card = cleared). Ephemeral: never part of the board data. */
+export interface PresenceResource {
+  login?: string;
+  card?: string;
+}
+
 /** WatchFrame is one event on the /api/v1/watch WebSocket. */
 export interface WatchFrame {
   type?: "ADDED" | "MODIFIED" | "DELETED";

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -543,7 +543,7 @@ export function Card({
             <img
               key={login}
               className="card-presence-avatar"
-              style={{ left: `${-10 - i * 12}px` }}
+              style={{ left: `${-17 - i * 12}px` }}
               src={avatarUrlFor(login, users?.[login])}
               alt=""
               title={`Selected by ${displayName(login, users?.[login])}`}

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -417,7 +417,7 @@ export function Card({
 
   return (
     <div
-      className={`card${selected || (selectedBy?.length ?? 0) > 0 ? " card-selected" : ""}${
+      className={`card${selected ? " card-selected" : ""}${(selectedBy?.length ?? 0) > 0 ? " card-peer-selected" : ""}${
         card.plan ? ` card-plan-${card.plan}` : ""
       }${taken ? " card-plan-taken" : ""}${card.reviewOf ? " card-review" : ""}${
         dimAvatar ? " card-dim-avatar" : ""
@@ -543,7 +543,7 @@ export function Card({
             <img
               key={login}
               className="card-presence-avatar"
-              style={{ right: `${-10 - i * 12}px` }}
+              style={{ left: `${-10 - i * 12}px` }}
               src={avatarUrlFor(login, users?.[login])}
               alt=""
               title={`Selected by ${displayName(login, users?.[login])}`}

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -60,6 +60,9 @@ interface CardProps {
   /** Resolve the card's description links server-side (GitHub issue/PR refs
    *  get their titles). The menu falls back to the local extraction. */
   onLoadLinks?: (card: CardModel) => Promise<CardLink[]>;
+  /** Logins of teammates whose Me view has this card selected right now: the
+   *  card highlights and their avatars hang off its right border. */
+  selectedBy?: string[];
 }
 
 const SEGMENTS = 10;
@@ -103,6 +106,7 @@ export function Card({
   onSetWeek,
   dimAvatar,
   onLoadLinks,
+  selectedBy,
 }: CardProps) {
   // Done is derived, not stored: a card with no stage at 100% renders as done
   // (legacy cards with a stored Done option still count too).
@@ -413,7 +417,7 @@ export function Card({
 
   return (
     <div
-      className={`card${selected ? " card-selected" : ""}${
+      className={`card${selected || (selectedBy?.length ?? 0) > 0 ? " card-selected" : ""}${
         card.plan ? ` card-plan-${card.plan}` : ""
       }${taken ? " card-plan-taken" : ""}${card.reviewOf ? " card-review" : ""}${
         dimAvatar ? " card-dim-avatar" : ""
@@ -533,6 +537,20 @@ export function Card({
         {stageVisible && stageControl}
       </span>
 
+      {selectedBy && selectedBy.length > 0 && (
+        <span className="card-presence" aria-hidden="true">
+          {selectedBy.map((login, i) => (
+            <img
+              key={login}
+              className="card-presence-avatar"
+              style={{ right: `${-10 - i * 12}px` }}
+              src={avatarUrlFor(login, users?.[login])}
+              alt=""
+              title={`Selected by ${displayName(login, users?.[login])}`}
+            />
+          ))}
+        </span>
+      )}
       {card.createdAt && (
         <div
           className="card-age-wrap"

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -46,6 +46,8 @@ interface MeBoardProps {
   reload: () => void;
   onError: (message: string) => void;
   onOpen: (card: CardModel) => void;
+  /** Share the live selection with other boards ("" clears on deselect). */
+  onPresence?: (card: string | null) => void;
 }
 
 /** Per-group metadata for the Me board: just the destination zone. */
@@ -80,9 +82,17 @@ export function MeBoard({
   reload,
   onError,
   onOpen,
+  onPresence,
 }: MeBoardProps) {
   const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  // Broadcast the selection as shared presence: teammates' Team boards
+  // highlight this card with our avatar. Cleared on deselect and unmount.
+  useEffect(() => {
+    onPresence?.(selectedCardId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCardId]);
+  useEffect(() => () => onPresence?.(null), []); // eslint-disable-line react-hooks/exhaustive-deps
   // Eye toggle by the team chips: when on, show only the selected teams' cards.
   // Deliberately not persisted — resets to off (show all) on reload.
   const [teamFocus, setTeamFocus] = useState(false);

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -561,6 +561,74 @@ export function MeBoard({
     [byZone],
   );
 
+  // Keyboard navigation over the visible day list (zone bands top to bottom):
+  // arrows move the selection, Shift+arrows reorder the selected card, Escape
+  // deselects. Ignored while typing in an input.
+  const flatCards = useMemo(() => groups.flatMap((g) => g.cards), [groups]);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "Escape") {
+        setSelectedCardId(null);
+        return;
+      }
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
+        return;
+      }
+      if (flatCards.length === 0) {
+        return;
+      }
+      e.preventDefault();
+      const idx = flatCards.findIndex((c) => c.itemId === selectedCardId);
+      const dir = e.key === "ArrowDown" ? 1 : -1;
+      if (!e.shiftKey) {
+        const next =
+          idx < 0
+            ? dir === 1
+              ? 0
+              : flatCards.length - 1
+            : Math.min(Math.max(idx + dir, 0), flatCards.length - 1);
+        setSelectedCardId(flatCards[next].itemId);
+        return;
+      }
+      // Shift+arrow: reorder the selected card past its visible neighbour.
+      if (idx < 0) {
+        return;
+      }
+      const swap = idx + dir;
+      if (swap < 0 || swap >= flatCards.length) {
+        return;
+      }
+      const card = flatCards[idx];
+      const afterId =
+        dir === 1
+          ? flatCards[swap].itemId
+          : swap - 1 >= 0
+            ? flatCards[swap - 1].itemId
+            : null;
+      const order = board.cards
+        .map((c) => c.itemId)
+        .filter((id) => id !== card.itemId);
+      const pos = afterId ? order.indexOf(afterId) + 1 : 0;
+      order.splice(pos, 0, card.itemId);
+      reorderCards(order);
+      void provider.moveCard(board, card.itemId, afterId).catch((err: unknown) => {
+        reload();
+        onError(errMessage(err));
+      });
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [flatCards, selectedCardId, board, provider, reorderCards, reload, onError]);
+
   const handleDrop = ({ card, fromMeta, toMeta, groups: g }: DropResult<MeMeta>) => {
     const zoneChanged = fromMeta.zone !== toMeta.zone;
 

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -765,13 +765,15 @@ export function TeamBoard({
   // clears a legacy stored done below full, and — when this is a review card —
   // drives the original's review stage. The optimistic patch mirrors the
   // clamps; the re-list converges the linked original.
-  // Who has this card selected in their Me view right now (excluding me).
+  // Who has this card selected in their Me view right now. Own selections
+  // from another window count too — the map only ever carries OTHER tabs'
+  // marks (this tab's watch echo is suppressed), so nothing self-duplicates.
   const selectedByFor = (card: CardModel): string[] | undefined => {
     if (!presence) {
       return undefined;
     }
     const logins = Object.entries(presence)
-      .filter(([login, uid]) => uid === card.itemId && login !== me)
+      .filter(([, uid]) => uid === card.itemId)
       .map(([login]) => login);
     return logins.length > 0 ? logins : undefined;
   };

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -53,6 +53,8 @@ interface TeamBoardProps {
   removeCard: (itemId: string) => void;
   reorderCards: (orderedItemIds: string[]) => void;
   reload: () => void;
+  /** Other users' live selections (login -> card uid) shown as avatars. */
+  presence?: Record<string, string>;
   onError: (message: string) => void;
   onOpen: (card: CardModel) => void;
 }
@@ -97,6 +99,7 @@ export function TeamBoard({
   removeCard,
   reorderCards,
   reload,
+  presence,
   onError,
   onOpen,
 }: TeamBoardProps) {
@@ -762,6 +765,17 @@ export function TeamBoard({
   // clears a legacy stored done below full, and — when this is a review card —
   // drives the original's review stage. The optimistic patch mirrors the
   // clamps; the re-list converges the linked original.
+  // Who has this card selected in their Me view right now (excluding me).
+  const selectedByFor = (card: CardModel): string[] | undefined => {
+    if (!presence) {
+      return undefined;
+    }
+    const logins = Object.entries(presence)
+      .filter(([login, uid]) => uid === card.itemId && login !== me)
+      .map(([login]) => login);
+    return logins.length > 0 ? logins : undefined;
+  };
+
   // Resolve a card's description links (GitHub refs get titles) for the menu.
   const loadCardLinks = (card: CardModel) =>
     provider.listLinks(board, card.itemId);
@@ -1528,6 +1542,7 @@ export function TeamBoard({
           group.meta.kind === "band" ? (
             <Card
               card={card}
+              selectedBy={selectedByFor(card)}
               onLoadLinks={loadCardLinks}
               selected={card.itemId === selectedCardId}
               onSelect={(c) => setSelectedCardId(c.itemId)}
@@ -1555,6 +1570,7 @@ export function TeamBoard({
           ) : (
             <Card
               card={card}
+              selectedBy={selectedByFor(card)}
               onLoadLinks={loadCardLinks}
               selected={card.itemId === selectedCardId}
               onSelect={(c) => setSelectedCardId(c.itemId)}
@@ -1582,6 +1598,7 @@ export function TeamBoard({
           renderOverlay={(card) => (
             <Card
               card={card}
+              selectedBy={selectedByFor(card)}
               onLoadLinks={loadCardLinks}
               selected={false}
               onSelect={() => {}}

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -318,6 +318,15 @@ export const apiProvider: Provider = {
     return list.items ?? [];
   },
 
+  async setPresence(
+    board: BoardAddr,
+    login: string,
+    card: string | null,
+  ): Promise<void> {
+    const uid = card && !card.startsWith("tmp-") ? card : "";
+    await api(board, "POST", "/presence", { login, card: uid });
+  },
+
   async listNotes(board: BoardAddr, uid: string): Promise<Note[]> {
     uid = await resolveCardId(uid);
     return notesFrom(board, "GET", `/cards/${uid}/notes`);

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -188,6 +188,8 @@ export interface Provider {
   /** URLs from the card's description: GitHub issue/PR refs (resolved with
    *  titles when possible) first, plain links after. */
   listLinks(board: BoardAddr, uid: string): Promise<CardLink[]>;
+  /** Share the caller's live card selection ("" clears) with other boards. */
+  setPresence(board: BoardAddr, login: string, card: string | null): Promise<void>;
   listNotes(board: BoardAddr, uid: string): Promise<Note[]>;
   addNote(board: BoardAddr, uid: string, text: string): Promise<Note[]>;
   editNote(

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2206,3 +2206,17 @@ button.card-age {
 .card-links:last-child {
   margin-right: -3px;
 }
+
+/* Shared presence: a teammate has this card selected in their Me view. Their
+   avatar is a team-badge-sized circle hanging 60% off the card's right border. */
+.card-presence-avatar {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--bg);
+  background: var(--bg-soft);
+  z-index: 3;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2211,12 +2211,6 @@ button.card-age {
    avatar is a team-badge-sized circle hanging 60% off the card's LEFT border,
    and the card gets a soft glow — deliberately quieter than the local
    .card-selected outline, so the two never read as the same thing. */
-/* The wrapper must not participate in the card's flex layout (it would eat a
-   6px gap slot before the day counter); its avatars position against the card. */
-.card-presence {
-  display: contents;
-}
-
 .card-presence-avatar {
   position: absolute;
   top: 50%;
@@ -2231,4 +2225,11 @@ button.card-age {
 
 .card-peer-selected {
   box-shadow: 0 0 0 1px rgba(9, 105, 218, 0.18);
+}
+
+/* The presence wrapper must not occupy a flex slot in the card row (its gap
+   would widen the space before the day counter); only its absolutely
+   positioned avatars exist visually. */
+.card-presence {
+  display: contents;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2208,7 +2208,9 @@ button.card-age {
 }
 
 /* Shared presence: a teammate has this card selected in their Me view. Their
-   avatar is a team-badge-sized circle hanging 60% off the card's right border. */
+   avatar is a team-badge-sized circle hanging 60% off the card's LEFT border,
+   and the card gets a soft glow — deliberately quieter than the local
+   .card-selected outline, so the two never read as the same thing. */
 .card-presence-avatar {
   position: absolute;
   top: 50%;
@@ -2219,4 +2221,8 @@ button.card-age {
   border: 1px solid var(--bg);
   background: var(--bg-soft);
   z-index: 3;
+}
+
+.card-peer-selected {
+  box-shadow: 0 0 0 1px rgba(9, 105, 218, 0.18);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -332,10 +332,7 @@ button {
 .zone-area {
   display: flex;
   align-items: stretch;
-  /* The gutter between the spine and the cards fits a presence avatar (16px):
-     a teammate's selection mark lives there, right of the spine, fully left
-     of the card. */
-  gap: 16px;
+  gap: 6px;
   border-left: 3px solid #ccc;
   border-radius: 0;
   padding: 5px 6px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2211,6 +2211,12 @@ button.card-age {
    avatar is a team-badge-sized circle hanging 60% off the card's LEFT border,
    and the card gets a soft glow — deliberately quieter than the local
    .card-selected outline, so the two never read as the same thing. */
+/* The wrapper must not participate in the card's flex layout (it would eat a
+   6px gap slot before the day counter); its avatars position against the card. */
+.card-presence {
+  display: contents;
+}
+
 .card-presence-avatar {
   position: absolute;
   top: 50%;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -332,7 +332,10 @@ button {
 .zone-area {
   display: flex;
   align-items: stretch;
-  gap: 6px;
+  /* The gutter between the spine and the cards fits a presence avatar (16px):
+     a teammate's selection mark lives there, right of the spine, fully left
+     of the card. */
+  gap: 16px;
   border-left: 3px solid #ccc;
   border-radius: 0;
   padding: 5px 6px;
@@ -2224,7 +2227,8 @@ button.card-age {
 }
 
 .card-peer-selected {
-  box-shadow: 0 0 0 1px rgba(9, 105, 218, 0.18);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.35);
 }
 
 /* The presence wrapper must not occupy a flex slot in the card row (its gap


### PR DESCRIPTION
Selecting a card in the Me view now marks it for the whole team: everyone else's Team board highlights that card exactly like a local selection and hangs the selector's avatar on it — a team-badge-sized (16px) circle offset 60% past the card's right border; multiple selectors stack outward.

The state is a shared cursor, not board data. The server keeps it in the watch hub keyed by client id and broadcasts it as a new Presence watch frame ({login, card}, empty card clears): echo-suppressed for the originator, snapshotted to newly connected watchers, cleared automatically when the selector's tab disconnects, and never written to GitHub. POST /api/v1/presence is the write; the resources= watch filter gains a presence kind (included by default).

The Me view also gains keyboard navigation: ArrowUp/ArrowDown move the selection through the visible day list (zone bands top to bottom), Shift+Arrow reorders the selected card past its visible neighbour (optimistic with re-list rollback), Escape deselects. Keys are ignored while an input is focused.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein