### PR TITLE
fix(web): close the .me-today rule so the round badge is styled

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2239,8 +2239,10 @@ button.card-age {
    right edge of the toolbar. */
 .me-today {
   margin-left: auto;
-/* Review-round badge: a small red number just left of the day counter on a
-   review card that has been sent back for another round (round 2+). */
+}
+
+/* Review-round badge: a dark-yellow circled number just left of the day counter
+   on a review card that has been sent back for another round (round 2+). */
 .card-review-round {
   flex: none;
   display: inline-flex;


### PR DESCRIPTION
A merge-conflict resolution dropped the closing brace of the `.me-today` rule, so it swallowed the following `.card-review-round` block — the badge selector was never created and the round number rendered unstyled (a plain grey digit instead of the dark-yellow circle). Closing `.me-today` restores it.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein