### PR TITLE
fix(plan): make carry-week's recurrent reseed idempotent across torn runs

### DIFF
--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -430,11 +430,20 @@ func (s *Service) CarryWeek(ctx context.Context, owner string, project int, team
 		week = board.MondayOf(board.TodayIso())
 	}
 	// Titles already planned in the target week, for the recurrent reseed dedup:
-	// re-running carry-week must not create a second copy.
+	// re-running carry-week must not create a second copy. A plan card with an
+	// EMPTY week is a torn reseed from an interrupted earlier run (create landed,
+	// the week write did not) — track those to finish them instead of duplicating.
 	inTarget := map[string]bool{}
+	torn := map[string]board.Card{}
 	for _, c := range b.Cards {
-		if c.Plan != board.PlanNone && c.Week == week && c.Team == team {
+		if c.Plan == board.PlanNone || c.Team != team {
+			continue
+		}
+		if c.Week == week {
 			inTarget[c.Title] = true
+		}
+		if c.Week == "" {
+			torn[c.Title] = c
 		}
 	}
 	var rep CarryReport
@@ -450,6 +459,15 @@ func (s *Service) CarryWeek(ctx context.Context, owner string, project int, team
 			}
 			rep.Reseeded++
 			if dryRun {
+				continue
+			}
+			// Finish a torn reseed instead of creating another copy.
+			if stray, ok := torn[c.Title]; ok {
+				if err := s.backend.SetWeek(ctx, b, stray, week); err != nil {
+					return rep, err
+				}
+				delete(torn, c.Title)
+				inTarget[c.Title] = true
 				continue
 			}
 			if err := s.reseedRecurrent(ctx, b, c, board.CreateInput{

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1620,3 +1620,37 @@ func TestCarryWeekTightensFriToWed(t *testing.T) {
 		}
 	}
 }
+
+// Carry-week's reseed is idempotent: a copy already in the target week blocks a
+// second one, and a torn reseed (plan band set, week empty — an interrupted
+// earlier run) is finished by setting its week instead of duplicating.
+func TestCarryWeekReseedDedupAndTornRepair(t *testing.T) {
+	week := "2026-07-06"
+	// Case 1: copy already in the target week -> nothing new.
+	f := newFake([]board.Card{
+		{ItemID: "src", Team: "alpha", Title: "Habit", Plan: board.PlanFri, Week: "2026-06-29",
+			Stage: board.StageRecurrent, Progress: 100},
+		{ItemID: "copy", Team: "alpha", Title: "Habit", Plan: board.PlanFri, Week: week},
+	}, nil)
+	if _, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", week, false); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("CreateCard") != 0 {
+		t.Fatal("an existing target-week copy must block the reseed")
+	}
+	// Case 2: torn reseed (week empty) -> repaired, not duplicated.
+	f = newFake([]board.Card{
+		{ItemID: "src", Team: "alpha", Title: "Habit", Plan: board.PlanFri, Week: "2026-06-29",
+			Stage: board.StageRecurrent, Progress: 100},
+		{ItemID: "stray", Team: "alpha", Title: "Habit", Plan: board.PlanWed, Week: ""},
+	}, nil)
+	if _, err := f2svc(f).CarryWeek(ctx, "acme", 1, "alpha", week, false); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("CreateCard") != 0 {
+		t.Fatal("a torn reseed must be repaired, not duplicated")
+	}
+	if c := f.get("stray"); c.Week != week {
+		t.Fatalf("the torn copy must be finished into the target week: %+v", c)
+	}
+}


### PR DESCRIPTION
The reseed dedup only counted copies whose week already equals the target week, so a torn reseed from an interrupted earlier run (the create landed, the week write did not — Projects v2 sets fields with separate mutations) was invisible to it, and every following carry-week created another copy of the recurrent card. Track plan cards with an empty week as torn reseeds and finish them (set their week) instead of duplicating.

This is how «Мирхостинг…» ended up duplicated on board 37: the copies predate the dedup (created 29.06, dedup shipped 02.07), and one of them is a torn week-less stray that would keep seeding duplicates.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein