### PR TITLE
feat(plan): week history for worked cards; never delete a worked card via ×

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -62,6 +62,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 | --- | --- | --- | --- |
 | V1 | Team/Me/Weekly LIST selectors return exactly what the UI renders, sorted by board order | board filters (✅) + 🆕 apiserver `TestListSelectors*` |
 | V2 | Weekly view response carries wed/fri bands + plan progress (recurrent excluded, done→100, average) | **frontend** (planProgress) | 🆕 `TestWeeklyViewProgress*` |
+| W1 | Weekly history: a worked plan card (has a start date) carried forward keeps showing in every past week it was worked in, mirroring the day grid's sprint history; a pure never-started plan card moves with its week | board.planShowsInWeek + TeamBoard showsInWeek | ✅ TestWeeklyHistoryForWorkedCards |
+| W2 | Smart-remove never deletes nor unhooks a worked card: the plan × on an assigned-or-worked card and the grid × on a worked taken card shed only the plan membership (person, dates and sprint history stay); only untouched cards release/demote/delete as before | boardservice.Remove/ReleaseFromPlan | ✅ TestPlanRemoveKeepsWorkedCard / TestGridRemoveOnTakenPlanCard |
 | V3 | Watch (unscoped): ADDED/MODIFIED/DELETED per card; echo suppression by client id | server store | ✅ (live-verified) + 🆕 `TestWatchEvents*` |
 | V4 | Watch (view-scoped): entering/leaving the selection delivers ADDED/DELETED for that subscription | 🆕 apiserver `TestScopedWatch*` |
 | V5 | Ordering singleton: move emits one MODIFIED Ordering; LIST stays sorted | 🆕 apiserver `TestOrdering*` |

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -320,3 +320,33 @@ func TestBoardResourceMembers(t *testing.T) {
 		t.Fatalf("members = %v, want [lllamnyp octocat]", got)
 	}
 }
+
+// A worked plan card carried forward keeps showing in every past week it was
+// worked in (week history, mirroring the day grid's sprint history); a pure
+// never-started plan card moves with its week and leaves no history.
+func TestWeeklyHistoryForWorkedCards(t *testing.T) {
+	b := board.Board{Cards: []board.Card{
+		{ItemID: "worked", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06",
+			StartDate: "2026-07-01", Assignees: []string{"bob"}, Progress: 40},
+		{ItemID: "pure", Team: "alpha", Plan: board.PlanFri, Week: "2026-07-06"},
+		{ItemID: "later", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-13",
+			StartDate: "2026-07-08", Progress: 20},
+	}}
+	ids := func(week string) map[string]bool {
+		out := map[string]bool{}
+		for _, c := range FilterCards(b, Selector{View: "weekly", Team: "alpha", Week: week}) {
+			out[c.ItemID] = true
+		}
+		return out
+	}
+	prev := ids("2026-06-29")
+	if !prev["worked"] || prev["pure"] || prev["later"] {
+		t.Fatalf("week 06-29 = %v, want only the worked card as history", prev)
+	}
+	cur := ids("2026-07-06")
+	// "later" started on 07-08 (inside week 07-06) and was carried to 07-13,
+	// so week 07-06 keeps it as history alongside its own members.
+	if !cur["worked"] || !cur["pure"] || !cur["later"] {
+		t.Fatalf("week 07-06 = %v, want worked+pure+later", cur)
+	}
+}

--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -116,7 +116,7 @@ type WeeklyBands struct {
 func WeeklyPlan(b Board, team, week string) WeeklyBands {
 	bands := WeeklyBands{Wed: []Card{}, Fri: []Card{}}
 	for _, c := range b.Cards {
-		if c.Plan == PlanNone || c.Week != week || c.Team != team {
+		if c.Plan == PlanNone || c.Team != team || !planShowsInWeek(c, week) {
 			continue
 		}
 		if c.Plan == PlanFri {
@@ -126,4 +126,18 @@ func WeeklyPlan(b Board, team, week string) WeeklyBands {
 		}
 	}
 	return bands
+}
+
+// planShowsInWeek reports whether a plan card belongs on week W's panel: its
+// own week, or — mirroring the day grid's sprint history — any past week it was
+// actually worked in. A card taken into work (it has a start date) that was
+// carried forward keeps showing in every week from the one it started in up to
+// (but excluding) the week it now belongs to, so carrying the plan forward does
+// not erase the weeks it was worked in. A pure (never-started) plan card moves
+// with its week and leaves no history.
+func planShowsInWeek(c Card, week string) bool {
+	if c.Week == week {
+		return true
+	}
+	return c.StartDate != "" && c.Week > week && MondayOf(c.StartDate) <= week
 }

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -551,7 +551,10 @@ func (s *Service) Remove(ctx context.Context, owner string, project int, itemID,
 		return err
 	}
 	if from == "plan" {
-		if len(c.Assignees) > 0 {
+		// A card someone is (or was) working on is never deleted by the plan ×:
+		// it sheds only its weekly membership and stays with the person and on
+		// the sprint days it passed through.
+		if len(c.Assignees) > 0 || c.Progress > 0 {
 			if err := s.backend.SetPlan(ctx, b, c, board.PlanNone); err != nil {
 				return err
 			}
@@ -563,6 +566,16 @@ func (s *Service) Remove(ctx context.Context, owner string, project int, itemID,
 		return s.deleteWithCascade(ctx, b, c)
 	}
 	if c.Plan != board.PlanNone {
+		// The grid × on an untouched taken plan card undoes the take: it releases
+		// back to the plan pool. A card already worked on (progress > 0) must NOT
+		// lose its person or sprint history — it sheds the plan membership
+		// instead and stays a regular sprint card.
+		if c.Progress > 0 {
+			if err := s.backend.SetPlan(ctx, b, c, board.PlanNone); err != nil {
+				return err
+			}
+			return s.backend.SetWeek(ctx, b, c, "")
+		}
 		if err := s.backend.SetAssignee(ctx, b, c, ""); err != nil {
 			return err
 		}
@@ -1220,7 +1233,7 @@ func (s *Service) ReleaseFromPlan(ctx context.Context, owner string, project int
 	if err != nil {
 		return err
 	}
-	if len(card.Assignees) == 0 {
+	if len(card.Assignees) == 0 && card.Progress == 0 {
 		if prevWeek := previousWeekFor(b, card); prevWeek != "" {
 			return s.backend.SetWeek(ctx, b, card, prevWeek)
 		}

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1541,3 +1541,53 @@ func TestReReviewRelocatesToNewSprintWithCounter(t *testing.T) {
 		t.Fatalf("re-review resets to 0 and bumps the round: %+v", r)
 	}
 }
+
+// The plan × never deletes a card someone worked on: even unassigned, a card
+// with progress sheds only its weekly membership and survives.
+func TestPlanRemoveKeepsWorkedCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "p", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06", Progress: 40},
+	}, nil)
+	if err := f2svc(f).Remove(ctx, "acme", 1, "p", "plan"); err != nil {
+		t.Fatal(err)
+	}
+	c := f.get("p")
+	if f.count("DeleteCard") != 0 {
+		t.Fatal("a worked card must not be deleted by the plan ×")
+	}
+	if c.Plan != board.PlanNone || c.Week != "" {
+		t.Fatalf("plan membership must be shed: %+v", c)
+	}
+}
+
+// The grid × on a taken plan card: untouched → released back to the plan
+// (person + sprint cleared); already worked → keeps the person and its sprint
+// history, shedding only the plan membership.
+func TestGridRemoveOnTakenPlanCard(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "fresh", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06",
+			Assignees: []string{"bob"}, SprintStart: "2026-07-03", StartDate: "2026-07-03"},
+		{ItemID: "worked", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06",
+			Assignees: []string{"bob"}, SprintStart: "2026-07-03", StartDate: "2026-07-03", Progress: 40},
+	}, nil)
+	svc := f2svc(f)
+	if err := svc.Remove(ctx, "acme", 1, "fresh", "grid"); err != nil {
+		t.Fatal(err)
+	}
+	if c := f.get("fresh"); len(c.Assignees) != 0 || c.SprintStart != "" || c.Plan == board.PlanNone {
+		t.Fatalf("untouched taken card must release back to the plan: %+v", c)
+	}
+	if err := svc.Remove(ctx, "acme", 1, "worked", "grid"); err != nil {
+		t.Fatal(err)
+	}
+	c := f.get("worked")
+	if len(c.Assignees) == 0 || c.SprintStart == "" {
+		t.Fatalf("worked card must keep its person and sprint: %+v", c)
+	}
+	if c.Plan != board.PlanNone || c.Week != "" {
+		t.Fatalf("worked card sheds only the plan membership: %+v", c)
+	}
+	if f.count("DeleteCard") != 0 {
+		t.Fatal("nothing must be deleted")
+	}
+}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -291,8 +291,18 @@ export function TeamBoard({
   const weekly = useMemo(() => {
     const wed: CardModel[] = [];
     const fri: CardModel[] = [];
+    // A card shows in its own week — and, mirroring the day grid's sprint
+    // history, in every past week it was actually worked in: taken into work
+    // (it has a start date) and carried forward past that week. Carrying the
+    // plan forward does not erase the weeks it was worked in.
+    const showsInWeek = (c: CardModel): boolean =>
+      c.week === currentWeek ||
+      (!!c.startDate &&
+        !!c.week &&
+        c.week > currentWeek &&
+        mondayOf(c.startDate) <= currentWeek);
     for (const c of board.cards) {
-      if (!c.plan || c.week !== currentWeek || !passesFilter(c)) {
+      if (!c.plan || !showsInWeek(c) || !passesFilter(c)) {
         continue;
       }
       (c.plan === "fri" ? fri : wed).push(c);
@@ -937,14 +947,21 @@ export function TeamBoard({
         };
       }
     } else {
-      // A taken plan card is released (assignee + sprint cleared), so it stays
-      // in the weekly plan.
-      const prev: Partial<CardModel> = {
-        assignees: card.assignees,
-        sprintStart: card.sprintStart,
-      };
-      patchCard(card.itemId, { assignees: [], sprintStart: undefined });
-      rollback = () => patchCard(card.itemId, prev);
+      // An untouched taken plan card is released (assignee + sprint cleared),
+      // so it stays in the weekly plan. A card already worked on keeps its
+      // person and sprint history and sheds only the plan membership.
+      if ((card.progress ?? 0) > 0) {
+        const prev: Partial<CardModel> = { plan: card.plan, week: card.week };
+        patchCard(card.itemId, { plan: undefined, week: undefined });
+        rollback = () => patchCard(card.itemId, prev);
+      } else {
+        const prev: Partial<CardModel> = {
+          assignees: card.assignees,
+          sprintStart: card.sprintStart,
+        };
+        patchCard(card.itemId, { assignees: [], sprintStart: undefined });
+        rollback = () => patchCard(card.itemId, prev);
+      }
     }
     void provider
       .removeCard(board, card.itemId, "grid")
@@ -969,7 +986,7 @@ export function TeamBoard({
       return;
     }
     let rollback: () => void;
-    if (card.assignees.length === 0) {
+    if (card.assignees.length === 0 && (card.progress ?? 0) === 0) {
       const prevWeek = previousWeekFor(card);
       if (prevWeek) {
         const prev: Partial<CardModel> = { week: card.week };


### PR DESCRIPTION
Two coupled weekly-plan rules, mirroring the day grid's sprint history (per team feedback):

- **Week history**: a plan card taken into work (it has a start date) that was carried forward keeps showing in every past week it was actually worked in — carrying the plan forward no longer erases the weeks it was worked. A pure never-started plan card moves with its week, as before.
- **Worked cards survive the ×**: the plan × on an assigned-or-worked card and the grid × on a worked (progress > 0) taken card shed only the plan membership — the person, dates and sprint history stay; nothing is deleted. Only untouched cards still release/demote/delete as before.

Server rule in `board.planShowsInWeek` + guards in `boardservice.Remove`/`ReleaseFromPlan`, mirrored in the TeamBoard panel filter and its optimistic × handlers. Verified on dev against the real cozystack plan: the previous week now shows the done card plus all five carried worked cards; the next week is unchanged.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein