### PR TITLE
feat(api): default the cards list to Me and lazy-load the UI per view

### DIFF
--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -144,6 +144,9 @@ func runMCP(args []string) error {
 		Lock:         *lockBoard,
 		Version:      version,
 		ResolveToken: resolveGitHubToken,
+		// Scope the default (unspecified-view) list to the local user's own Me
+		// board; best-effort via the gh CLI, else the list stays sprint-scoped.
+		ResolveLogin: ghcli.Login,
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,12 +111,15 @@ The carry actions return `{carried, reseeded}` counts; with `dryRun: true` they 
 
 `GET /api/v1/cards` reproduces the UI's views server-side:
 
-- `?view=team&team=platform&day=2026-07-02` — the Team grid for a team on a day (day defaults to today).
-- `?view=me&user=octocat&day=` — the personal day view (empty user = everyone).
+- **No view** — defaults to the caller's personal **Me** board (their own cards in the active sprint). Who-am-I is resolved server-side (session/token login), so no `user` is needed; an explicit `?user=` still wins. This is where everyone works day to day.
+- `?view=all` — every card on the board (the old bare-list behaviour; still honours the field/team filters).
+- `?view=team&team=platform&day=2026-07-02` — the Team grid (the lead view) for a team on a day; `team=` accepts a comma-separated set (`team=platform,marketing`) so the multi-team board loads in one request. Day defaults to today.
+- `?view=me&user=octocat&day=` — the personal day view for a specific user (empty user = the caller; on the Me view an empty user resolves to who-am-i via the handler).
 - `?view=weekly&team=platform&week=2026-06-29` — the weekly plan (week = a Monday, defaults to the current week); the response also carries `weekly: {progress}` (recurrent cards excluded).
 - Field selectors — `stage=`, `zone=`, `assignee=` — compose with a view or apply to all cards.
 - `focus=true` — keep only cards workable right now (drops done, on-review and locked); the "what can I pick up now" filter.
-- On `view=me` (and the default all-cards list), `team=` filters the personal board to a team — a comma-separated set (`team=marketing,portal`) matches any of them.
+- `reviews=true` — on a me/team view, append each card's linked review card so a client rendering the reviewer badge has it without a second request (the UI uses this; off by default so an agent's Me list isn't padded with review cards).
+- On the me / all lists, `team=` filters by a comma-separated set (`team=marketing,portal`) matching any of them.
 
 ### Live updates: list + watch
 
@@ -171,7 +174,7 @@ curl -X POST 'http://127.0.0.1:8765/api/v1/sprints/actions/carry-over?owner=acme
 | Tool | Purpose |
 | --- | --- |
 | `get_board` | Board identity and team roster. |
-| `list_cards` | LIST with the same selectors (`view`, `team`, `day`, `user`, `week`, `stage`, `zone`, `assignee`). |
+| `list_cards` | LIST with the same selectors (`view`, `team`, `day`, `user`, `week`, `stage`, `zone`, `assignee`, `focus`). No view defaults to your own Me board (who-am-i resolved server-side); `view=all` is the whole board, `view=team` the lead view. |
 | `get_card` / `list_notes` / `list_links` | One card; its notes; its description links (GitHub refs resolved with titles). |
 | `create_card` | Create a card (joins or starts its team's sprint; plan cards via `plan`+`week`). A title that is only a GitHub issue/PR URL is auto-filled from that item. |
 | `update_card` | The PATCH: only provided fields apply, empty clears. The `description` is the card's shared body — also the place for reference links: URLs are surfaced on the card, GitHub issue/PR links resolved to titles (`list_links`). |

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -229,6 +229,19 @@ func (s *Server) handleListCards(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// An unspecified view defaults to the caller's personal Me board — their own
+	// cards in the active sprint — since that is where everyone works day to day;
+	// Team is the lead view, requested explicitly with ?view=team, and ?view=all
+	// lists the whole board. "Who am I" is resolved here, server-side, so a Me
+	// request needs no user (an explicit ?user= still wins, e.g. for "view as").
+	if sel.View == "" {
+		sel.View = "me"
+	}
+	if sel.View == "me" && sel.User == "" {
+		if _, login, err := s.apiTokens(r); err == nil {
+			sel.User = login
+		}
+	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
 		s.apiError(w, err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -473,8 +473,8 @@ func TestAPIListCardsFocusQuery(t *testing.T) {
 		{ItemID: "beta", Team: "beta", Progress: 40},
 	}, nil)
 	srv := apiServer(t, Options{}, fake)
-	// focus=true drops review/done, keeps workable.
-	rec := do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1&focus=true", "")
+	// focus=true drops review/done, keeps workable (over the whole board).
+	rec := do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1&view=all&focus=true", "")
 	got := map[string]bool{}
 	for _, c := range decodeList(t, rec).Items {
 		got[c.Metadata.UID] = true
@@ -482,8 +482,8 @@ func TestAPIListCardsFocusQuery(t *testing.T) {
 	if !got["wip"] || !got["beta"] || got["rev"] || got["done"] {
 		t.Fatalf("focus list = %v", got)
 	}
-	// comma-separated team set filters the default list.
-	rec = do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1&team=alpha&focus=true", "")
+	// comma-separated team set filters the view=all list too.
+	rec = do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1&view=all&team=alpha&focus=true", "")
 	only := decodeList(t, rec).Items
 	if len(only) != 1 || only[0].Metadata.UID != "wip" {
 		t.Fatalf("team+focus = %v", only)
@@ -509,5 +509,31 @@ func TestAPIReReviewReactivatesWithRound(t *testing.T) {
 	c := decodeCard(t, rec)
 	if c.Spec.Progress != 0 || c.Status.ReviewRound != 2 {
 		t.Fatalf("re-review resource = progress %d round %d, want 0 / 2", c.Spec.Progress, c.Status.ReviewRound)
+	}
+}
+
+func TestAPIListDefaultsToMe(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "mine", Team: "alpha", Assignees: []string{"bob"}, Progress: 40, SprintStart: today},
+		{ItemID: "theirs", Team: "alpha", Assignees: []string{"carol"}, Progress: 40, SprintStart: today},
+	}, map[string]board.SprintState{"alpha": {Current: today, ItemID: "s1"}})
+	srv := apiServer(t, Options{}, fake)
+	srv.apiTokens = func(*http.Request) (string, string, error) { return "tok", "bob", nil }
+	// Bare list → the caller's own Me board (who-am-I resolved server-side).
+	got := map[string]bool{}
+	for _, c := range decodeList(t, do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1", "")).Items {
+		got[c.Metadata.UID] = true
+	}
+	if !got["mine"] || got["theirs"] {
+		t.Fatalf("bare list must be the caller's Me board: %v", got)
+	}
+	// view=all still lists the whole board.
+	all := map[string]bool{}
+	for _, c := range decodeList(t, do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1&view=all", "")).Items {
+		all[c.Metadata.UID] = true
+	}
+	if !all["mine"] || !all["theirs"] {
+		t.Fatalf("view=all must list the whole board: %v", all)
 	}
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -18,6 +18,11 @@ import (
 // bridges it onto the context the tools actually run with.
 type mcpTokenCtxKey struct{}
 
+// mcpLoginCtxKey carries the caller's GitHub login (the verified TokenInfo's
+// UserID) to the ResolveLogin seam, so the default list can scope to their own
+// Me board without a round-trip.
+type mcpLoginCtxKey struct{}
+
 // registerMCP mounts the MCP streamable HTTP transport at /mcp, guarded by the
 // bearer-token middleware so unauthenticated callers get a 401 carrying the
 // protected-resource metadata URL. It is only mounted in OAuth mode.
@@ -42,6 +47,7 @@ func (s *Server) mcpServerForRequest(*http.Request) *mcp.Server {
 		Endpoint:     s.graphqlEndpoint,
 		HTTPClient:   s.httpClient,
 		ResolveToken: resolveTokenFromContext,
+		ResolveLogin: resolveLoginFromContext,
 		// Route MCP writes through the shared board store, so agent edits update
 		// the cache and reach the UI's watch stream like every other write.
 		WrapBackend: func(b boardservice.Backend) boardservice.Backend {
@@ -60,6 +66,9 @@ func injectGitHubToken(next mcp.MethodHandler) mcp.MethodHandler {
 			if tok, ok := extra.TokenInfo.Extra[githubTokenExtraKey].(string); ok && tok != "" {
 				ctx = context.WithValue(ctx, mcpTokenCtxKey{}, tok)
 			}
+			if extra.TokenInfo.UserID != "" {
+				ctx = context.WithValue(ctx, mcpLoginCtxKey{}, extra.TokenInfo.UserID)
+			}
 		}
 		return next(ctx, method, req)
 	}
@@ -72,4 +81,14 @@ func resolveTokenFromContext(ctx context.Context) (string, error) {
 		return "", errors.New("no authenticated GitHub token for this MCP request")
 	}
 	return tok, nil
+}
+
+// resolveLoginFromContext is the MCP ResolveLogin seam for the HTTP transport:
+// the caller's login is the verified session's UserID, injected above.
+func resolveLoginFromContext(ctx context.Context) (string, error) {
+	login, _ := ctx.Value(mcpLoginCtxKey{}).(string)
+	if login == "" {
+		return "", errors.New("no authenticated login for this MCP request")
+	}
+	return login, nil
 }

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -165,6 +165,32 @@ func TestSelectorParsing(t *testing.T) {
 	if _, err := ParseSelector(url.Values{"view": {"nope"}}); err == nil {
 		t.Fatal("unknown view must error")
 	}
+	if _, err := ParseSelector(url.Values{"view": {"all"}}); err != nil {
+		t.Fatalf("view=all must be accepted: %v", err)
+	}
+}
+
+// view=all lists every card (like the empty view) and still honours the team
+// set and field filters — it is the explicit whole-board request.
+func TestViewAllListsEverythingWithTeamFilter(t *testing.T) {
+	b := board.Board{Cards: []board.Card{
+		{ItemID: "a1", Team: "alpha", Progress: 40},
+		{ItemID: "a2", Team: "alpha", Progress: 100},
+		{ItemID: "b1", Team: "beta", Progress: 40},
+	}}
+	ids := func(sel Selector) []string {
+		out := []string{}
+		for _, c := range FilterCards(b, sel) {
+			out = append(out, c.ItemID)
+		}
+		return out
+	}
+	if got := ids(Selector{View: "all"}); !reflect.DeepEqual(got, []string{"a1", "a2", "b1"}) {
+		t.Fatalf("view=all = %v, want all three", got)
+	}
+	if got := ids(Selector{View: "all", Team: "beta"}); !reflect.DeepEqual(got, []string{"b1"}) {
+		t.Fatalf("view=all&team=beta = %v, want [b1]", got)
+	}
 }
 
 func TestOrderingResource(t *testing.T) {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -239,3 +239,55 @@ func TestSelectorFocusAndMultiTeam(t *testing.T) {
 		t.Fatal("focus=true must parse")
 	}
 }
+
+// reviews=true appends a me/team card's linked review card so the view is
+// self-contained for the badge; off by default it is not mixed in.
+func TestViewIncludeReviews(t *testing.T) {
+	today := board.TodayIso()
+	b := board.Board{
+		Cards: []board.Card{
+			{ItemID: "mine", Team: "alpha", Assignees: []string{"bob"}, Progress: 40, SprintStart: today},
+			{ItemID: "rev", Team: "alpha", Assignees: []string{"carol"}, ReviewOf: "mine", Progress: 50, SprintStart: today},
+		},
+		SprintStates: map[string]board.SprintState{"alpha": {Current: today}},
+	}
+	has := func(sel Selector, id string) bool {
+		for _, c := range FilterCards(b, sel) {
+			if c.ItemID == id {
+				return true
+			}
+		}
+		return false
+	}
+	base := Selector{View: "me", User: "bob", Day: today}
+	if !has(base, "mine") || has(base, "rev") {
+		t.Fatal("plain me view holds only the user's own card")
+	}
+	withRev := Selector{View: "me", User: "bob", Day: today, IncludeReviews: true}
+	if !has(withRev, "mine") || !has(withRev, "rev") {
+		t.Fatal("reviews=true must append the linked review card")
+	}
+}
+
+// view=team accepts a comma set: the Team board fetches every team it shows in
+// one request (union of the per-team grids).
+func TestTeamViewMultiTeam(t *testing.T) {
+	day := "2026-01-10"
+	b := board.Board{
+		Cards: []board.Card{
+			{ItemID: "a1", Team: "alpha", Progress: 40, StartDate: day, SprintStart: day},
+			{ItemID: "b1", Team: "beta", Progress: 40, StartDate: day, SprintStart: day},
+			{ItemID: "g1", Team: "gamma", Progress: 40, StartDate: day, SprintStart: day},
+		},
+		SprintStates: map[string]board.SprintState{
+			"alpha": {Current: day}, "beta": {Current: day}, "gamma": {Current: day},
+		},
+	}
+	ids := map[string]bool{}
+	for _, c := range FilterCards(b, Selector{View: "team", Team: "alpha,beta", Day: day}) {
+		ids[c.ItemID] = true
+	}
+	if !ids["a1"] || !ids["b1"] || ids["g1"] {
+		t.Fatalf("team=alpha,beta = %v, want alpha+beta only", ids)
+	}
+}

--- a/pkg/apiserver/views.go
+++ b/pkg/apiserver/views.go
@@ -31,18 +31,24 @@ type Selector struct {
 	// Focus keeps only workable cards — the "what can I act on now" filter
 	// (drops done, on-review and locked). It mirrors the Me view's focus toggle.
 	Focus bool
+	// IncludeReviews appends each returned card's linked review card to a me/team
+	// view, so a client rendering the reviewer badge has it on hand without a
+	// second request. It is a UI convenience, off by default (agents listing a
+	// Me board do not want the review cards mixed in).
+	IncludeReviews bool
 }
 
 // ParseSelector reads a selector from query parameters. Unknown views error.
 func ParseSelector(q url.Values) (Selector, error) {
 	sel := Selector{
-		View:     q.Get("view"),
-		Team:     q.Get("team"),
-		Day:      q.Get("day"),
-		User:     q.Get("user"),
-		Week:     q.Get("week"),
-		Assignee: q.Get("assignee"),
-		Focus:    q.Get("focus") == "true" || q.Get("focus") == "1",
+		View:           q.Get("view"),
+		Team:           q.Get("team"),
+		Day:            q.Get("day"),
+		User:           q.Get("user"),
+		Week:           q.Get("week"),
+		Assignee:       q.Get("assignee"),
+		Focus:          q.Get("focus") == "true" || q.Get("focus") == "1",
+		IncludeReviews: q.Get("reviews") == "true" || q.Get("reviews") == "1",
 	}
 	if q.Has("stage") {
 		v := q.Get("stage")
@@ -80,7 +86,17 @@ func FilterCards(b board.Board, sel Selector) []board.Card {
 	var base []board.Card
 	switch sel.View {
 	case "team":
-		base = board.TeamGrid(b, sel.Team, sel.Day)
+		// team accepts a comma-separated set so the Team board fetches every team
+		// it shows in one request; the grids are unioned, deduped by item id.
+		seen := map[string]bool{}
+		for _, t := range strings.Split(sel.Team, ",") {
+			for _, c := range board.TeamGrid(b, strings.TrimSpace(t), sel.Day) {
+				if !seen[c.ItemID] {
+					seen[c.ItemID] = true
+					base = append(base, c)
+				}
+			}
+		}
 	case "me":
 		base = board.MeView(b, sel.User, sel.Day)
 	case "weekly":
@@ -111,6 +127,28 @@ func FilterCards(b board.Board, sel Selector) []board.Card {
 			continue
 		}
 		out = append(out, c)
+	}
+	if sel.IncludeReviews && (sel.View == "me" || sel.View == "team") {
+		out = withLinkedReviews(b, out)
+	}
+	return out
+}
+
+// withLinkedReviews appends each card's linked review card (reviewOf == its id),
+// skipping any already present, so a me/team view is self-contained for a client
+// that renders the reviewer badge from the same card set.
+func withLinkedReviews(b board.Board, out []board.Card) []board.Card {
+	present := make(map[string]bool, len(out))
+	ids := make(map[string]bool, len(out))
+	for _, c := range out {
+		present[c.ItemID] = true
+		ids[c.ItemID] = true
+	}
+	for _, c := range b.Cards {
+		if c.ReviewOf != "" && ids[c.ReviewOf] && !present[c.ItemID] {
+			out = append(out, c)
+			present[c.ItemID] = true
+		}
 	}
 	return out
 }

--- a/pkg/apiserver/views.go
+++ b/pkg/apiserver/views.go
@@ -12,7 +12,8 @@ import (
 // exactly what the UI renders (the Team grid, the Me day board, the Weekly
 // plan); the plain field selectors compose with no view.
 type Selector struct {
-	// View is "", "team", "me" or "weekly".
+	// View is "", "all", "team", "me" or "weekly". "" and "all" both list every
+	// card (the HTTP/MCP layer defaults an unspecified view to the caller's "me").
 	View string
 	// Team is the team key for the team/weekly views ("" = the no-team group).
 	Team string
@@ -52,7 +53,7 @@ func ParseSelector(q url.Values) (Selector, error) {
 		sel.Zone = &v
 	}
 	switch sel.View {
-	case "", "team", "me", "weekly":
+	case "", "all", "team", "me", "weekly":
 	default:
 		return Selector{}, fmt.Errorf("unknown view %q", sel.View)
 	}
@@ -99,11 +100,11 @@ func FilterCards(b board.Board, sel Selector) []board.Card {
 		if sel.Assignee != "" && !contains(c.Assignees, sel.Assignee) {
 			continue
 		}
-		// team filters the views that are not already scoped by it (the me and
-		// default lists). It accepts a comma-separated set, so
+		// team filters the views that are not already scoped by it (the me, all
+		// and default lists). It accepts a comma-separated set, so
 		// ?view=me&team=marketing,portal narrows the personal board to those
 		// teams — the Me view's team-focus toggle over the selected chips.
-		if (sel.View == "me" || sel.View == "") && !teamInSet(c.Team, sel.Team) {
+		if (sel.View == "me" || sel.View == "" || sel.View == "all") && !teamInSet(c.Team, sel.Team) {
 			continue
 		}
 		if sel.Focus && !board.Workable(c) {

--- a/pkg/mcpserver/mcpserver.go
+++ b/pkg/mcpserver/mcpserver.go
@@ -27,6 +27,11 @@ type Config struct {
 	Version string
 	// ResolveToken returns a GitHub token for the current call.
 	ResolveToken func(ctx context.Context) (string, error)
+	// ResolveLogin returns the caller's own GitHub login, used to scope the
+	// default (unspecified-view) list to their personal Me board. Optional: when
+	// nil or it errors, an unspecified list falls back to the Me view for
+	// everyone in the active sprint rather than a personal one.
+	ResolveLogin func(ctx context.Context) (string, error)
 	// Endpoint overrides the GraphQL endpoint (used in tests).
 	Endpoint string
 	// HTTPClient overrides the HTTP client (used in tests).
@@ -65,7 +70,7 @@ func New(cfg Config) *mcp.Server {
 func (h *server) mcpServer() *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{Name: "aeman", Version: h.cfg.Version}, nil)
 	mcp.AddTool(s, &mcp.Tool{Name: "get_board", Description: "Get the board identity and its team roster."}, h.getBoard)
-	mcp.AddTool(s, &mcp.Tool{Name: "list_cards", Description: "List cards, optionally scoped to a view (team, me, weekly) and filtered by stage, semantic zone (urgent/unplanned/planned/niceToHave), assignee or team. Pass focus=true to keep only cards that can be worked on right now (drops done, on-review and locked) — the go-to way to answer \"what should I pick up next\"."}, h.listCards)
+	mcp.AddTool(s, &mcp.Tool{Name: "list_cards", Description: "List cards. With no view it defaults to YOUR personal Me board — your own cards in the active sprint — because that is where everyone works and you normally act only on your own cards. Pass view=team&team=X for a team lead's grid of the whole team's cards (the lead view; you usually don't need it and shouldn't edit others' cards unless you're the lead or creating one), view=weekly for the plan, or view=all for every card on the board. Also filter by stage, semantic zone (urgent/unplanned/planned/niceToHave), assignee or team, and focus=true to keep only cards workable right now (drops done, on-review and locked) — the go-to way to answer \"what should I pick up next\"."}, h.listCards)
 	mcp.AddTool(s, &mcp.Tool{Name: "get_card", Description: "Get a single card by uid."}, h.getCard)
 	mcp.AddTool(s, &mcp.Tool{Name: "create_card", Description: "Create a card that joins (or starts) its team's sprint — or a weekly-plan card when a plan band is given; zones are semantic (urgent/unplanned/planned/niceToHave). A title that is just a GitHub issue/PR URL is auto-filled from that issue/PR (its real title, with the link kept in the card description). To attach reference links afterwards, put them in the description via update_card."}, h.createCard)
 	mcp.AddTool(s, &mcp.Tool{Name: "update_card", Description: "Patch a card: only the provided fields change, an explicit empty string clears a field; zones are semantic (urgent/unplanned/planned/niceToHave). Use the description field to leave context the whole team should see on the card — it is the card body everyone sees and it live-syncs onto the linked review card. Put reference links in the description too: any URL is surfaced on the card, and GitHub issue/PR links are resolved to their titles and listed first (read them with list_links). (For shareable context prefer this over add_note, which is a private per-person log.)"}, h.updateCard)

--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -127,7 +127,7 @@ func TestMCPListCardsZoneFilterIsSemantic(t *testing.T) {
 		{ItemID: "c2", Zone: board.ZoneGray},
 	}, nil)
 	cs := connect(t, Config{Owner: "acme", Project: 1}, fake)
-	res := call(t, cs, "list_cards", map[string]any{"zone": "urgent"})
+	res := call(t, cs, "list_cards", map[string]any{"view": "all", "zone": "urgent"})
 	if !strings.Contains(textOf(res), "c1") || strings.Contains(textOf(res), "c2") {
 		t.Fatalf("zone=urgent should hold exactly c1: %s", textOf(res))
 	}
@@ -314,5 +314,24 @@ func TestMCPMissingBoardConfig(t *testing.T) {
 	cs := connect(t, Config{}, boardservicetest.New(nil, nil))
 	if msg := callErr(t, cs, "list_cards", nil); !strings.Contains(msg, "owner and project are required") {
 		t.Fatalf("expected board-required error, got %s", msg)
+	}
+}
+
+func TestMCPListDefaultsToMe(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "mine", Team: "alpha", Assignees: []string{"bob"}, Progress: 40, SprintStart: today},
+		{ItemID: "theirs", Team: "alpha", Assignees: []string{"carol"}, Progress: 40, SprintStart: today},
+	}, map[string]board.SprintState{"alpha": {Current: today, ItemID: "s1"}})
+	cs := connect(t, Config{Owner: "acme", Project: 1, ResolveLogin: func(context.Context) (string, error) { return "bob", nil }}, fake)
+	// No view → the caller's own Me board.
+	res := call(t, cs, "list_cards", map[string]any{})
+	if !strings.Contains(textOf(res), "mine") || strings.Contains(textOf(res), "theirs") {
+		t.Fatalf("default list must be the caller's Me board: %s", textOf(res))
+	}
+	// view=all lists the whole board.
+	all := call(t, cs, "list_cards", map[string]any{"view": "all"})
+	if !strings.Contains(textOf(all), "mine") || !strings.Contains(textOf(all), "theirs") {
+		t.Fatalf("view=all must list the whole board: %s", textOf(all))
 	}
 }

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -117,9 +117,20 @@ func (h *server) listCards(ctx context.Context, _ *mcp.CallToolRequest, in listC
 	}
 	sel := apiserver.Selector{View: in.View, Team: in.Team, Day: in.Day, User: in.User, Week: in.Week, Assignee: in.Assignee, Focus: in.Focus}
 	switch sel.View {
-	case "", "team", "me", "weekly":
+	case "", "all", "team", "me", "weekly":
 	default:
-		return nil, apiserver.CardList{}, fmt.Errorf("unknown view %q (use team, me or weekly)", sel.View)
+		return nil, apiserver.CardList{}, fmt.Errorf("unknown view %q (use all, team, me or weekly)", sel.View)
+	}
+	// An unspecified view defaults to the caller's personal Me board (their own
+	// cards); Team is the lead view and view=all is the whole board. "Who am I"
+	// is resolved server-side, so a Me request needs no user (explicit wins).
+	if sel.View == "" {
+		sel.View = "me"
+	}
+	if sel.View == "me" && sel.User == "" && h.cfg.ResolveLogin != nil {
+		if login, err := h.cfg.ResolveLogin(ctx); err == nil {
+			sel.User = login
+		}
 	}
 	// MCP inputs cannot distinguish absent from empty, so an empty stage/zone
 	// means "not filtering" (unlike the HTTP query, where ?stage= filters).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,8 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.7.2",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1246,6 +1247,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1290,6 +1298,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1355,6 +1381,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1425,6 +1574,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1463,6 +1622,13 @@
       "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1514,6 +1680,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1613,6 +1799,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1648,6 +1844,27 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1797,6 +2014,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1805,6 +2029,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1822,6 +2077,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1955,6 +2220,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -22,6 +23,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.7.2",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.9"
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,8 @@ import { TeamBoard } from "./components/TeamBoard";
 import { CardDetail } from "./components/CardDetail";
 import { Logo } from "./components/Logo";
 import { fetchUsers, type GhUser } from "./users";
+import { queryString, viewQuery } from "./viewquery";
+import { todayIso } from "./date";
 
 type ViewMode = "me" | "team";
 
@@ -68,6 +70,9 @@ export function App() {
   const [view, setView] = useState<ViewMode>(readView);
 
   const [board, setBoard] = useState<Board | null>(null);
+  // The viewed day, shared by both boards and driving the lazy view fetch and
+  // the scoped watch. Lifted out of the boards so the App owns what to load.
+  const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [users, setUsers] = useState<Record<string, GhUser>>({});
   const fetchedUsers = useRef<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
@@ -124,6 +129,27 @@ export function App() {
     localStorage.setItem(LS_VIEW, view);
   }, [view]);
 
+  // A tab left open past midnight keeps a stale "today". When it regains focus,
+  // catch the viewed day up to the real today — unless the user navigated to a
+  // specific other day. (Formerly TeamBoard owned this.)
+  const lastTodayRef = useRef(todayIso());
+  useEffect(() => {
+    const sync = () => {
+      const now = todayIso();
+      if (now === lastTodayRef.current) {
+        return;
+      }
+      setSelectedDate((d) => (d === lastTodayRef.current ? now : d));
+      lastTodayRef.current = now;
+    };
+    document.addEventListener("visibilitychange", sync);
+    window.addEventListener("focus", sync);
+    return () => {
+      document.removeEventListener("visibilitychange", sync);
+      window.removeEventListener("focus", sync);
+    };
+  }, []);
+
   const provider = apiProvider;
 
   // The roster: user-arranged teams first (in their saved order), then any team
@@ -138,16 +164,27 @@ export function App() {
         out.push(t);
       }
     }
-    if (board) {
-      for (const card of board.cards) {
-        if (card.team && !seen.has(card.team)) {
-          seen.add(card.team);
-          out.push(card.team);
-        }
+    // The board's own roster (teams with a sprint pointer) is the source of
+    // truth — cards now load one view at a time, so we can't infer teams from
+    // them. Any team present on the loaded cards is folded in as a fallback.
+    for (const t of [...(board?.teams ?? []), ...(board?.cards ?? []).map((c) => c.team ?? "")]) {
+      if (t && !seen.has(t)) {
+        seen.add(t);
+        out.push(t);
       }
     }
     return out;
   }, [addedTeams, board]);
+
+  // What the active board loads and watches: Me is personal (the server fills in
+  // "who am I"), Team names the teams it shows (the filter, or the whole roster).
+  // activeKey is the stable serialisation used to re-fetch and re-subscribe only
+  // when the selection actually changes.
+  const activeQuery = useMemo(
+    () => viewQuery(view, selectedDate, teamFilter ?? roster),
+    [view, selectedDate, teamFilter, roster],
+  );
+  const activeKey = queryString(activeQuery);
 
   // Reorder the whole roster (from the manage dialog) and persist the order.
   const reorderTeams = useCallback((ordered: string[]) => {
@@ -210,6 +247,35 @@ export function App() {
     },
     [provider],
   );
+
+  // Load the active view's cards whenever the selection (view/day/teams) changes
+  // or the board is (re)loaded. loadBoard brings only identity + sprints; the
+  // cards for one view arrive here, so the UI holds just what it shows.
+  const activeQueryRef = useRef(activeQuery);
+  activeQueryRef.current = activeQuery;
+  const bOwner = board?.owner;
+  const bNumber = board?.number;
+  useEffect(() => {
+    if (!bOwner || bNumber == null) {
+      return;
+    }
+    let cancelled = false;
+    provider
+      .listCards({ owner: bOwner, number: bNumber }, activeQueryRef.current)
+      .then((cards) => {
+        if (!cancelled) {
+          setBoard((cur) => (cur ? { ...cur, cards } : cur));
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(errMessage(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bOwner, bNumber, activeKey, provider]);
 
   // Locked board: auto-load the pinned project once authenticated. A user whose
   // token can't read it just gets a load error (the access-denied placeholder).
@@ -411,11 +477,13 @@ export function App() {
       // A fresh connection replays the presence snapshot; drop stale marks.
       setPresenceMap({});
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-      // No selector params: an unscoped watch streams every Card/Sprint/Ordering
-      // change; ?client= keeps our own mutations from echoing back.
+      // Scope the watch to the active view (activeKey = view/day/team/reviews):
+      // a card entering the selection arrives as ADDED, one leaving as DELETED,
+      // so the UI holds just what it shows. ?client= keeps our own mutations
+      // from echoing back. Re-subscribes when activeKey changes (a dep below).
       const url = `${proto}//${window.location.host}/api/v1/watch?owner=${encodeURIComponent(
         watchOwner,
-      )}&project=${watchProject}&client=${clientId}`;
+      )}&project=${watchProject}&client=${clientId}&${activeKey}`;
       socket = new WebSocket(url);
       socket.addEventListener("message", (e) => {
         let frame: WatchFrame;
@@ -446,6 +514,7 @@ export function App() {
     boardLoaded,
     watchOwner,
     watchProject,
+    activeKey,
     provider,
     addCard,
     removeCard,
@@ -643,6 +712,8 @@ export function App() {
         {board && view === "me" && (
           <MeBoard
             board={board}
+            selectedDate={selectedDate}
+            onSelectDate={setSelectedDate}
             provider={provider}
             me={config?.login ?? ""}
             users={users}
@@ -671,6 +742,8 @@ export function App() {
         {board && view === "team" && (
           <TeamBoard
             board={board}
+            selectedDate={selectedDate}
+            onSelectDate={setSelectedDate}
             provider={provider}
             me={config?.login ?? ""}
             users={users}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -30,6 +30,9 @@ interface MeBoardProps {
   board: Board;
   provider: Provider;
   me: string;
+  /** Viewed day, owned by the App (drives the lazy view fetch + scoped watch). */
+  selectedDate: string;
+  onSelectDate: (day: string) => void;
   /** GitHub user details (avatars / names) for the impersonate picker. */
   users: Record<string, GhUser>;
   /** Known teams to offer in the team selector. */
@@ -69,6 +72,8 @@ export function MeBoard({
   board,
   provider,
   me,
+  selectedDate,
+  onSelectDate,
   users,
   teams,
   teamFilter,
@@ -85,7 +90,6 @@ export function MeBoard({
   onOpen,
   onPresence,
 }: MeBoardProps) {
-  const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   // Broadcast the selection as shared presence: teammates' Team boards
   // highlight this card with our avatar. Cleared on deselect and unmount.
@@ -782,7 +786,7 @@ export function MeBoard({
             <button
               type="button"
               className="day-arrow"
-              onClick={() => setSelectedDate((d) => addDays(d, -1))}
+              onClick={() => onSelectDate(addDays(selectedDate, -1))}
               aria-label="Previous day"
               title="Previous day"
             >
@@ -791,12 +795,12 @@ export function MeBoard({
             <input
               type="date"
               value={selectedDate}
-              onChange={(e) => setSelectedDate(e.target.value || todayIso())}
+              onChange={(e) => onSelectDate(e.target.value || todayIso())}
             />
             <button
               type="button"
               className="day-arrow"
-              onClick={() => setSelectedDate((d) => addDays(d, 1))}
+              onClick={() => onSelectDate(addDays(selectedDate, 1))}
               aria-label="Next day"
               title="Next day"
             >
@@ -822,7 +826,7 @@ export function MeBoard({
         <button
           type="button"
           className="btn me-today"
-          onClick={() => setSelectedDate(todayIso())}
+          onClick={() => onSelectDate(todayIso())}
           disabled={selectedDate === todayIso()}
           title="Jump to today"
         >

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -37,6 +37,9 @@ interface TeamBoardProps {
   board: Board;
   provider: Provider;
   me: string;
+  /** Viewed day, owned by the App (drives the lazy view fetch + scoped watch). */
+  selectedDate: string;
+  onSelectDate: (day: string) => void;
   /** GitHub profiles (name + avatar) for assignees, keyed by login. */
   users: Record<string, GhUser>;
   /** Known teams (the roster), shown as filter chips. */
@@ -86,6 +89,8 @@ export function TeamBoard({
   board,
   provider,
   me,
+  selectedDate,
+  onSelectDate,
   users,
   roster,
   teamFilter,
@@ -103,7 +108,6 @@ export function TeamBoard({
   onError,
   onOpen,
 }: TeamBoardProps) {
-  const [selectedDate, setSelectedDate] = useState<string>(todayIso());
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [sprintMenuOpen, setSprintMenuOpen] = useState(false);
   const sprintRef = useRef<HTMLDivElement | null>(null);
@@ -174,29 +178,6 @@ export function TeamBoard({
     document.addEventListener("mousedown", onDocClick);
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [sprintMenuOpen]);
-
-  // A tab left open past midnight keeps a stale "today", so the weekly plan and
-  // newly-planned cards (week = mondayOf(selectedDate)) would land on the old
-  // week and vanish from the real current week. When the tab regains focus,
-  // catch the selected day up to the real today — unless the user navigated to a
-  // specific other day. (The grid create already reads the live date directly.)
-  const lastToday = useRef(todayIso());
-  useEffect(() => {
-    const sync = () => {
-      const now = todayIso();
-      if (now === lastToday.current) {
-        return;
-      }
-      setSelectedDate((d) => (d === lastToday.current ? now : d));
-      lastToday.current = now;
-    };
-    document.addEventListener("visibilitychange", sync);
-    window.addEventListener("focus", sync);
-    return () => {
-      document.removeEventListener("visibilitychange", sync);
-      window.removeEventListener("focus", sync);
-    };
-  }, []);
 
   // Single-select: no filter shows all; otherwise match the card's group.
   const passesFilter = (card: CardModel): boolean =>
@@ -1349,7 +1330,7 @@ export function TeamBoard({
     // overwrite the previous sprint, making previous = current = today. Still land
     // on today, so pressing Carry over always brings the current sprint into view.
     if (old === today) {
-      setSelectedDate(today);
+      onSelectDate(today);
       onError(`«${label}» is already on today's sprint.`);
       return;
     }
@@ -1371,7 +1352,7 @@ export function TeamBoard({
     // so the jump to the new sprint never depends on the request's outcome.
     // Only the closing (current) sprint's unfinished cards carry, mirroring
     // boardservice.CarryOver.
-    setSelectedDate(today);
+    onSelectDate(today);
     for (const c of board.cards) {
       if (
         (team === null ? c.team == null : c.team === team) &&
@@ -1401,7 +1382,7 @@ export function TeamBoard({
             <button
               type="button"
               className="day-arrow"
-              onClick={() => setSelectedDate((d) => addDays(d, -1))}
+              onClick={() => onSelectDate(addDays(selectedDate, -1))}
               aria-label="Previous day"
               title="Previous day"
             >
@@ -1410,12 +1391,12 @@ export function TeamBoard({
             <input
               type="date"
               value={selectedDate}
-              onChange={(e) => setSelectedDate(e.target.value || todayIso())}
+              onChange={(e) => onSelectDate(e.target.value || todayIso())}
             />
             <button
               type="button"
               className="day-arrow"
-              onClick={() => setSelectedDate((d) => addDays(d, 1))}
+              onClick={() => onSelectDate(addDays(selectedDate, 1))}
               aria-label="Next day"
               title="Next day"
             >
@@ -1492,7 +1473,7 @@ export function TeamBoard({
           className="btn"
           onClick={() => {
             if (sprintJump) {
-              setSelectedDate(sprintJump.target);
+              onSelectDate(sprintJump.target);
             }
           }}
           disabled={!sprintJump}
@@ -1506,7 +1487,7 @@ export function TeamBoard({
         <button
           type="button"
           className="btn"
-          onClick={() => setSelectedDate(todayIso())}
+          onClick={() => onSelectDate(todayIso())}
           disabled={selectedDate === todayIso()}
           title="Jump to today"
         >

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -146,9 +146,8 @@ function patchBody(patch: CardPatch): Record<string, unknown> {
 export const apiProvider: Provider = {
   async loadBoard(owner: string, number: number): Promise<Board> {
     const addr: BoardAddr = { owner, number };
-    const [info, cards, sprints] = await Promise.all([
+    const [info, sprints] = await Promise.all([
       api<BoardResource>(addr, "GET", "/board"),
-      api<CardListResource>(addr, "GET", "/cards"),
       api<SprintListResource>(addr, "GET", "/sprints"),
     ]);
     return {
@@ -156,11 +155,25 @@ export const apiProvider: Provider = {
       number,
       title: info.metadata.title ?? "",
       url: info.metadata.url ?? "",
-      // LIST responses are served in board order; the Ordering watch events
-      // keep the local copy sorted between re-lists.
-      cards: (cards.items ?? []).map(resourceToCard),
+      // Cards are loaded per view via listCards; the initial set arrives right
+      // after this from the App's first view fetch.
+      cards: [],
+      teams: info.metadata.teams ?? [],
       sprintStates: sprintStatesFrom(sprints.items ?? []),
     };
+  },
+
+  async listCards(
+    board: BoardAddr,
+    query: Record<string, string>,
+  ): Promise<Card[]> {
+    const qs = Object.keys(query)
+      .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
+      .join("&");
+    // LIST responses are served in board order; the Ordering watch events keep
+    // the local copy sorted between re-lists.
+    const cards = await api<CardListResource>(board, "GET", `/cards?${qs}`);
+    return (cards.items ?? []).map(resourceToCard);
   },
 
   async createCard(board: BoardAddr, input: NewCardInput): Promise<Card> {

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -95,6 +95,9 @@ export interface Board {
   title: string;
   url: string;
   cards: Card[];
+  /** The board's team roster (teams that have a sprint pointer), from GET
+   *  /board — the source of truth now that cards load one view at a time. */
+  teams: string[];
   /** Per-team sprint pointers, keyed by team name ("" = the no-team group). */
   sprintStates: Record<string, SprintState>;
 }
@@ -133,8 +136,12 @@ export interface CarryReport {
  * intent, keep optimistic state, and reconcile from the returned resources
  * (and the watch stream). All board rules live server-side. */
 export interface Provider {
-  /** Compose GET /board + /cards + /sprints into the frontend Board. */
+  /** Board identity + per-team sprint pointers (no cards — the active view is
+   *  loaded lazily via listCards). */
   loadBoard(owner: string, number: number): Promise<Board>;
+  /** The cards of one view (GET /cards with a selector), so the UI loads only
+   *  the active board — Me by default, a team's grid on demand. */
+  listCards(board: BoardAddr, query: Record<string, string>): Promise<Card[]>;
   createCard(board: BoardAddr, input: NewCardInput): Promise<Card>;
   patchCard(board: BoardAddr, uid: string, patch: CardPatch): Promise<Card>;
   /** Hard delete; the server cascades to the linked review card. */

--- a/web/src/viewquery.test.ts
+++ b/web/src/viewquery.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { queryString, viewQuery } from "./viewquery";
+
+describe("viewQuery", () => {
+  it("scopes the Me board to the day, with reviews and no user or team", () => {
+    const q = viewQuery("me", "2026-07-04", ["alpha", "beta"]);
+    expect(q).toEqual({ view: "me", day: "2026-07-04", reviews: "true" });
+    expect(q.user).toBeUndefined();
+    expect(q.team).toBeUndefined();
+  });
+
+  it("names every team the Team board shows as a comma set", () => {
+    const q = viewQuery("team", "2026-07-04", ["alpha", "beta"]);
+    expect(q).toEqual({
+      view: "team",
+      day: "2026-07-04",
+      team: "alpha,beta",
+      reviews: "true",
+    });
+  });
+
+  it("sends an empty team set when the Team board shows no teams", () => {
+    expect(viewQuery("team", "2026-07-04", []).team).toBe("");
+  });
+});
+
+describe("queryString", () => {
+  it("serialises with a stable (sorted) key order and encodes values", () => {
+    const q = viewQuery("team", "2026-07-04", ["a b", "c"]);
+    expect(queryString(q)).toBe(
+      "day=2026-07-04&reviews=true&team=a%20b%2Cc&view=team",
+    );
+  });
+
+  it("is identical for equal selectors, so the watch does not re-subscribe", () => {
+    const a = queryString(viewQuery("me", "2026-07-04", []));
+    const b = queryString(viewQuery("me", "2026-07-04", ["ignored-for-me"]));
+    expect(a).toBe(b);
+  });
+});

--- a/web/src/viewquery.ts
+++ b/web/src/viewquery.ts
@@ -1,0 +1,31 @@
+// The LIST/watch selector for a board view, shared by the data fetch and the
+// scoped watch so both scope to exactly what the active board shows.
+
+export type ViewMode = "me" | "team";
+
+// viewQuery builds the selector for a board view. Me is the personal board — the
+// server resolves "who am I", so no user is sent. Team is the multi-team lead
+// board: it names every team it shows as a comma-separated set. Both ask for
+// reviews=true so each card's linked review card rides along for the reviewer
+// badge without a second request.
+export function viewQuery(
+  view: ViewMode,
+  day: string,
+  teams: string[],
+): Record<string, string> {
+  const q: Record<string, string> = { view, day, reviews: "true" };
+  if (view === "team") {
+    q.team = teams.join(",");
+  }
+  return q;
+}
+
+// queryString serialises a selector to a URL fragment with a stable key order,
+// so it both drives the fetch and keys the watch subscription — the watch
+// re-subscribes only when the selection actually changes.
+export function queryString(q: Record<string, string>): string {
+  return Object.keys(q)
+    .sort()
+    .map((k) => `${k}=${encodeURIComponent(q[k])}`)
+    .join("&");
+}


### PR DESCRIPTION
## What

The cards LIST (HTTP API + MCP) now defaults to the caller's personal **Me** board instead of every card on the board, and the web UI loads one view at a time instead of the whole board up front.

**Backend**
- No `view` on `GET /api/v1/cards` (and MCP `list_cards`) → the caller's Me board (their own cards in the active sprint). Who-am-I is resolved server-side (session/token login for HTTP; verified session for hosted MCP, gh CLI for stdio), so no `user` is needed. Team is the lead view (`view=team`); `view=all` is the whole board.
- `view=team&team=a,b,c` — multi-team (union of grids), so the Team board loads in one request.
- `reviews=true` — a me/team view appends each card's linked review card (self-contained for the reviewer badge; off by default so agents' Me lists aren't padded).
- MCP `list_cards` description steers agents to Me and explains Team/all.

**Frontend**
- `loadBoard` brings only identity + team roster + sprint pointers; the App lifts the viewed day out of the boards and fetches just the active view's cards, re-fetching on a day/view/team change.
- The watch is **scoped** to the active selector and re-subscribes when it changes.
- View-selector logic extracted to a pure `viewquery` module, unit-tested with vitest (added as the web test runner).

## Why

The board fetched every card (hundreds) up front and derived views locally — slow. Agents also defaulted to seeing/touching everyone's cards; Me is where people actually work.

## Tests

- Go: apiserver (default, `view=all`, `reviews`, multi-team), server (HTTP default→Me, view=all), mcp (default→Me). All green, lint 0.
- Web: vitest on `viewquery`; `tsc` + build green.
- Verified on dev via browser: Me loads only the caller's cards (30 vs 298), Team loads the multi-team grid, day nav re-fetches per day, review/round badges render, no console errors, network shows `view=me`/`view=team` fetches.

**Deploy coupling:** the backend default change and the frontend must ship together (the old UI relied on bare `/cards` = all cards).

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein