### PR TITLE
fix(plan): anchor week history on the sprint join too

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -331,6 +331,10 @@ func TestWeeklyHistoryForWorkedCards(t *testing.T) {
 		{ItemID: "pure", Team: "alpha", Plan: board.PlanFri, Week: "2026-07-06"},
 		{ItemID: "later", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-13",
 			StartDate: "2026-07-08", Progress: 20},
+		// Taken into the sprint without a start date (take-into-plan sets only
+		// the sprint): the sprint join anchors its week history.
+		{ItemID: "sprintOnly", Team: "alpha", Plan: board.PlanFri, Week: "2026-07-06",
+			SprintStart: "2026-07-03", Assignees: []string{"dan"}},
 	}}
 	ids := func(week string) map[string]bool {
 		out := map[string]bool{}
@@ -340,8 +344,8 @@ func TestWeeklyHistoryForWorkedCards(t *testing.T) {
 		return out
 	}
 	prev := ids("2026-06-29")
-	if !prev["worked"] || prev["pure"] || prev["later"] {
-		t.Fatalf("week 06-29 = %v, want only the worked card as history", prev)
+	if !prev["worked"] || !prev["sprintOnly"] || prev["pure"] || prev["later"] {
+		t.Fatalf("week 06-29 = %v, want worked+sprintOnly as history", prev)
 	}
 	cur := ids("2026-07-06")
 	// "later" started on 07-08 (inside week 07-06) and was carried to 07-13,

--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -139,5 +139,11 @@ func planShowsInWeek(c Card, week string) bool {
 	if c.Week == week {
 		return true
 	}
-	return c.StartDate != "" && c.Week > week && MondayOf(c.StartDate) <= week
+	// The "began work" anchor is the earliest of the start date and the sprint
+	// join — take-into-plan sets the sprint but not necessarily a start date.
+	started := c.StartDate
+	if c.SprintStart != "" && (started == "" || c.SprintStart < started) {
+		started = c.SprintStart
+	}
+	return started != "" && c.Week > week && MondayOf(started) <= week
 }

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -295,12 +295,23 @@ export function TeamBoard({
     // history, in every past week it was actually worked in: taken into work
     // (it has a start date) and carried forward past that week. Carrying the
     // plan forward does not erase the weeks it was worked in.
-    const showsInWeek = (c: CardModel): boolean =>
-      c.week === currentWeek ||
-      (!!c.startDate &&
+    const showsInWeek = (c: CardModel): boolean => {
+      if (c.week === currentWeek) {
+        return true;
+      }
+      // The "began work" anchor is the earliest of the start date and the
+      // sprint join — take-into-plan sets the sprint, not always a start date.
+      let started = c.startDate ?? "";
+      if (c.sprintStart && (!started || c.sprintStart < started)) {
+        started = c.sprintStart;
+      }
+      return (
+        !!started &&
         !!c.week &&
         c.week > currentWeek &&
-        mondayOf(c.startDate) <= currentWeek);
+        mondayOf(started) <= currentWeek
+      );
+    };
     for (const c of board.cards) {
       if (!c.plan || !showsInWeek(c) || !passesFilter(c)) {
         continue;


### PR DESCRIPTION
Take-into-plan assigns the engineer and joins the sprint but does not always set a start date, so an assigned card taken into the sprint (e.g. «automated VPN site to site», sprint-joined on Friday with no start date) left no week history when carried forward. Anchor the "began work" week on the earliest of the start date and the sprint join, server-side and in the panel mirror.

Verified on dev: the card now shows in the previous week's plan alongside the other worked cards.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein