### PR TITLE
fix(security): harden auth, OAuth, and the API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # aeman
 
-Day-to-day project management for teams, with **GitHub Projects v2 as the storage** — aeman has no database of its own. The whole thing ships as one self-contained Go binary: an embedded React SPA (via `go:embed`), a JSON REST API, a WebSocket **watch** stream that keeps every open board updated live, and an MCP server for AI agents — all driving the same board service, with GitHub as the single source of truth.
+A short-term planning system for engineering teams — it keeps engineers focused, runs daily sprints, and makes unplanned work visible. **GitHub Projects v2 is the storage**, so aeman has no database of its own. The whole thing ships as one self-contained Go binary: an embedded React SPA (via `go:embed`), a JSON REST API, a WebSocket **watch** stream that keeps every open board updated live, and an MCP server for AI agents — all driving the same board service, with GitHub as the single source of truth.
 
 ## Concept
 

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -181,7 +181,7 @@ func (s *Server) defaultService(r *http.Request) (*boardservice.Service, error) 
 	if err != nil {
 		return nil, err
 	}
-	return boardservice.New(&storeBackend{inner: client, store: s.store}), nil
+	return boardservice.New(&storeBackend{inner: client, store: s.store, multiUser: s.auth != nil}), nil
 }
 
 // service resolves the board reference and builds the per-request board service.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -920,8 +920,7 @@ func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
 // (X-Aeman-Client) keys it, so a closed tab clears its own mark.
 func (s *Server) handleSetPresence(w http.ResponseWriter, r *http.Request) {
 	var in struct {
-		Login string `json:"login"`
-		Card  string `json:"card"`
+		Card string `json:"card"`
 	}
 	if !decodeJSON(w, r, &in) {
 		return
@@ -935,7 +934,11 @@ func (s *Server) handleSetPresence(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusUnauthorized, "not authenticated: "+err.Error())
 		return
 	}
-	s.store.SetPresence(storeKey(owner, project), clientIDFrom(r.Context()), in.Login, in.Card)
+	// The broadcast login is the caller's authenticated identity (stamped by
+	// actorMiddleware), not a client-supplied value — otherwise any signed-in
+	// user could show a chosen card as selected by someone else.
+	login := board.ActorFrom(r.Context())
+	s.store.SetPresence(storeKey(owner, project), clientIDFrom(r.Context()), login, in.Card)
 	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -574,3 +574,35 @@ func TestAPICardLogUnifiedFeed(t *testing.T) {
 		t.Fatalf("second item = %+v", list.Items[1])
 	}
 }
+
+// Presence is attributed to the caller's authenticated identity, not a
+// client-supplied login: a signed-in user cannot make a card show as selected
+// by someone else.
+func TestPresenceUsesAuthenticatedLogin(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	srv := apiServer(t, Options{}, fake)
+	srv.apiTokens = func(*http.Request) (string, string, error) {
+		return "tok", "realuser", nil
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/presence?owner=acme&project=1",
+		strings.NewReader(`{"login":"victim","card":"c1"}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Aeman-Client", "tab-1")
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, r)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	e := srv.store.entry(storeKey("acme", 1))
+	e.mu.Lock()
+	got := e.presence["tab-1"]
+	e.mu.Unlock()
+	if got.Login != "realuser" {
+		t.Fatalf("presence login = %q, want the authenticated realuser (body spoof ignored)", got.Login)
+	}
+	if got.Card != "c1" {
+		t.Fatalf("presence card = %q, want c1", got.Card)
+	}
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -20,7 +20,13 @@ const (
 	githubTokenURL     = "https://github.com/login/oauth/access_token" //nolint:gosec // OAuth endpoint, not a credential
 	sessionCookie      = "aeman_session"
 	stateCookie        = "aeman_oauth_state"
+	consentCookie      = "aeman_mcp_consent"
 	sessionTTL         = 14 * 24 * time.Hour
+	consentTTL         = 10 * time.Minute
+	// maxClients caps the dynamic MCP client registry: registration is public
+	// and unauthenticated, so the cap plus per-IP-agnostic pruning stops an
+	// attacker growing it (and the persisted file) without bound.
+	maxClients = 512
 )
 
 // OAuthConfig enables multi-user mode: each visitor signs in with GitHub and
@@ -95,6 +101,10 @@ type authManager struct {
 	pendingAuth map[string]pendingAuth
 	// authCodes holds issued single-use MCP authorization codes (5-min TTL).
 	authCodes map[string]authCode
+	// pendingConsent holds MCP authorizations that have passed GitHub login and
+	// now await the user's explicit approval of the client + redirect target,
+	// keyed by an unguessable id also bound to the browser via a cookie.
+	pendingConsent map[string]pendingConsent
 }
 
 // oauthClient is a dynamically-registered MCP OAuth client.
@@ -119,23 +129,39 @@ type authCode struct {
 	expiry        time.Time
 }
 
+// pendingConsent is an MCP authorization awaiting the user's approval: GitHub
+// login already resolved the acting user's token, but no authorization code is
+// issued until the user confirms the client and (remote) redirect target, so a
+// phished authorize link cannot silently deliver a code to an attacker's URI.
+type pendingConsent struct {
+	ghToken       string
+	login         string
+	clientID      string
+	redirectURI   string
+	codeChallenge string
+	clientState   string
+	browserToken  string
+	expiry        time.Time
+}
+
 func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 	if cfg.Scopes == "" {
 		cfg.Scopes = "repo project"
 	}
 	a := &authManager{
-		cfg:          cfg,
-		secure:       strings.HasPrefix(strings.ToLower(cfg.BaseURL), "https://"),
-		log:          log,
-		client:       &http.Client{Timeout: 15 * time.Second},
-		path:         cfg.SessionFile,
-		authorizeURL: githubAuthorizeURL,
-		tokenURL:     githubTokenURL,
-		apiBase:      githubAPIBase,
-		sessions:     map[string]oauthSession{},
-		clients:      map[string]oauthClient{},
-		pendingAuth:  map[string]pendingAuth{},
-		authCodes:    map[string]authCode{},
+		cfg:            cfg,
+		secure:         strings.HasPrefix(strings.ToLower(cfg.BaseURL), "https://"),
+		log:            log,
+		client:         &http.Client{Timeout: 15 * time.Second},
+		path:           cfg.SessionFile,
+		authorizeURL:   githubAuthorizeURL,
+		tokenURL:       githubTokenURL,
+		apiBase:        githubAPIBase,
+		sessions:       map[string]oauthSession{},
+		clients:        map[string]oauthClient{},
+		pendingAuth:    map[string]pendingAuth{},
+		authCodes:      map[string]authCode{},
+		pendingConsent: map[string]pendingConsent{},
 	}
 	a.load()
 	return a

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -105,6 +106,8 @@ type authManager struct {
 	// now await the user's explicit approval of the client + redirect target,
 	// keyed by an unguessable id also bound to the browser via a cookie.
 	pendingConsent map[string]pendingConsent
+	// registerLimiter rate-limits the public client-registration endpoint.
+	registerLimiter *rateLimiter
 }
 
 // oauthClient is a dynamically-registered MCP OAuth client.
@@ -118,7 +121,12 @@ type pendingAuth struct {
 	redirectURI   string
 	codeChallenge string
 	clientState   string
+	created       time.Time
 }
+
+// pendingAuthTTL bounds how long an abandoned authorize flow lingers before it
+// is swept, so unfinished flows cannot accumulate in memory.
+const pendingAuthTTL = 10 * time.Minute
 
 // authCode is an issued MCP authorization code (single-use, short-lived).
 type authCode struct {
@@ -144,6 +152,43 @@ type pendingConsent struct {
 	expiry        time.Time
 }
 
+// rateLimiter is a fixed-window per-key counter. It fronts the unauthenticated
+// registration endpoint so a flood cannot spin the O(n) state-file rewrite; the
+// window map is reset each period, so it never grows across windows.
+type rateLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	period time.Duration
+	window time.Time
+	hits   map[string]int
+}
+
+func newRateLimiter(limit int, period time.Duration) *rateLimiter {
+	return &rateLimiter{limit: limit, period: period, hits: map[string]int{}}
+}
+
+func (rl *rateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	if now.Sub(rl.window) >= rl.period {
+		rl.hits = map[string]int{}
+		rl.window = now
+	}
+	rl.hits[key]++
+	return rl.hits[key] <= rl.limit
+}
+
+// clientIP is the best-effort remote address used to key rate limiting: the
+// host part of RemoteAddr (behind a proxy every request shares the proxy's
+// address, which simply makes the registration limit effectively global).
+func clientIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
 func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 	if cfg.Scopes == "" {
 		cfg.Scopes = "repo project"
@@ -162,6 +207,9 @@ func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 		pendingAuth:    map[string]pendingAuth{},
 		authCodes:      map[string]authCode{},
 		pendingConsent: map[string]pendingConsent{},
+		// 30 registrations per minute per client address: legitimate MCP clients
+		// register once, so this only ever bites a flood.
+		registerLimiter: newRateLimiter(30, time.Minute),
 	}
 	a.load()
 	return a

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -40,8 +40,10 @@ type OAuthConfig struct {
 	BaseURL string
 	// Scopes is a space-separated OAuth scope list (defaults to "repo project").
 	Scopes string
-	// SessionFile, when set, persists sessions to this path so they survive
-	// restarts (empty = in-memory only, lost on restart).
+	// SessionFile, when set, persists the dynamic MCP client registry to this
+	// path so registered clients survive restarts. GitHub tokens (sessions) are
+	// never written here — they live only in memory — so a restart signs users
+	// out but leaks no credentials to disk.
 	SessionFile string
 }
 
@@ -51,12 +53,15 @@ type oauthSession struct {
 	created time.Time
 }
 
-// persistedState is the on-disk envelope: user sessions plus the dynamically
-// registered MCP OAuth clients (RFC 7591), which must survive restarts — MCP
-// clients cache their client_id and a wiped registry strands them on
-// "unknown client_id" until they re-register.
+// persistedState is the on-disk envelope. Only the dynamically registered MCP
+// OAuth clients (RFC 7591) are persisted — they must survive restarts, since a
+// client caches its client_id and a wiped registry strands it on "unknown
+// client_id" until it re-registers, and they carry no secrets (just redirect
+// URIs). The Sessions field is retained solely to detect and scrub legacy
+// files that older versions wrote plaintext GitHub tokens into; it is never
+// written back.
 type persistedState struct {
-	Sessions map[string]persistedSession `json:"sessions"`
+	Sessions map[string]persistedSession `json:"sessions,omitempty"`
 	Clients  map[string]persistedClient  `json:"clients,omitempty"`
 }
 
@@ -215,7 +220,9 @@ func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 	return a
 }
 
-// load restores persisted sessions (dropping expired ones). No-op without a
+// load restores the persisted MCP client registry. Sessions are never restored
+// (GitHub tokens do not persist); if a legacy file carried them, it is rewritten
+// clients-only so the plaintext tokens are scrubbed from disk. No-op without a
 // SessionFile or when the file is absent.
 func (a *authManager) load() {
 	if a.path == "" {
@@ -224,60 +231,46 @@ func (a *authManager) load() {
 	data, err := os.ReadFile(a.path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			a.log.Error("session load failed", "err", err)
+			a.log.Error("client registry load failed", "err", err)
 		}
 		return
 	}
 	var in persistedState
-	if err := json.Unmarshal(data, &in); err != nil || in.Sessions == nil {
-		// Legacy format: a bare map of sessions with no envelope.
-		var legacy map[string]persistedSession
-		if err := json.Unmarshal(data, &legacy); err != nil {
-			a.log.Error("session load: parse failed", "err", err)
-			return
-		}
-		in = persistedState{Sessions: legacy}
-	}
-	now := time.Now()
-	for sid, s := range in.Sessions {
-		if now.Sub(s.Created) > sessionTTL {
-			continue
-		}
-		a.sessions[sid] = oauthSession{token: s.Token, login: s.Login, created: s.Created}
+	if err := json.Unmarshal(data, &in); err != nil {
+		a.log.Error("client registry load: parse failed", "err", err)
+		return
 	}
 	for id, c := range in.Clients {
 		a.clients[id] = oauthClient{redirectURIs: append([]string(nil), c.RedirectURIs...)}
 	}
-	a.log.Info("sessions restored", "count", len(a.sessions), "clients", len(a.clients))
+	a.log.Info("client registry restored", "clients", len(a.clients))
+	// Rewrite clients-only: scrubs any plaintext session tokens an older
+	// version may have left in the file.
+	a.saveLocked()
 }
 
-// saveLocked writes the current sessions to disk. Callers must hold a.mu.
+// saveLocked writes the MCP client registry to disk (no sessions, so no GitHub
+// tokens ever reach the file). Callers must hold a.mu.
 func (a *authManager) saveLocked() {
 	if a.path == "" {
 		return
 	}
-	out := persistedState{
-		Sessions: make(map[string]persistedSession, len(a.sessions)),
-		Clients:  make(map[string]persistedClient, len(a.clients)),
-	}
-	for sid, s := range a.sessions {
-		out.Sessions[sid] = persistedSession{Token: s.token, Login: s.login, Created: s.created}
-	}
+	out := persistedState{Clients: make(map[string]persistedClient, len(a.clients))}
 	for id, c := range a.clients {
 		out.Clients[id] = persistedClient{RedirectURIs: append([]string(nil), c.redirectURIs...)}
 	}
 	data, err := json.Marshal(out)
 	if err != nil {
-		a.log.Error("session save: marshal failed", "err", err)
+		a.log.Error("client registry save: marshal failed", "err", err)
 		return
 	}
 	tmp := a.path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		a.log.Error("session save: write failed", "err", err)
+		a.log.Error("client registry save: write failed", "err", err)
 		return
 	}
 	if err := os.Rename(tmp, a.path); err != nil {
-		a.log.Error("session save: rename failed", "err", err)
+		a.log.Error("client registry save: rename failed", "err", err)
 	}
 }
 

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -65,6 +65,11 @@ func clientIDFrom(ctx context.Context) string {
 // it from the backend, so edits made outside aeman eventually surface.
 const boardFreshFor = 30 * time.Second
 
+// authFreshFor bounds how long a login's proven read access is trusted before
+// a cache hit forces a fresh token-scoped load to re-authorize it — so access
+// revoked on GitHub takes effect within this window.
+const authFreshFor = 60 * time.Second
+
 // boardEntry is the cached board plus its watcher set for one owner/project.
 type boardEntry struct {
 	mu sync.Mutex
@@ -82,6 +87,12 @@ type boardEntry struct {
 	// view — ephemeral shared-cursor state, never persisted, cleared when the
 	// client's watch connection goes away.
 	presence map[string]presenceEntry
+	// authed records, per login, when that user's own GitHub token last proved
+	// it can read this board (a token-scoped backend load succeeded). The
+	// shared cache is keyed only by owner/project, so without this a warm board
+	// would be served to any signed-in user regardless of access; a cache hit
+	// is allowed only for a login that authorized within authFreshFor.
+	authed map[string]time.Time
 	// recentCards / recentGone guard the cache against GitHub's eventually
 	// consistent item list: a card created (or deleted) through aeman seconds
 	// ago may still be missing from (or present in) a fresh full load, and a
@@ -151,14 +162,44 @@ func (e *boardEntry) applyRecent(fresh board.Board) board.Board {
 	return fresh
 }
 
-// fresh returns the cached board while it is loaded and within its TTL.
-func (e *boardEntry) fresh() (board.Board, bool) {
+// freshFor returns the cached board while it is loaded, within its TTL, and the
+// caller is allowed to see it. A named login (OAuth multi-user mode) must have
+// proven token-scoped access within authFreshFor; an empty login is the single
+// local user (no OAuth), always allowed. multiUser forces the login check even
+// if a login somehow arrives empty, so an OAuth deployment never serves the
+// cache without a recent per-user authorization.
+func (e *boardEntry) freshFor(login string, multiUser bool) (board.Board, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.loaded && time.Since(e.loadedAt) < boardFreshFor {
-		return e.board, true
+	if !e.loaded || time.Since(e.loadedAt) >= boardFreshFor {
+		return board.Board{}, false
 	}
-	return board.Board{}, false
+	if multiUser || login != "" {
+		ts, ok := e.authed[login]
+		if login == "" || !ok || time.Since(ts) >= authFreshFor {
+			return board.Board{}, false
+		}
+	}
+	return e.board, true
+}
+
+// markAuthed records that a login's own token just proved read access, and
+// sweeps expired entries so the map tracks only currently-active users. The
+// caller holds e.mu.
+func (e *boardEntry) markAuthed(login string) {
+	if login == "" {
+		return
+	}
+	if e.authed == nil {
+		e.authed = map[string]time.Time{}
+	}
+	now := time.Now()
+	for l, ts := range e.authed {
+		if now.Sub(ts) >= authFreshFor {
+			delete(e.authed, l)
+		}
+	}
+	e.authed[login] = now
 }
 
 // cardChanged fans one card change out to the subscriptions. The caller holds
@@ -457,6 +498,10 @@ func (s *boardStore) reevaluateAll(key string) {
 type storeBackend struct {
 	inner boardservice.Backend
 	store *boardStore
+	// multiUser is set in OAuth mode, where each request carries a distinct
+	// user's token: a cache hit is then gated on that login having proven
+	// token-scoped access. Off in local-proxy mode (a single gh identity).
+	multiUser bool
 }
 
 var _ boardservice.Backend = (*storeBackend)(nil)
@@ -466,15 +511,19 @@ var _ boardservice.Backend = (*storeBackend)(nil)
 // External edits surface on the next reload.
 func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
 	e := b.store.entry(storeKey(owner, project))
-	if bd, ok := e.fresh(); ok {
+	login := board.ActorFrom(ctx)
+	if bd, ok := e.freshFor(login, b.multiUser); ok {
 		return bd, nil
 	}
 	e.loadMu.Lock()
 	defer e.loadMu.Unlock()
 	// A concurrent loader may have refreshed the cache while we waited.
-	if bd, ok := e.fresh(); ok {
+	if bd, ok := e.freshFor(login, b.multiUser); ok {
 		return bd, nil
 	}
+	// The token-scoped backend load is the authorization check: GitHub rejects a
+	// token that can't read this board, so reaching a cached result requires
+	// having passed it (recorded per login below).
 	bd, err := b.inner.LoadBoard(ctx, owner, project)
 	if err != nil {
 		return board.Board{}, err
@@ -484,6 +533,7 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 	e.board = bd
 	e.loaded = true
 	e.loadedAt = time.Now()
+	e.markAuthed(login)
 	e.mu.Unlock()
 	return bd, nil
 }

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/aenix-org/aeman/pkg/apiserver"
 	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-org/aeman/pkg/boardservice"
 )
 
 // frame decodes one marshalled watch frame from a subscription channel.
@@ -292,5 +296,85 @@ func TestReloadKeepsRecentMutations(t *testing.T) {
 	}
 	if ids["c1"] {
 		t.Fatalf("recently deleted card resurrected on reload: %v", ids)
+	}
+}
+
+// authzBackend is a per-user inner backend: LoadBoard succeeds or fails
+// depending on whether that user's token can read the board, and counts calls
+// so the test can prove when the shared cache was (not) consulted.
+type authzBackend struct {
+	boardservice.Backend // nil: only LoadBoard is exercised
+	loads                int
+	deny                 bool
+}
+
+func (a *authzBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	a.loads++
+	if a.deny {
+		return board.Board{}, errors.New("github: not authorized")
+	}
+	return board.Board{Owner: "acme", Number: 1}, nil
+}
+
+// A warm board cached by one authorized user must not be served to a different
+// signed-in user until that user's own token has proven access — the shared
+// cache is keyed only by owner/project, so per-login authorization is the gate.
+func TestBoardCachePerUserAuthz(t *testing.T) {
+	store := newBoardStore()
+
+	alice := &authzBackend{}
+	aliceBE := &storeBackend{inner: alice, store: store, multiUser: true}
+	mallory := &authzBackend{deny: true}
+	malloryBE := &storeBackend{inner: mallory, store: store, multiUser: true}
+
+	aliceCtx := board.WithActor(context.Background(), "alice")
+	malloryCtx := board.WithActor(context.Background(), "mallory")
+
+	// Alice's first read authorizes her token and warms the cache.
+	if _, err := aliceBE.LoadBoard(aliceCtx, "acme", 1); err != nil {
+		t.Fatalf("alice load: %v", err)
+	}
+	if alice.loads != 1 {
+		t.Fatalf("alice loads = %d, want 1", alice.loads)
+	}
+	// Alice again within the TTL: served from cache, no second backend hit.
+	if _, err := aliceBE.LoadBoard(aliceCtx, "acme", 1); err != nil {
+		t.Fatalf("alice second load: %v", err)
+	}
+	if alice.loads != 1 {
+		t.Fatalf("alice cache hit expected, loads = %d", alice.loads)
+	}
+	// Mallory hits the same warm cache but has never authorized: the store must
+	// fall through to HER token-scoped load, which GitHub rejects. Without the
+	// gate she would read alice's cached board.
+	if _, err := malloryBE.LoadBoard(malloryCtx, "acme", 1); err == nil {
+		t.Fatal("mallory read a board she cannot access (cache leak)")
+	}
+	if mallory.loads != 1 {
+		t.Fatalf("mallory's token was never checked, loads = %d", mallory.loads)
+	}
+}
+
+// freshFor gates a cache hit on load freshness AND, in multi-user mode, the
+// caller having authorized within authFreshFor; local single-user mode (empty
+// login, multiUser=false) always serves a fresh cache.
+func TestFreshForAuthz(t *testing.T) {
+	e := &boardEntry{loaded: true, loadedAt: time.Now()}
+	if _, ok := e.freshFor("", false); !ok {
+		t.Fatal("local single-user mode should serve the fresh cache")
+	}
+	if _, ok := e.freshFor("alice", true); ok {
+		t.Fatal("multi-user: unauthorized login must miss the cache")
+	}
+	e.markAuthed("alice")
+	if _, ok := e.freshFor("alice", true); !ok {
+		t.Fatal("multi-user: authorized login must hit the fresh cache")
+	}
+	if _, ok := e.freshFor("", true); ok {
+		t.Fatal("multi-user: an empty login must never hit the cache")
+	}
+	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
+	if _, ok := e.freshFor("alice", true); ok {
+		t.Fatal("a stale board must miss regardless of authorization")
 	}
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -51,7 +51,9 @@ func (s *Server) mcpServerForRequest(*http.Request) *mcp.Server {
 		// Route MCP writes through the shared board store, so agent edits update
 		// the cache and reach the UI's watch stream like every other write.
 		WrapBackend: func(b boardservice.Backend) boardservice.Backend {
-			return &storeBackend{inner: b, store: s.store}
+			// /mcp is mounted only in OAuth mode, so every request is a distinct
+			// token-bearing user: gate cache hits on per-login authorization.
+			return &storeBackend{inner: b, store: s.store, multiUser: true}
 		},
 	})
 	srv.AddReceivingMiddleware(injectGitHubToken)

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"slices"
@@ -40,6 +41,7 @@ func (s *Server) registerOAuthServer(mux *http.ServeMux) {
 	mux.HandleFunc("/.well-known/oauth-authorization-server", a.handleAuthServerMetadata)
 	mux.HandleFunc("/oauth/register", a.handleRegister)
 	mux.HandleFunc("/oauth/authorize", a.handleAuthorize)
+	mux.HandleFunc("/oauth/consent", a.handleConsent)
 	mux.HandleFunc("/oauth/token", a.handleToken)
 }
 
@@ -98,8 +100,25 @@ func (a *authManager) handleRegister(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "redirect_uris is required")
 		return
 	}
+	// Only https (remote clients) or loopback http (local MCP clients, RFC 8252)
+	// may be registered: this blocks javascript:/data: and cleartext redirects
+	// to arbitrary hosts that would leak an authorization code.
+	for _, uri := range meta.RedirectURIs {
+		if !isAllowedRedirect(uri) {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri",
+				"redirect_uris must be https or loopback http")
+			return
+		}
+	}
 	clientID := randToken()
 	a.mu.Lock()
+	a.pruneClientsLocked()
+	if len(a.clients) >= maxClients {
+		a.mu.Unlock()
+		writeOAuthError(w, http.StatusServiceUnavailable, "temporarily_unavailable",
+			"client registry is full; try again later")
+		return
+	}
 	a.clients[clientID] = oauthClient{redirectURIs: append([]string(nil), meta.RedirectURIs...)}
 	a.saveLocked()
 	a.mu.Unlock()
@@ -189,8 +208,11 @@ func (a *authManager) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleMCPCallback resumes an MCP authorization after GitHub redirects back: it
-// exchanges the GitHub code for a token, opens a session, mints a single-use MCP
-// code and bounces the browser back to the client's redirect_uri.
+// exchanges the GitHub code for the acting user's token and reads their login.
+// A loopback redirect (the code can only reach the initiator's own machine, so
+// there is nothing to phish) completes immediately; any other redirect target
+// is first put to the user on an explicit consent screen, so a phished
+// authorize link cannot silently hand an authorization code to a remote host.
 func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, p pendingAuth) {
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -210,6 +232,17 @@ func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	if isLoopbackRedirect(p.redirectURI) {
+		a.completeMCPAuth(w, r, ghToken, login, p)
+		return
+	}
+	a.promptConsent(w, ghToken, login, p)
+}
+
+// completeMCPAuth opens the session, mints a single-use MCP authorization code
+// and bounces the browser back to the client's redirect_uri. It runs only for a
+// loopback redirect or after the user approves the consent screen.
+func (a *authManager) completeMCPAuth(w http.ResponseWriter, r *http.Request, ghToken, login string, p pendingAuth) {
 	now := time.Now()
 	sid := randToken()
 	mcpCode := randToken()
@@ -238,6 +271,76 @@ func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, 
 	}
 	dest.RawQuery = rq.Encode()
 	http.Redirect(w, r, dest.String(), http.StatusFound)
+}
+
+// promptConsent stashes the resolved authorization and renders the approval
+// screen, binding it to this browser via a cookie so only the user who just
+// authenticated can approve (and a cross-site POST, which drops the Lax cookie,
+// cannot).
+func (a *authManager) promptConsent(w http.ResponseWriter, ghToken, login string, p pendingAuth) {
+	consentID := randToken()
+	browserToken := randToken()
+	a.mu.Lock()
+	a.pruneConsentLocked()
+	a.pendingConsent[consentID] = pendingConsent{
+		ghToken:       ghToken,
+		login:         login,
+		clientID:      p.clientID,
+		redirectURI:   p.redirectURI,
+		codeChallenge: p.codeChallenge,
+		clientState:   p.clientState,
+		browserToken:  browserToken,
+		expiry:        time.Now().Add(consentTTL),
+	}
+	a.mu.Unlock()
+	a.setCookie(w, consentCookie, browserToken, int(consentTTL/time.Second))
+	renderConsentPage(w, consentID, login, p.clientID, p.redirectURI)
+}
+
+// handleConsent finalizes an MCP authorization the user approved (or aborts the
+// one they denied). It requires the consent id from the form to match the
+// browser cookie set by promptConsent, so a forged or cross-site submission —
+// which cannot carry the Lax cookie — is rejected.
+func (a *authManager) handleConsent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	_ = r.ParseForm()
+	consentID := r.PostFormValue("consent_id")
+	approve := r.PostFormValue("action") == "approve"
+
+	cookie, err := r.Cookie(consentCookie)
+	a.setCookie(w, consentCookie, "", -1)
+
+	a.mu.Lock()
+	pc, ok := a.pendingConsent[consentID]
+	if ok {
+		delete(a.pendingConsent, consentID)
+	}
+	a.mu.Unlock()
+
+	if !ok || time.Now().After(pc.expiry) {
+		writeJSONError(w, http.StatusBadRequest, "consent request expired or unknown")
+		return
+	}
+	if err != nil || subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(pc.browserToken)) != 1 {
+		writeJSONError(w, http.StatusBadRequest, "consent does not match this browser")
+		return
+	}
+
+	p := pendingAuth{
+		clientID:      pc.clientID,
+		redirectURI:   pc.redirectURI,
+		codeChallenge: pc.codeChallenge,
+		clientState:   pc.clientState,
+	}
+	if !approve {
+		a.log.Info("mcp authorization denied by user", "login", pc.login, "client_id", pc.clientID)
+		a.redirectError(w, r, pc.redirectURI, pc.clientState, "access_denied", "user denied the request")
+		return
+	}
+	a.completeMCPAuth(w, r, pc.ghToken, pc.login, p)
 }
 
 // handleToken redeems an MCP authorization code for an access token. The token
@@ -407,4 +510,76 @@ func isLoopbackRedirect(raw string) bool {
 	}
 	host := u.Hostname()
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// isAllowedRedirect reports whether a redirect URI may be registered: https to
+// any host (remote clients) or loopback http (local MCP clients). This rejects
+// javascript:/data: and cleartext http to arbitrary hosts, either of which
+// would leak an authorization code.
+func isAllowedRedirect(raw string) bool {
+	if isLoopbackRedirect(raw) {
+		return true
+	}
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme == "https" && u.Host != ""
+}
+
+// pruneConsentLocked drops expired pending-consent entries. Caller holds a.mu.
+func (a *authManager) pruneConsentLocked() {
+	now := time.Now()
+	for id, pc := range a.pendingConsent {
+		if now.After(pc.expiry) {
+			delete(a.pendingConsent, id)
+		}
+	}
+}
+
+// pruneClientsLocked makes room in the dynamic client registry when it is at
+// capacity by evicting one entry; an evicted client simply re-registers on its
+// next use. Caller holds a.mu.
+func (a *authManager) pruneClientsLocked() {
+	for len(a.clients) >= maxClients {
+		for id := range a.clients {
+			delete(a.clients, id)
+			break
+		}
+	}
+}
+
+// renderConsentPage writes the MCP authorization approval screen. Every
+// interpolated value is HTML-escaped: redirect_uri and client_id come from the
+// (attacker-controllable) authorize request, and login from GitHub.
+func renderConsentPage(w http.ResponseWriter, consentID, login, clientID, redirectURI string) {
+	page := `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authorize MCP access — aeman</title>
+<style>
+  body{font:15px/1.5 system-ui,sans-serif;max-width:34rem;margin:3rem auto;padding:0 1.25rem;color:#1a1a1a}
+  h1{font-size:1.3rem}
+  .card{border:1px solid #e2e2e2;border-radius:10px;padding:1.25rem 1.5rem;margin:1.5rem 0}
+  dl{display:grid;grid-template-columns:auto 1fr;gap:.4rem 1rem;margin:0}
+  dt{color:#666}
+  dd{margin:0;word-break:break-all;font-family:ui-monospace,monospace;font-size:.9rem}
+  .warn{background:#fff8e1;border:1px solid #ffe082;border-radius:8px;padding:.75rem 1rem;font-size:.9rem}
+  .row{display:flex;gap:.75rem;margin-top:1.5rem}
+  button{font:inherit;padding:.6rem 1.2rem;border-radius:8px;border:1px solid #ccc;cursor:pointer}
+  .approve{background:#1f6feb;color:#fff;border-color:#1f6feb}
+</style></head><body>
+<h1>Authorize MCP access</h1>
+<p>An application wants to connect to aeman as <strong>@` + html.EscapeString(login) + `</strong> using your GitHub access.</p>
+<div class="card"><dl>
+  <dt>Client</dt><dd>` + html.EscapeString(clientID) + `</dd>
+  <dt>Redirects to</dt><dd>` + html.EscapeString(redirectURI) + `</dd>
+</dl></div>
+<p class="warn">Only approve if you started this from a tool you trust and recognize the address above. Approving lets it act on your GitHub projects.</p>
+<form method="POST" action="/oauth/consent" class="row">
+  <input type="hidden" name="consent_id" value="` + html.EscapeString(consentID) + `">
+  <button class="approve" type="submit" name="action" value="approve">Approve</button>
+  <button type="submit" name="action" value="deny">Deny</button>
+</form>
+</body></html>`
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(page))
 }

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -91,6 +91,11 @@ func (a *authManager) handleRegister(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, http.StatusMethodNotAllowed, "invalid_request", "method not allowed")
 		return
 	}
+	if !a.registerLimiter.allow(clientIP(r)) {
+		writeOAuthError(w, http.StatusTooManyRequests, "temporarily_unavailable",
+			"registration rate limit exceeded; try again shortly")
+		return
+	}
 	var meta oauthex.ClientRegistrationMetadata
 	if err := json.NewDecoder(r.Body).Decode(&meta); err != nil {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "invalid JSON body")
@@ -191,11 +196,13 @@ func (a *authManager) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	state := randToken()
 	a.mu.Lock()
+	a.pruneEphemeralLocked()
 	a.pendingAuth[state] = pendingAuth{
 		clientID:      clientID,
 		redirectURI:   redirectURI,
 		codeChallenge: challenge,
 		clientState:   clientState,
+		created:       time.Now(),
 	}
 	a.mu.Unlock()
 
@@ -281,7 +288,7 @@ func (a *authManager) promptConsent(w http.ResponseWriter, ghToken, login string
 	consentID := randToken()
 	browserToken := randToken()
 	a.mu.Lock()
-	a.pruneConsentLocked()
+	a.pruneEphemeralLocked()
 	a.pendingConsent[consentID] = pendingConsent{
 		ghToken:       ghToken,
 		login:         login,
@@ -524,9 +531,21 @@ func isAllowedRedirect(raw string) bool {
 	return err == nil && u.Scheme == "https" && u.Host != ""
 }
 
-// pruneConsentLocked drops expired pending-consent entries. Caller holds a.mu.
-func (a *authManager) pruneConsentLocked() {
+// pruneEphemeralLocked sweeps every short-lived authorization map — abandoned
+// authorize flows, expired codes, and un-answered consents — so none of them
+// can accumulate in memory. Caller holds a.mu.
+func (a *authManager) pruneEphemeralLocked() {
 	now := time.Now()
+	for state, p := range a.pendingAuth {
+		if now.Sub(p.created) > pendingAuthTTL {
+			delete(a.pendingAuth, state)
+		}
+	}
+	for code, c := range a.authCodes {
+		if now.After(c.expiry) {
+			delete(a.authCodes, code)
+		}
+	}
 	for id, pc := range a.pendingConsent {
 		if now.After(pc.expiry) {
 			delete(a.pendingConsent, id)

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -476,11 +476,15 @@ func TestOAuthClientRegistrationPersists(t *testing.T) {
 	}
 }
 
-// The pre-envelope session file (a bare map of sessions) still loads.
-func TestSessionFileLegacyFormat(t *testing.T) {
+// GitHub tokens are not persisted: a file written by an older version that
+// stored sessions must NOT restore them, and the plaintext tokens must be
+// scrubbed from disk on load — while a registered client in the same file is
+// still restored.
+func TestSessionTokensNotPersisted(t *testing.T) {
 	path := t.TempDir() + "/sessions.json"
-	legacy := `{"sid1":{"token":"gh-tok","login":"octocat","created":"` +
-		time.Now().Format(time.RFC3339Nano) + `"}}`
+	legacy := `{"sessions":{"sid1":{"token":"gh-tok","login":"octocat","created":"` +
+		time.Now().Format(time.RFC3339Nano) + `"}},"clients":{"cid1":{"redirectUris":["` +
+		testRedirectURI + `"]}}}`
 	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -496,8 +500,21 @@ func TestSessionFileLegacyFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, ok := srv.auth.sessions["sid1"]; !ok {
-		t.Fatal("legacy session not restored")
+	if _, ok := srv.auth.sessions["sid1"]; ok {
+		t.Fatal("a persisted GitHub token was restored; tokens must never survive a restart")
+	}
+	if _, ok := srv.auth.clients["cid1"]; !ok {
+		t.Fatal("the registered client was not restored")
+	}
+	on, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(on), "gh-tok") {
+		t.Fatalf("plaintext token was not scrubbed from disk: %s", on)
+	}
+	if !strings.Contains(string(on), "cid1") {
+		t.Fatalf("client registry was lost from disk: %s", on)
 	}
 }
 

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/oauthex"
 )
+
+const testRemoteRedirectURI = "https://client.example/cb"
+
+var consentIDRe = regexp.MustCompile(`name="consent_id" value="([^"]+)"`)
 
 const testBaseURL = "https://aeman.test"
 
@@ -534,5 +539,141 @@ func TestOAuthAuthorizeUnknownClientRemoteRedirect(t *testing.T) {
 	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// driveToConsent runs register(remote) → authorize → GitHub callback for a
+// non-loopback redirect and returns the consent page: the callback must render
+// the approval screen (not deliver a code), the consent id embedded in it, and
+// the browser-binding cookie the server set.
+func driveToConsent(t *testing.T, srv *Server, redirectURI string) (consentID, cookie, verifier, clientID string) {
+	t.Helper()
+	clientID = registerClient(t, srv, redirectURI)
+	verifier = "pkce-verifier-sufficiently-long-0123456789"
+	aq := url.Values{}
+	aq.Set("client_id", clientID)
+	aq.Set("redirect_uri", redirectURI)
+	aq.Set("response_type", "code")
+	aq.Set("code_challenge", pkceChallenge(verifier))
+	aq.Set("code_challenge_method", "S256")
+	aq.Set("state", "client-state")
+	rec := do(t, srv, http.MethodGet, "/oauth/authorize?"+aq.Encode(), "")
+	ghLoc, _ := url.Parse(rec.Header().Get("Location"))
+
+	cb := do(t, srv, http.MethodGet, "/auth/callback?code=gh-code&state="+ghLoc.Query().Get("state"), "")
+	if cb.Code != http.StatusOK {
+		t.Fatalf("remote-redirect callback status = %d, want 200 consent page (no code delivered)", cb.Code)
+	}
+	if loc := cb.Header().Get("Location"); loc != "" {
+		t.Fatalf("consent must not redirect yet; got Location=%s", loc)
+	}
+	if !strings.Contains(cb.Body.String(), redirectURI) {
+		t.Fatal("consent page must show the redirect target to the user")
+	}
+	m := consentIDRe.FindStringSubmatch(cb.Body.String())
+	if m == nil {
+		t.Fatalf("no consent_id in page: %s", cb.Body.String())
+	}
+	for _, c := range cb.Result().Cookies() {
+		if c.Name == consentCookie {
+			cookie = c.Value
+		}
+	}
+	if cookie == "" {
+		t.Fatal("consent flow set no browser-binding cookie")
+	}
+	return m[1], cookie, verifier, clientID
+}
+
+func postConsent(t *testing.T, srv *Server, consentID, action, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{}
+	form.Set("consent_id", consentID)
+	form.Set("action", action)
+	r := httptest.NewRequest(http.MethodPost, "/oauth/consent", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if cookie != "" {
+		r.AddCookie(&http.Cookie{Name: consentCookie, Value: cookie})
+	}
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, r)
+	return rec
+}
+
+// A remote (non-loopback) redirect must go through the consent screen, and
+// approving it (from the same browser) then delivers a redeemable code. This is
+// the account-takeover fix: no code reaches a remote URI without the user
+// having seen and approved that URI.
+func TestOAuthConsentApproveDeliversCode(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	consentID, cookie, verifier, clientID := driveToConsent(t, srv, testRemoteRedirectURI)
+
+	rec := postConsent(t, srv, consentID, "approve", cookie)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("approve status = %d, want 302", rec.Code)
+	}
+	loc, _ := url.Parse(rec.Header().Get("Location"))
+	if loc.Scheme+"://"+loc.Host+loc.Path != testRemoteRedirectURI {
+		t.Fatalf("approve redirected to %s, want the client redirect_uri", loc)
+	}
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatal("approve delivered no authorization code")
+	}
+	// The delivered code redeems for an access token, completing the flow.
+	tok := redeemToken(t, srv, code, verifier, testRemoteRedirectURI, clientID)
+	if tok.Code != http.StatusOK {
+		t.Fatalf("redeem status = %d, body = %s", tok.Code, tok.Body.String())
+	}
+	if !strings.Contains(tok.Body.String(), "access_token") {
+		t.Fatalf("no access_token in redeem response: %s", tok.Body.String())
+	}
+}
+
+// Approving from a different browser (no matching consent cookie) is rejected —
+// a forged or cross-site submission cannot complete the authorization.
+func TestOAuthConsentRejectsWrongBrowser(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	consentID, _, _, _ := driveToConsent(t, srv, testRemoteRedirectURI)
+
+	if rec := postConsent(t, srv, consentID, "approve", ""); rec.Code != http.StatusBadRequest {
+		t.Fatalf("approve without the browser cookie status = %d, want 400", rec.Code)
+	}
+	if rec := postConsent(t, srv, consentID, "approve", "wrong-cookie-value"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("approve with a mismatched cookie status = %d, want 400", rec.Code)
+	}
+}
+
+// Denying redirects back with an OAuth error and hands out no code.
+func TestOAuthConsentDeny(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	consentID, cookie, _, _ := driveToConsent(t, srv, testRemoteRedirectURI)
+
+	rec := postConsent(t, srv, consentID, "deny", cookie)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("deny status = %d, want 302", rec.Code)
+	}
+	loc, _ := url.Parse(rec.Header().Get("Location"))
+	if loc.Query().Get("error") != "access_denied" {
+		t.Fatalf("deny error = %q, want access_denied", loc.Query().Get("error"))
+	}
+	if loc.Query().Get("code") != "" {
+		t.Fatal("deny must not deliver a code")
+	}
+}
+
+// Registration rejects redirect URIs that could leak a code: non-https remote
+// schemes and cleartext http to a remote host.
+func TestOAuthRegisterRejectsUnsafeRedirects(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	for _, bad := range []string{
+		"javascript:alert(1)",
+		"http://evil.example/cb",
+		"data:text/html,x",
+	} {
+		rec := do(t, srv, http.MethodPost, "/oauth/register", `{"redirect_uris":["`+bad+`"]}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("register %q status = %d, want 400", bad, rec.Code)
+		}
 	}
 }

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -677,3 +677,46 @@ func TestOAuthRegisterRejectsUnsafeRedirects(t *testing.T) {
 		}
 	}
 }
+
+// Registration is rate-limited so an unauthenticated flood cannot grow the
+// registry / rewrite the state file without bound.
+func TestOAuthRegisterRateLimited(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	srv.auth.registerLimiter = newRateLimiter(3, time.Minute)
+	limited := false
+	for i := 0; i < 6; i++ {
+		rec := do(t, srv, http.MethodPost, "/oauth/register", `{"redirect_uris":["`+testRedirectURI+`"]}`)
+		if rec.Code == http.StatusTooManyRequests {
+			limited = true
+		}
+	}
+	if !limited {
+		t.Fatal("registration flood was never rate-limited")
+	}
+}
+
+// pruneEphemeralLocked clears abandoned authorize flows, expired codes, and
+// stale consents so none of them accumulate.
+func TestPruneEphemeral(t *testing.T) {
+	srv, _ := newOAuthServer(t)
+	a := srv.auth
+	a.mu.Lock()
+	a.pendingAuth["stale"] = pendingAuth{created: time.Now().Add(-2 * pendingAuthTTL)}
+	a.pendingAuth["fresh"] = pendingAuth{created: time.Now()}
+	a.authCodes["expired"] = authCode{expiry: time.Now().Add(-time.Minute)}
+	a.authCodes["live"] = authCode{expiry: time.Now().Add(time.Minute)}
+	a.pendingConsent["old"] = pendingConsent{expiry: time.Now().Add(-time.Minute)}
+	a.pruneEphemeralLocked()
+	_, staleGone := a.pendingAuth["stale"]
+	_, freshKept := a.pendingAuth["fresh"]
+	_, expiredGone := a.authCodes["expired"]
+	_, liveKept := a.authCodes["live"]
+	_, oldGone := a.pendingConsent["old"]
+	a.mu.Unlock()
+	if staleGone || expiredGone || oldGone {
+		t.Fatal("expired ephemeral entries were not swept")
+	}
+	if !freshKept || !liveKept {
+		t.Fatal("live ephemeral entries were wrongly swept")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,8 +117,54 @@ func New(opts Options) (*Server, error) {
 	}
 	s.registerAPI(mux)
 	mux.Handle("/", spaHandler(dist))
-	s.handler = logRequests(s.log, clientIDMiddleware(s.actorMiddleware(mux)))
+	s.handler = logRequests(s.log, clientIDMiddleware(s.csrfGuard(s.actorMiddleware(mux))))
 	return s, nil
+}
+
+// csrfGuard rejects cross-site state-changing requests to the token-bearing
+// /api/ surface. In local-proxy mode a request is authenticated purely by
+// reaching the server, so a browser on another site could otherwise drive
+// mutations with the injected gh token; browsers attach an Origin header to
+// every cross-site POST (even "simple" text/plain ones, which skip preflight),
+// so an Origin mismatch is the tell. A request with no Origin is a non-browser
+// client (curl, scripts), which carries no ambient credentials to abuse.
+func (s *Server) csrfGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isStateChanging(r.Method) && strings.HasPrefix(r.URL.Path, "/api/") {
+			if origin := r.Header.Get("Origin"); origin != "" && !s.originAllowed(origin, r) {
+				writeJSONError(w, http.StatusForbidden, "cross-site request blocked")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isStateChanging reports whether the method mutates server state.
+func isStateChanging(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// originAllowed reports whether a request's Origin may drive a mutation:
+// same-origin always, plus localhost (the Vite dev proxy) in local-proxy mode.
+func (s *Server) originAllowed(origin string, r *http.Request) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if u.Host == r.Host {
+		return true
+	}
+	if s.auth == nil {
+		h := u.Hostname()
+		return h == "localhost" || h == "127.0.0.1" || h == "::1"
+	}
+	return false
 }
 
 // URL returns the address the server can be reached on in a browser.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -68,3 +68,46 @@ func TestURLNormalisesHost(t *testing.T) {
 		}
 	}
 }
+
+// csrfGuard blocks a cross-site state-changing request to /api (a browser
+// attaches Origin to every cross-site POST), while allowing same-origin,
+// no-Origin (non-browser) callers, and safe methods.
+func TestCSRFGuard(t *testing.T) {
+	local := &Server{}                     // local-proxy mode (auth nil)
+	oauth := &Server{auth: &authManager{}} // OAuth mode
+
+	req := func(method, origin, host string) *http.Request {
+		r := httptest.NewRequest(method, "/api/v1/cards", nil)
+		r.Host = host
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+	run := func(s *Server, r *http.Request) int {
+		rec := httptest.NewRecorder()
+		s.csrfGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, r)
+		return rec.Code
+	}
+
+	if run(local, req(http.MethodPost, "http://evil.example", "127.0.0.1:8765")) != http.StatusForbidden {
+		t.Fatal("cross-site POST must be blocked")
+	}
+	if run(local, req(http.MethodPost, "http://127.0.0.1:8765", "127.0.0.1:8765")) != http.StatusOK {
+		t.Fatal("same-origin POST must pass")
+	}
+	if run(local, req(http.MethodPost, "http://localhost:5173", "127.0.0.1:8765")) != http.StatusOK {
+		t.Fatal("localhost dev origin must pass in local mode")
+	}
+	if run(oauth, req(http.MethodPost, "http://localhost:5173", "aeman.test")) != http.StatusForbidden {
+		t.Fatal("OAuth mode must be strict same-origin")
+	}
+	if run(local, req(http.MethodPost, "", "127.0.0.1:8765")) != http.StatusOK {
+		t.Fatal("no-Origin (non-browser) POST must pass")
+	}
+	if run(local, req(http.MethodGet, "http://evil.example", "127.0.0.1:8765")) != http.StatusOK {
+		t.Fatal("safe methods must not be guarded")
+	}
+}

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -64,10 +64,10 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		s.apiError(w, err)
 		return
 	}
-	// The stream carries nothing a same-origin page can't already read via the
-	// API and performs no mutations, so cross-origin (the Vite dev proxy) is
-	// allowed rather than rejected on an Origin mismatch.
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	// The Origin is checked so a cross-site page cannot open the stream and
+	// read the board — in local-proxy mode the request is authenticated purely
+	// by reaching the server, so without this any site could exfiltrate it.
+	conn, err := websocket.Accept(w, r, s.wsAcceptOptions())
 	if err != nil {
 		return
 	}
@@ -108,6 +108,20 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+}
+
+// wsAcceptOptions authorizes the watch handshake by Origin. Same-origin is
+// always allowed. In local-proxy mode (no OAuth: the request is trusted purely
+// for reaching the server) the Vite dev proxy's localhost origins are allowed
+// too; a remote page is rejected. In OAuth mode only same-origin is allowed —
+// tighter, and the SameSite session cookie already blocks cross-site anyway.
+func (s *Server) wsAcceptOptions() *websocket.AcceptOptions {
+	if s.auth != nil {
+		return &websocket.AcceptOptions{}
+	}
+	return &websocket.AcceptOptions{
+		OriginPatterns: []string{"localhost:*", "127.0.0.1:*", "[::1]:*"},
 	}
 }
 

--- a/internal/server/watch_test.go
+++ b/internal/server/watch_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// wsAcceptOptions is strict same-origin in OAuth mode and additionally allows
+// the Vite dev proxy's localhost origins in local-proxy mode.
+func TestWSAcceptOptionsPerMode(t *testing.T) {
+	oauth := &Server{auth: &authManager{}}
+	if got := oauth.wsAcceptOptions(); len(got.OriginPatterns) != 0 || got.InsecureSkipVerify {
+		t.Fatalf("oauth mode must be strict same-origin, got %+v", got)
+	}
+	local := &Server{}
+	got := local.wsAcceptOptions()
+	if got.InsecureSkipVerify {
+		t.Fatal("origin verification must never be skipped")
+	}
+	if len(got.OriginPatterns) == 0 {
+		t.Fatal("local mode must allow the localhost dev origins")
+	}
+}
+
+// The Origin check actually rejects a cross-site handshake while allowing the
+// localhost dev origin — a remote page cannot open the watch and read the board.
+func TestWatchOriginEnforced(t *testing.T) {
+	local := &Server{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, local.wsAcceptOptions())
+		if err != nil {
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer ts.Close()
+
+	dial := func(origin string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		c, resp, err := websocket.Dial(ctx, "ws"+ts.URL[len("http"):], &websocket.DialOptions{
+			HTTPHeader: http.Header{"Origin": {origin}},
+		})
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil {
+			_ = c.Close(websocket.StatusNormalClosure, "")
+		}
+		return err
+	}
+
+	if err := dial("http://evil.example"); err == nil {
+		t.Fatal("cross-site origin was accepted (board is exfiltratable)")
+	}
+	if err := dial("http://localhost:5173"); err != nil {
+		t.Fatalf("localhost dev origin was rejected: %v", err)
+	}
+}

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1971,14 +1971,15 @@ func TestLogEventRetriesTransientFailures(t *testing.T) {
 func TestDescriptionLengthLimit(t *testing.T) {
 	f := newFake([]board.Card{{ItemID: "c1", Team: "alpha"}}, nil)
 	svc := f2svc(f)
-	long := strings.Repeat("ы", MaxDescriptionLen+1)
+	// A multi-byte rune (3 bytes) verifies the cap counts runes, not bytes.
+	long := strings.Repeat("€", MaxDescriptionLen+1)
 	if err := svc.SetDescription(ctx, "acme", 1, "c1", long); !errors.Is(err, ErrDescriptionTooLong) {
 		t.Fatalf("err = %v, want ErrDescriptionTooLong", err)
 	}
 	if f.count("SetDescription") != 0 {
 		t.Fatal("nothing must be written on rejection")
 	}
-	if err := svc.SetDescription(ctx, "acme", 1, "c1", strings.Repeat("ы", MaxDescriptionLen)); err != nil {
+	if err := svc.SetDescription(ctx, "acme", 1, "c1", strings.Repeat("€", MaxDescriptionLen)); err != nil {
 		t.Fatalf("at the limit must pass: %v", err)
 	}
 }

--- a/pkg/ghprojects/fields.go
+++ b/pkg/ghprojects/fields.go
@@ -5,14 +5,14 @@ import "strings"
 // roleAliases maps a field role to the field names (case-insensitive) that fill
 // it. It mirrors web/src/providers/fields.ts, extended with a "team" role.
 var roleAliases = map[string][]string{
-	"zone":        {"zone", "priority zone", "зона"},
-	"progress":    {"progress", "readiness", "% done", "percent", "готовность"},
-	"day":         {"day", "date", "due date", "due", "день", "дата"},
-	"start":       {"start", "start date", "начало", "старт"},
-	"sprintStart": {"sprint start", "sprintstart", "спринт старт"},
-	"sprint":      {"sprint", "iteration", "спринт", "итерация"},
-	"status":      {"status", "stage", "статус"},
-	"team":        {"team", "group", "команда", "группа"},
+	"zone":        {"zone", "priority zone"},
+	"progress":    {"progress", "readiness", "% done", "percent"},
+	"day":         {"day", "date", "due date", "due"},
+	"start":       {"start", "start date"},
+	"sprintStart": {"sprint start", "sprintstart"},
+	"sprint":      {"sprint", "iteration"},
+	"status":      {"status", "stage"},
+	"team":        {"team", "group"},
 }
 
 // roles maps the board's fields onto well-known roles by name.

--- a/pkg/ghprojects/load.go
+++ b/pkg/ghprojects/load.go
@@ -319,17 +319,17 @@ type domainFieldRoles struct {
 // fill it. It mirrors ALIASES in web/src/providers/fields.ts (Stage is its own
 // role here, distinct from the default Status field).
 var domainRoleAliases = map[string][]string{
-	"zone":        {"zone", "priority zone", "зона"},
-	"progress":    {"progress", "readiness", "% done", "percent", "готовность"},
-	"day":         {"day", "date", "due date", "due", "finish", "finish date", "день", "дата"},
-	"start":       {"start", "start date", "начало", "старт"},
-	"sprintStart": {"sprint start", "sprintstart", "спринт старт"},
-	"sprint":      {"sprint", "iteration", "спринт", "итерация"},
-	"status":      {"status", "статус"},
-	"plan":        {"plan", "план"},
-	"week":        {"week", "неделя"},
-	"stage":       {"stage", "состояние"},
-	"team":        {"team", "команда"},
+	"zone":        {"zone", "priority zone"},
+	"progress":    {"progress", "readiness", "% done", "percent"},
+	"day":         {"day", "date", "due date", "due", "finish", "finish date"},
+	"start":       {"start", "start date"},
+	"sprintStart": {"sprint start", "sprintstart"},
+	"sprint":      {"sprint", "iteration"},
+	"status":      {"status"},
+	"plan":        {"plan"},
+	"week":        {"week"},
+	"stage":       {"stage"},
+	"team":        {"team"},
 	"reviewOf":    {"review of", "reviewof"},
 	"reviewRound": {"review round", "reviewround"},
 }

--- a/pkg/ghprojects/model.go
+++ b/pkg/ghprojects/model.go
@@ -170,7 +170,7 @@ func (b *Board) fieldByName(name string) *ProjectField {
 // default GitHub "Status" field.
 func (b *Board) stageField() *ProjectField {
 	for i := range b.Fields {
-		if equalFold(b.Fields[i].Name, "stage") || equalFold(b.Fields[i].Name, "состояние") {
+		if equalFold(b.Fields[i].Name, "stage") {
 			return &b.Fields[i]
 		}
 	}


### PR DESCRIPTION
Addresses the findings from the security review of the auth / OAuth / MCP surface. Two high-severity issues were exploitable against the live deployment; the rest are hardening (also part of preparing the repo to be open-sourced). Every fix has tests; the full suite and `golangci-lint` are green.

**High**
- **Per-user authorization on the board cache.** The shared board store served any signed-in user a warm cache entry without checking their own token could read it, leaking another user's cards/notes/logs (and the live watch). Cache hits are now gated per login against a recent token-scoped load.
- **Consent before MCP codes reach remote redirects.** Open client registration + no approval step allowed a one-click account takeover via a phished authorize link. Non-loopback redirects now go through a browser-bound consent screen; registration rejects non-https / non-loopback redirect URIs.

**Medium**
- **OAuth registration DoS** — rate-limit + registry cap + sweep of abandoned flows / expired codes.
- **WebSocket Origin check** — the watch no longer accepts any Origin (was cross-site exfiltratable in local-proxy mode).
- **CSRF guard** — cross-site state-changing requests to `/api/` are blocked (Origin-based).

**Low**
- **GitHub tokens off disk** — sessions live only in memory; the session file persists just the secret-free MCP client registry, and a legacy file's plaintext tokens are scrubbed on load.
- **Presence anti-spoof** — the shared-cursor login is the authenticated identity, not a client-supplied value.

Also drops Russian field-name aliases from the Go code (the frontend never had them; both prod boards use English field names) and reframes the README as a short-term planning system.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt