### PR TITLE
fix(web): hide the recurrent stage on review cards

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -966,7 +966,8 @@ func (s *Server) apiError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, boardservice.ErrCardNotFound), errors.Is(err, boardservice.ErrNoteNotFound):
 		writeJSONError(w, http.StatusNotFound, err.Error())
-	case errors.Is(err, ghprojects.ErrFieldNotFound), errors.Is(err, ghprojects.ErrNoContent):
+	case errors.Is(err, ghprojects.ErrFieldNotFound), errors.Is(err, ghprojects.ErrNoContent),
+		errors.Is(err, boardservice.ErrInvalidStage):
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 	default:
 		writeJSONError(w, http.StatusBadGateway, err.Error())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -447,3 +447,20 @@ func TestAPICreateCardFromGitHubURL(t *testing.T) {
 		t.Fatalf("card = %+v", c.Spec)
 	}
 }
+
+func TestAPIRecurrentOnReviewCardRejected(t *testing.T) {
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "orig", Team: "alpha"},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	rec := do(t, srv, http.MethodPatch, "/api/v1/cards/rev?owner=acme&project=1", `{"stage":"recurrent"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("recurrent on a review card must be 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// A non-review card still accepts recurrent.
+	rec = do(t, srv, http.MethodPatch, "/api/v1/cards/orig?owner=acme&project=1", `{"stage":"recurrent"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("recurrent on a normal card must be OK, got %d", rec.Code)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -17,6 +17,10 @@ var ErrCardNotFound = errors.New("card not found")
 // ErrNoteNotFound is returned when a note id is not on the loaded card.
 var ErrNoteNotFound = errors.New("note not found")
 
+// ErrInvalidStage is returned when a stage cannot apply to a card — a review
+// card cannot be made recurrent (a review is one-off, not a repeating task).
+var ErrInvalidStage = errors.New("invalid stage for this card")
+
 // Service performs aeman's board actions. It is stateless: every method loads
 // the board through the backend, computes the change with internal/board logic,
 // then applies it through the backend setters.
@@ -654,6 +658,10 @@ func (s *Service) SetStage(ctx context.Context, owner string, project int, itemI
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return err
+	}
+	// A review card is auxiliary and one-off: it cannot be made recurrent.
+	if stage == board.StageRecurrent && card.ReviewOf != "" {
+		return fmt.Errorf("%w: a review card cannot be recurrent", ErrInvalidStage)
 	}
 	if err := s.applyStage(ctx, b, card, stage); err != nil {
 		return err

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -2,6 +2,7 @@ package boardservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1367,5 +1368,24 @@ func TestCarryOverReviewCardsOnlyWhileRequired(t *testing.T) {
 	}
 	if f.get("revLive").SprintStart == "2026-01-01" {
 		t.Fatal("a still-required review card carries")
+	}
+}
+
+// A review card cannot be made recurrent — the backend rejects it.
+func TestRecurrentRejectedOnReviewCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "orig", Team: "alpha"},
+		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40},
+	}, nil)
+	err := f2svc(f).SetStage(ctx, "acme", 1, "rev", board.StageRecurrent)
+	if err == nil || !errors.Is(err, ErrInvalidStage) {
+		t.Fatalf("expected ErrInvalidStage, got %v", err)
+	}
+	if f.count("SetStage") != 0 {
+		t.Fatal("nothing must be written when the stage is rejected")
+	}
+	// A non-review card can still go recurrent.
+	if err := f2svc(f).SetStage(ctx, "acme", 1, "orig", board.StageRecurrent); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -395,8 +395,10 @@ export function Card({
           In Progress
         </button>
         {STAGE_ORDER.map((stage) =>
-          // A review card cannot be put on the "review" stage itself.
-          stage === "review" && card.reviewOf ? null : (
+          // A review card is auxiliary: it cannot be put on the "review" stage
+          // itself, nor made "recurrent" (a repeating task makes no sense for a
+          // one-off review).
+          (stage === "review" || stage === "recurrent") && card.reviewOf ? null : (
             <button
               key={stage}
               type="button"


### PR DESCRIPTION
A review card is auxiliary and one-off; making it recurrent (a repeating task that reseeds on carry) makes no sense. Drop the recurrent option from its stage menu, the same way the review stage is already hidden there.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein