### PR TITLE
fix(cards): keep a URL card usable when the link can't be resolved

### DIFF
--- a/pkg/board/links.go
+++ b/pkg/board/links.go
@@ -1,6 +1,7 @@
 package board
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -25,6 +26,17 @@ type Link struct {
 
 // IsGitHubRef reports whether the link addresses a GitHub issue or PR.
 func (l Link) IsGitHubRef() bool { return l.Kind == "issue" || l.Kind == "pull" }
+
+// FallbackTitle is a readable card title for a GitHub ref whose real title
+// could not be fetched (e.g. a token without access to a private repo):
+// "Issue: owner/repo#123" or "Pull: owner/repo#123".
+func (l Link) FallbackTitle() string {
+	kind := "Issue"
+	if l.Kind == "pull" {
+		kind = "Pull"
+	}
+	return fmt.Sprintf("%s: %s/%s#%d", kind, l.Owner, l.Repo, l.Number)
+}
 
 var urlPattern = regexp.MustCompile(`https?://[^\s<>"'\)\]]+`)
 

--- a/pkg/board/links_test.go
+++ b/pkg/board/links_test.go
@@ -53,3 +53,19 @@ func TestParseGitHubRef(t *testing.T) {
 		}
 	}
 }
+
+func TestFallbackTitle(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/aenix-org/cozyportal/issues/1060": "Issue: aenix-org/cozyportal#1060",
+		"https://github.com/acme/repo/pull/34":                "Pull: acme/repo#34",
+	}
+	for url, want := range cases {
+		ref, ok := ParseGitHubRef(url)
+		if !ok {
+			t.Fatalf("%s did not parse as a ref", url)
+		}
+		if got := ref.FallbackTitle(); got != want {
+			t.Errorf("FallbackTitle(%s) = %q, want %q", url, got, want)
+		}
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -175,14 +175,18 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 	}
 	// A title that is nothing but a GitHub issue/PR URL turns into that item's
 	// real title, with the link moved into the description — a one-time
-	// resolution at create, never re-synced. Resolution failures (no access,
-	// dead link) keep the URL as the title.
+	// resolution at create, never re-synced. The URL is always filed in the
+	// body, and the title defaults to a readable "Issue: owner/repo#N" /
+	// "Pull: owner/repo#N": when resolution fails (no repo access on a private
+	// repo, dead link) the card stays usable — a bare URL as the title, or a
+	// content-less item that never renders, is what left cards invisible.
 	var linkDescription string
 	if ref, ok := board.ParseGitHubRef(strings.TrimSpace(args.Title)); ok {
+		linkDescription = ref.URL
+		args.Title = ref.FallbackTitle()
 		if resolver, hasResolver := s.backend.(LinkResolver); hasResolver {
 			if resolved, err := resolver.ResolveIssueRef(ctx, ref); err == nil && resolved.Title != "" {
 				args.Title = resolved.Title
-				linkDescription = ref.URL
 			}
 		}
 	}

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1232,7 +1232,9 @@ func TestCreateCardFromGitHubURL(t *testing.T) {
 	}
 }
 
-// Create-by-URL degrades gracefully: an unresolvable link keeps the URL title.
+// Create-by-URL degrades gracefully: an unresolvable link (no repo access on a
+// private repo) still yields a usable card — a readable "Issue: owner/repo#N"
+// title, with the source URL filed in the body — instead of a bare-URL title.
 func TestCreateCardFromURLUnresolved(t *testing.T) {
 	fake := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20", ItemID: "s1"}})
 	svc := New(fake)
@@ -1242,11 +1244,29 @@ func TestCreateCardFromURLUnresolved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if card.Title != "https://github.com/acme/private/issues/9" {
-		t.Fatalf("title = %q", card.Title)
+	if card.Title != "Issue: acme/private#9" {
+		t.Fatalf("title = %q, want the fallback label", card.Title)
 	}
-	if fake.count("SetDescription") != 0 {
-		t.Fatal("no description for an unresolved link")
+	if card.Description != "https://github.com/acme/private/issues/9" {
+		t.Fatalf("the source URL must be filed in the body, got %q", card.Description)
+	}
+	if fake.count("SetDescription") != 1 {
+		t.Fatal("the URL should have been written to the description")
+	}
+}
+
+// A PR URL falls back to a "Pull: owner/repo#N" label.
+func TestCreateCardFromPullURLUnresolved(t *testing.T) {
+	fake := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20", ItemID: "s1"}})
+	svc := New(fake)
+	card, err := svc.CreateCard(context.Background(), "acme", 1, CreateCardArgs{
+		Team: "alpha", Title: "https://github.com/aenix-org/cozyportal/pull/1234",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Title != "Pull: aenix-org/cozyportal#1234" {
+		t.Fatalf("title = %q, want the pull fallback label", card.Title)
 	}
 }
 


### PR DESCRIPTION
A card added from a bare GitHub issue/PR URL used to resolve the link to the item's real title and file the URL in the body — but only when resolution succeeded. If it failed (a token without access to a **private** repo, a dead link), the raw URL stayed as the title and nothing went into the body. Worse: loaded with a `project`-only OAuth token that can't read the private issue's content, such an item comes back content-less — no title, no assignee — so it can't be placed in a person column and effectively **disappears** from the board.

Now, for any GitHub issue/PR URL:
- the **source URL is always filed in the body**, and
- the title defaults to a readable **`Issue: owner/repo#N`** / **`Pull: owner/repo#N`**, overridden by the real title only when the link resolves.

So a card from a private cross-repo issue stays usable and visible even without repo access, instead of silently vanishing. (This is the graceful-degradation path; reading the real title/assignee of a private cross-repo issue still requires a `repo`-scoped token.)

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt