### PR TITLE
fix(web): reload() must not blank the board; carry-over navigates after the call

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,19 @@ function writeStringList(key: string, value: string[]) {
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
+// mergeCardLists flattens a view's lists (e.g. the Team grid + its weekly
+// plan), deduping by item id; board order within each list is preserved.
+function mergeCardLists(lists: CardModel[][]): CardModel[] {
+  const seen = new Set<string>();
+  return lists.flat().filter((c) => {
+    if (seen.has(c.itemId)) {
+      return false;
+    }
+    seen.add(c.itemId);
+    return true;
+  });
+}
+
 export function App() {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [tokenWarningDismissed, setTokenWarningDismissed] = useState(false);
@@ -247,8 +260,17 @@ export function App() {
       setLoading(true);
       setError(null);
       try {
-        const loaded = await provider.loadBoard(ownerArg, numberArg);
-        setBoard(loaded);
+        // Identity + sprints AND the active view's cards together, swapped in
+        // as one board: a reload() must never leave the board empty while the
+        // cards are still in flight (loadBoard itself carries no cards).
+        const addr = { owner: ownerArg, number: numberArg };
+        const [loaded, lists] = await Promise.all([
+          provider.loadBoard(ownerArg, numberArg),
+          Promise.all(
+            activeQueriesRef.current.map((q) => provider.listCards(addr, q)),
+          ),
+        ]);
+        setBoard({ ...loaded, cards: mergeCardLists(lists) });
       } catch (err: unknown) {
         setError(errMessage(err));
       } finally {
@@ -276,17 +298,7 @@ export function App() {
         if (cancelled) {
           return;
         }
-        // Merge the view's lists (e.g. the Team grid + its weekly plan),
-        // deduping by item id; board order within each list is preserved.
-        const seen = new Set<string>();
-        const cards = lists.flat().filter((c) => {
-          if (seen.has(c.itemId)) {
-            return false;
-          }
-          seen.add(c.itemId);
-          return true;
-        });
-        setBoard((cur) => (cur ? { ...cur, cards } : cur));
+        setBoard((cur) => (cur ? { ...cur, cards: mergeCardLists(lists) } : cur));
       })
       .catch((err: unknown) => {
         if (!cancelled) {

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1366,11 +1366,11 @@ export function TeamBoard({
     ) {
       return;
     }
-    // Land on today and move the cards optimistically before the network call,
-    // so the jump to the new sprint never depends on the request's outcome.
-    // Only the closing (current) sprint's unfinished cards carry, mirroring
-    // boardservice.CarryOver.
-    onSelectDate(today);
+    // Move the cards optimistically so the current view keeps showing them
+    // while the (slow) carry runs; the jump to today happens AFTER the server
+    // call — changing the day now would refetch the view against the not-yet-
+    // advanced sprint and blank the board. Only the closing (current) sprint's
+    // unfinished cards carry, mirroring boardservice.CarryOver.
     for (const c of board.cards) {
       if (
         (team === null ? c.team == null : c.team === team) &&
@@ -1387,7 +1387,9 @@ export function TeamBoard({
     } catch (err: unknown) {
       onError(errMessage(err));
     }
-    // Re-read the advanced state (and reconcile the carried cards).
+    // Land on today and re-read the advanced state (the day-change refetch now
+    // sees the post-carry sprint).
+    onSelectDate(today);
     reload();
   };
 


### PR DESCRIPTION
Two halves of the «press Carry over → empty page until a manual refresh» bug:

- **Every `reload()` blanked the board** since per-view loading: `loadBoard` carries no cards, so `doLoad` replaced the board with an empty list — and the view-fetch effect did not re-run (its selector hadn't changed). `doLoad` now fetches identity + sprints **and** the active view's cards together, swapping the board in as one piece. This also fixes the blank-after-reload for every other mutation that re-lists.
- **Carry-over jumped to today before the (slow) server call**, so the day-change refetch read the not-yet-advanced sprint and returned an empty grid. It now lands on today after the call, when the refetch sees the post-carry state; the optimistic card moves keep the current view populated during the run.

Verified in the browser on dev: a create (which reloads) leaves the board fully populated where it previously blanked.

https://claude.ai/code/session_01LcuC9rD93sXWYobJUDeein