### PR TITLE
feat(plan): assignee avatar on taken weekly cards; history only in finished weeks

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -113,7 +113,7 @@ func (s *Server) handleAPIIndex(w http.ResponseWriter, _ *http.Request) {
 			{"PATCH", "/api/v1/cards/{uid}", "Edit spec fields; the server applies clamps, links and date rules"},
 			{"DELETE", "/api/v1/cards/{uid}", "Hard delete (cascades to the linked review card)"},
 			{"POST", "/api/v1/cards/{uid}/actions/remove", "The smart remove: demote, release or delete by board rules ({from: grid|plan})"},
-			{"POST", "/api/v1/cards/{uid}/actions/move", "Reorder after another card ({after}, empty = top)"},
+			{"POST", "/api/v1/cards/{uid}/actions/move", "Reorder after ({after}) or before ({before}) another card; empty = top"},
 			{"POST", "/api/v1/cards/{uid}/actions/defer", "Push the scheduled day {days} ahead of today"},
 			{"POST", "/api/v1/cards/{uid}/actions/in-progress", "Move to the implicit In Progress status"},
 			{"POST", "/api/v1/cards/{uid}/actions/send-to-review", "Send to review ({reviewer, day}); reassigns if a review card exists"},
@@ -585,7 +585,8 @@ func (s *Server) handleRemoveCard(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleMoveCard(w http.ResponseWriter, r *http.Request) {
 	var in struct {
-		After string `json:"after"`
+		After  string `json:"after"`
+		Before string `json:"before"`
 	}
 	if !decodeJSON(w, r, &in) {
 		return
@@ -594,7 +595,13 @@ func (s *Server) handleMoveCard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := svc.MoveCard(r.Context(), owner, project, r.PathValue("uid"), in.After); err != nil {
+	move := func() error {
+		if in.Before != "" {
+			return svc.MoveCardBefore(r.Context(), owner, project, r.PathValue("uid"), in.Before)
+		}
+		return svc.MoveCard(r.Context(), owner, project, r.PathValue("uid"), in.After)
+	}
+	if err := move(); err != nil {
 		s.apiError(w, err)
 		return
 	}

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -321,20 +321,25 @@ func TestBoardResourceMembers(t *testing.T) {
 	}
 }
 
-// A worked plan card carried forward keeps showing in every past week it was
-// worked in (week history, mirroring the day grid's sprint history); a pure
-// never-started plan card moves with its week and leaves no history.
+// A worked plan card moved forward keeps showing in FINISHED past weeks it was
+// worked in (week history); a pure never-started plan card moves with its week
+// and leaves no history. Weeks are relative to the real clock — a fully past
+// week is deterministic; the running-week gate is covered by
+// TestPlanShowsInWeekAt in pkg/board.
 func TestWeeklyHistoryForWorkedCards(t *testing.T) {
+	wPrev := board.AddDays(board.MondayOf(board.TodayIso()), -7)
+	wCur := board.MondayOf(board.TodayIso())
 	b := board.Board{Cards: []board.Card{
-		{ItemID: "worked", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06",
-			StartDate: "2026-07-01", Assignees: []string{"bob"}, Progress: 40},
-		{ItemID: "pure", Team: "alpha", Plan: board.PlanFri, Week: "2026-07-06"},
-		{ItemID: "later", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-13",
-			StartDate: "2026-07-08", Progress: 20},
+		{ItemID: "worked", Team: "alpha", Plan: board.PlanWed, Week: wCur,
+			StartDate: board.AddDays(wPrev, 2), Assignees: []string{"bob"}, Progress: 40},
+		{ItemID: "pure", Team: "alpha", Plan: board.PlanFri, Week: wCur},
 		// Taken into the sprint without a start date (take-into-plan sets only
 		// the sprint): the sprint join anchors its week history.
-		{ItemID: "sprintOnly", Team: "alpha", Plan: board.PlanFri, Week: "2026-07-06",
-			SprintStart: "2026-07-03", Assignees: []string{"dan"}},
+		{ItemID: "sprintOnly", Team: "alpha", Plan: board.PlanFri, Week: wCur,
+			SprintStart: board.AddDays(wPrev, 4), Assignees: []string{"dan"}},
+		// Anchored only in the current week: no trace in the previous one.
+		{ItemID: "later", Team: "alpha", Plan: board.PlanWed,
+			Week: board.AddDays(wCur, 7), StartDate: wCur, Progress: 20},
 	}}
 	ids := func(week string) map[string]bool {
 		out := map[string]bool{}
@@ -343,30 +348,30 @@ func TestWeeklyHistoryForWorkedCards(t *testing.T) {
 		}
 		return out
 	}
-	prev := ids("2026-06-29")
+	prev := ids(wPrev)
 	if !prev["worked"] || !prev["sprintOnly"] || prev["pure"] || prev["later"] {
-		t.Fatalf("week 06-29 = %v, want worked+sprintOnly as history", prev)
+		t.Fatalf("previous week = %v, want worked+sprintOnly as history", prev)
 	}
-	cur := ids("2026-07-06")
-	// "later" started on 07-08 (inside week 07-06) and was carried to 07-13,
-	// so week 07-06 keeps it as history alongside its own members.
-	if !cur["worked"] || !cur["pure"] || !cur["later"] {
-		t.Fatalf("week 07-06 = %v, want worked+pure+later", cur)
+	cur := ids(wCur)
+	if !cur["worked"] || !cur["pure"] || !cur["sprintOnly"] {
+		t.Fatalf("current week = %v, want its own members", cur)
 	}
 }
 
-// A week-history entry sits in the by-Friday band of the past week regardless
-// of its current band; in its own week it sits in its own band.
+// A week-history entry sits in the by-Friday band of the finished past week
+// regardless of its current band; in its own week it sits in its own band.
 func TestWeeklyHistoryLandsInFriBand(t *testing.T) {
+	wPrev := board.AddDays(board.MondayOf(board.TodayIso()), -7)
+	wCur := board.MondayOf(board.TodayIso())
 	b := board.Board{Cards: []board.Card{
-		{ItemID: "moved", Team: "alpha", Plan: board.PlanWed, Week: "2026-07-06",
-			StartDate: "2026-07-01", Progress: 40},
+		{ItemID: "moved", Team: "alpha", Plan: board.PlanWed, Week: wCur,
+			StartDate: board.AddDays(wPrev, 2), Progress: 40},
 	}}
-	prev := board.WeeklyPlan(b, "alpha", "2026-06-29")
+	prev := board.WeeklyPlan(b, "alpha", wPrev)
 	if len(prev.Fri) != 1 || len(prev.Wed) != 0 {
 		t.Fatalf("past week: history goes to the fri band, got wed=%d fri=%d", len(prev.Wed), len(prev.Fri))
 	}
-	cur := board.WeeklyPlan(b, "alpha", "2026-07-06")
+	cur := board.WeeklyPlan(b, "alpha", wCur)
 	if len(cur.Wed) != 1 || len(cur.Fri) != 0 {
 		t.Fatalf("own week: the card sits in its own band, got wed=%d fri=%d", len(cur.Wed), len(cur.Fri))
 	}

--- a/pkg/board/events_test.go
+++ b/pkg/board/events_test.go
@@ -84,3 +84,30 @@ func TestNoteAuthorRoundTrip(t *testing.T) {
 		t.Fatal("empty author stores the bare text")
 	}
 }
+
+// The weekly history rule against an explicit clock: a worked card moved to a
+// later week shows in a week only once that week's Friday has passed — a card
+// pushed forward mid-week leaves the running week's panel.
+func TestPlanShowsInWeekAt(t *testing.T) {
+	worked := Card{Plan: PlanWed, Week: "2026-07-13", StartDate: "2026-06-29", Progress: 30}
+	cases := []struct {
+		name  string
+		card  Card
+		week  string
+		today string
+		want  bool
+	}{
+		{"own week always shows", worked, "2026-07-13", "2026-07-06", true},
+		{"running week hides a forward-moved card (Freedom bandwidth)", worked, "2026-07-06", "2026-07-06", false},
+		{"still hidden on that week's Friday", worked, "2026-07-06", "2026-07-10", false},
+		{"finished week shows the history", worked, "2026-07-06", "2026-07-11", true},
+		{"Sunday after the closing Friday shows it (the carry-week sync case)", worked, "2026-06-29", "2026-07-05", true},
+		{"never-started plan card leaves no history", Card{Plan: PlanFri, Week: "2026-07-13"}, "2026-07-06", "2026-07-11", false},
+		{"weeks before the work anchor stay empty", worked, "2026-06-22", "2026-07-11", false},
+	}
+	for _, tc := range cases {
+		if got := planShowsInWeekAt(tc.card, tc.week, tc.today); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -132,15 +132,27 @@ func WeeklyPlan(b Board, team, week string) WeeklyBands {
 }
 
 // planShowsInWeek reports whether a plan card belongs on week W's panel: its
-// own week, or — mirroring the day grid's sprint history — any past week it was
-// actually worked in. A card taken into work (it has a start date) that was
-// carried forward keeps showing in every week from the one it started in up to
-// (but excluding) the week it now belongs to, so carrying the plan forward does
-// not erase the weeks it was worked in. A pure (never-started) plan card moves
-// with its week and leaves no history.
+// own week, or — mirroring the day grid's sprint history — any FINISHED week
+// it was actually worked in. A card taken into work that was moved forward
+// keeps showing in the weeks it was worked once those weeks are over (their
+// Friday has passed); while a week is still running, a card deliberately
+// pushed to a future week leaves its panel — it is not this week's work
+// anymore. A pure (never-started) plan card moves with its week and leaves no
+// history.
 func planShowsInWeek(c Card, week string) bool {
+	return planShowsInWeekAt(c, week, TodayIso())
+}
+
+// planShowsInWeekAt is planShowsInWeek against an explicit "today" (testable).
+func planShowsInWeekAt(c Card, week, today string) bool {
 	if c.Week == week {
 		return true
+	}
+	// History only in weeks whose working days are over: past the week's
+	// Friday (the plan's bands are wed/fri deadlines; the weekend belongs to
+	// wrap-up, not new placement).
+	if today <= AddDays(week, 4) {
+		return false
 	}
 	// The "began work" anchor is the earliest of the start date and the sprint
 	// join — take-into-plan sets the sprint but not necessarily a start date.

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1346,6 +1346,28 @@ func (s *Service) MoveCard(ctx context.Context, owner string, project int, itemI
 	return s.backend.MoveCard(ctx, b, card, afterID)
 }
 
+// MoveCardBefore reorders a card to sit right before beforeID. Clients that
+// render a filtered slice of the board (a weekly-plan band) cannot name the
+// global predecessor for "move to the top of my group" — but the server knows
+// the full order, so it resolves the card just before beforeID (skipping the
+// moved card itself) and anchors there ("" = top of the board).
+func (s *Service) MoveCardBefore(ctx context.Context, owner string, project int, itemID, beforeID string) error {
+	b, card, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	afterID := ""
+	for _, c := range b.Cards {
+		if c.ItemID == beforeID {
+			break
+		}
+		if c.ItemID != itemID {
+			afterID = c.ItemID
+		}
+	}
+	return s.backend.MoveCard(ctx, b, card, afterID)
+}
+
 // DeleteCard deletes a card, cascading to its linked review card. It mirrors
 // handleDelete in TeamBoard.tsx (deleting a reviewed card removes both).
 func (s *Service) DeleteCard(ctx context.Context, owner string, project int, itemID string) error {

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1982,3 +1982,31 @@ func TestDescriptionLengthLimit(t *testing.T) {
 		t.Fatalf("at the limit must pass: %v", err)
 	}
 }
+
+// MoveCardBefore resolves the true global anchor server-side: the card lands
+// right before the named card, skipping itself when scanning for the
+// predecessor. Clients rendering a filtered slice (a weekly-plan band) use it
+// for "move to the top of my group" without knowing the full board order.
+func TestMoveCardBefore(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name         string
+		move, before string
+		wantAfter    string
+	}{
+		{"before the first card = board top", "c3", "c1", ""},
+		{"anchors on the true predecessor", "c1", "c3", "c2"},
+		{"skips itself when already adjacent", "c2", "c3", "c1"},
+	}
+	for _, tc := range cases {
+		f := newFake([]board.Card{{ItemID: "c1"}, {ItemID: "c2"}, {ItemID: "c3"}, {ItemID: "c4"}}, nil)
+		svc := New(f)
+		if err := svc.MoveCardBefore(ctx, "acme", 1, tc.move, tc.before); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		want := fmt.Sprintf("MoveCard %s after=%s", tc.move, tc.wantAfter)
+		if !f.saw(want) {
+			t.Errorf("%s: want %q; log=%v", tc.name, want, f.log)
+		}
+	}
+}

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -365,7 +365,8 @@ func (h *server) removeCard(ctx context.Context, _ *mcp.CallToolRequest, in remo
 // moveCardInput reorders a card on the board.
 type moveCardInput struct {
 	cardRef
-	After string `json:"after,omitempty" jsonschema:"uid to position after; empty moves the card to the top"`
+	After  string `json:"after,omitempty" jsonschema:"uid to position after; empty moves the card to the top"`
+	Before string `json:"before,omitempty" jsonschema:"uid to position right before (the server resolves the true anchor); wins over after"`
 }
 
 func (h *server) moveCard(ctx context.Context, _ *mcp.CallToolRequest, in moveCardInput) (*mcp.CallToolResult, apiserver.Card, error) {
@@ -373,7 +374,13 @@ func (h *server) moveCard(ctx context.Context, _ *mcp.CallToolRequest, in moveCa
 	if err != nil {
 		return nil, apiserver.Card{}, err
 	}
-	if err := svc.MoveCard(ctx, owner, project, in.UID, in.After); err != nil {
+	move := func() error {
+		if in.Before != "" {
+			return svc.MoveCardBefore(ctx, owner, project, in.UID, in.Before)
+		}
+		return svc.MoveCard(ctx, owner, project, in.UID, in.After)
+	}
+	if err := move(); err != nil {
 		return nil, apiserver.Card{}, err
 	}
 	return h.cardResource(ctx, svc, owner, project, in.UID)

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -302,6 +302,17 @@ export function Card({
   // A plan card not yet taken into work hasn't started aging: show 0d. Once it
   // has an assignee it ages normally; and it gets a green "taken" background.
   const taken = Boolean(weekMode) && card.assignees.length > 0;
+  // The small second avatar: on a weekly-plan card it is the person the card
+  // is ASSIGNED to (who took it into work) — not the review counterpart; on
+  // grid cards it stays the counterpart (the reviewer / the implementer).
+  const smallAvatars = weekMode
+    ? card.assignees
+    : (counterpartAssignees ?? []);
+  const smallAvatarRole = weekMode
+    ? "Assigned to"
+    : card.reviewOf
+      ? "In implementation"
+      : "On review";
   const ageDays =
     weekMode && card.assignees.length === 0 ? 0 : daysSince(card.createdAt, asOf);
 
@@ -676,7 +687,9 @@ export function Card({
         </div>
       )}
 
-      {(card.team || canAssign || (counterpartAssignees?.length ?? 0) > 0) && (
+      {(card.team ||
+        canAssign ||
+        smallAvatars.length > 0) && (
         <div className="card-assign" ref={assignRef}>
           {card.team ? (
             <button
@@ -714,11 +727,11 @@ export function Card({
               +
             </button>
           )}
-          {counterpartAssignees && counterpartAssignees.length > 0 && (
+          {smallAvatars.length > 0 && (
             <button
               type="button"
               className="card-counterpart-avatar-btn"
-              title={`${card.reviewOf ? "In implementation" : "On review"}: ${counterpartAssignees
+              title={`${smallAvatarRole}: ${smallAvatars
                 .map((p) => displayName(p, users?.[p]))
                 .join(", ")}`}
               onClick={
@@ -732,14 +745,8 @@ export function Card({
             >
               <img
                 className="card-counterpart-avatar"
-                src={avatarUrlFor(
-                  counterpartAssignees[0],
-                  users?.[counterpartAssignees[0]],
-                )}
-                alt={displayName(
-                  counterpartAssignees[0],
-                  users?.[counterpartAssignees[0]],
-                )}
+                src={avatarUrlFor(smallAvatars[0], users?.[smallAvatars[0]])}
+                alt={displayName(smallAvatars[0], users?.[smallAvatars[0]])}
               />
             </button>
           )}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -696,8 +696,18 @@ export function TeamBoard({
       subset.has(c.itemId) ? order[i++] : c.itemId,
     );
     reorderCards(next);
-    const afterId = afterIdFor(next, card.itemId);
-    void provider.moveCard(board, card.itemId, afterId).catch((err: unknown) => {
+    // Persist anchored on a BAND neighbour, never on the local global order:
+    // the board list here is a merge of the grid and weekly fetches, so
+    // non-band neighbours don't reflect the true project order. After the
+    // new predecessor — or, for the top slot, before the card now second.
+    const idx = order.indexOf(card.itemId);
+    const persist =
+      idx > 0
+        ? provider.moveCard(board, card.itemId, order[idx - 1])
+        : order.length > 1
+          ? provider.moveCardBefore(board, card.itemId, order[1])
+          : null;
+    void persist?.catch((err: unknown) => {
       onError(errMessage(err));
       reload();
     });

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -299,6 +299,12 @@ export function TeamBoard({
       if (c.week === currentWeek) {
         return true;
       }
+      // History only in weeks whose working days are over (past the week's
+      // Friday): while a week runs, a card pushed to a future week leaves its
+      // panel — it is not this week's work anymore.
+      if (todayIso() <= addDays(currentWeek, 4)) {
+        return false;
+      }
       // The "began work" anchor is the earliest of the start date and the
       // sprint join — take-into-plan sets the sprint, not always a start date.
       let started = c.startDate ?? "";

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -233,6 +233,16 @@ export const apiProvider: Provider = {
     await api(board, "POST", `/cards/${uid}/actions/move`, { after });
   },
 
+  async moveCardBefore(
+    board: BoardAddr,
+    uid: string,
+    beforeId: string,
+  ): Promise<void> {
+    uid = await resolveCardId(uid);
+    const before = await resolveCardId(beforeId);
+    await api(board, "POST", `/cards/${uid}/actions/move`, { before });
+  },
+
   async deferCard(board: BoardAddr, uid: string, days: number): Promise<Card> {
     uid = await resolveCardId(uid);
     return cardFrom(board, "POST", `/cards/${uid}/actions/defer`, { days });

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -165,6 +165,10 @@ export interface Provider {
   removeCard(board: BoardAddr, uid: string, from: "grid" | "plan"): Promise<void>;
   /** Reposition card after afterId in the project order (null = top). */
   moveCard(board: BoardAddr, uid: string, afterId: string | null): Promise<void>;
+  /** Reorder to sit right before another card: the server resolves the true
+   *  global anchor, so callers rendering a filtered slice (a weekly band)
+   *  don't need to know the full board order. */
+  moveCardBefore(board: BoardAddr, uid: string, beforeId: string): Promise<void>;
   /** Push the scheduled day N days ahead of max(today, current start). */
   deferCard(board: BoardAddr, uid: string, days: number): Promise<Card>;
   /** Move to the implicit In Progress status (no stage, progress in [10,90]). */


### PR DESCRIPTION
Two weekly-panel refinements:

- **Assignee avatar**: a taken weekly-plan card shows a small second avatar of the person it is assigned to (who took it into work) — not the review counterpart, which remains the small avatar on grid cards.
- **History only in finished weeks**: a worked card deliberately pushed to a future week no longer lingers in the RUNNING week's panel — week-history entries appear only once the viewed week's Friday has passed. The Friday-sync case (worked cards carried forward, viewed on the weekend) still shows; a card moved ahead mid-week (e.g. «Freedom bandwidth» +1 week) leaves the current panel immediately. Verified live on the board: gone from the current portal week, present in the next one.

Covered by a clock-injected unit test over the rule (running week / Friday boundary / finished week / Sunday sync case) and clock-relative view tests.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt