### PR TITLE
fix(ghprojects): keep multi-line draft-note bodies

### DIFF
--- a/pkg/ghprojects/load.go
+++ b/pkg/ghprojects/load.go
@@ -160,8 +160,11 @@ func domainParseDraftBody(body, itemID string) (string, []board.Note) {
 	return strings.TrimSpace(strings.Join(descLines, "\n")), notes
 }
 
-// domainParseNoteLines extracts "[timestamp] text" draft-log lines from text,
-// mirroring parseNoteLines in the frontend githubProvider.
+// domainParseNoteLines extracts "- [timestamp] text" draft-log entries from
+// text. A note may span multiple lines: everything after its header line and
+// before the next header belongs to its body (agents routinely file whole
+// review checklists as one note), so continuation lines are accumulated
+// instead of dropped. Note ids stay anchored to the header line's index.
 func domainParseNoteLines(text, itemID string) []board.Note {
 	var notes []board.Note
 	for i, line := range strings.Split(text, "\n") {
@@ -172,7 +175,15 @@ func domainParseNoteLines(text, itemID string) []board.Note {
 				CreatedAt: m[1],
 				Source:    "draft",
 			})
+			continue
 		}
+		if len(notes) == 0 {
+			continue
+		}
+		notes[len(notes)-1].Body += "\n" + line
+	}
+	for i := range notes {
+		notes[i].Body = strings.TrimSpace(notes[i].Body)
 	}
 	return notes
 }

--- a/pkg/ghprojects/load_test.go
+++ b/pkg/ghprojects/load_test.go
@@ -233,3 +233,33 @@ func cardOf(t *testing.T, b board.Board, itemID string) board.Card {
 	t.Fatalf("card %q not found", itemID)
 	return board.Card{}
 }
+
+// A draft-log note may span multiple lines: everything up to the next
+// "- [timestamp]" header belongs to its body, and the edit/delete rebuild
+// round-trips it unchanged.
+func TestDraftLogMultilineNotes(t *testing.T) {
+	body := "context\n\n<!-- aeman:log -->\n" +
+		"- [2026-07-02T18:46:58Z] Review list (day one).\n" +
+		"\nMerged:\n- repo#1011 — roles catalog\n- repo#1013 — subject matching\n" +
+		"- [2026-07-03T07:52:38Z] Second note.\nWith one continuation line."
+	desc, notes := domainParseDraftBody(body, "item1")
+	if desc != "context" {
+		t.Fatalf("description = %q", desc)
+	}
+	if len(notes) != 2 {
+		t.Fatalf("notes = %d, want 2", len(notes))
+	}
+	want0 := "Review list (day one).\n\nMerged:\n- repo#1011 — roles catalog\n- repo#1013 — subject matching"
+	if notes[0].Body != want0 {
+		t.Fatalf("note[0] = %q", notes[0].Body)
+	}
+	if notes[1].Body != "Second note.\nWith one continuation line." {
+		t.Fatalf("note[1] = %q", notes[1].Body)
+	}
+	// The rebuild (what EditNote/DeleteNote write back) must keep both bodies.
+	rebuilt := domainBuildDraftBody(desc, notes)
+	desc2, notes2 := domainParseDraftBody(rebuilt, "item1")
+	if desc2 != desc || len(notes2) != 2 || notes2[0].Body != want0 {
+		t.Fatalf("round-trip lost content: %q %+v", desc2, notes2)
+	}
+}


### PR DESCRIPTION
The draft-log note parser was line-based: each "- [timestamp] text" entry kept only its header line, and every continuation line was silently dropped on read. An agent filing a whole review checklist as one note over MCP saw only the first sentence survive into the UI — the full text was intact in the draft body on GitHub the entire time. Surfaced by a real card whose two notes rendered as 69 and 62 characters while the body held 5.7 KB.

The parser now accumulates everything between a note's header and the next header into that note's body; ids stay anchored to the header line. Nested list bullets inside a body don't match the header pattern, so they stay in the note. The rebuild used by note edit/delete round-trips multi-line bodies unchanged (covered by a new round-trip test). Verified against the affected live card: both notes now come back whole (1863 and 2471 characters).

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein