### PR TITLE
feat(auth): persist sessions encrypted so restarts keep users signed in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,19 @@ AEMAN_BASE_URL=https://aeman.example.com
 # project alone is enough for a board of draft cards.
 AEMAN_SCOPES=repo project
 
-# Persist sessions to this path (on a mounted volume) so a restart keeps users
-# signed in. Leave unset for in-memory sessions (lost on restart).
+# Where the session store lives (on a mounted volume). It always persists the
+# dynamic MCP client registry across restarts. Sessions (GitHub tokens) are
+# written here only when AEMAN_SESSION_KEY is set — encrypted — so a restart
+# keeps users signed in and MCP tokens live. Leave the key unset to keep
+# sessions in memory only (signed out on restart); no plaintext token ever
+# touches disk either way.
 AEMAN_SESSION_FILE=/data/sessions.json
+
+# Secret that encrypts persisted sessions at rest (any long random string, e.g.
+# `openssl rand -hex 32`). Set it — and keep it stable — to survive restarts;
+# changing or losing it just signs everyone out. Store it out of the session
+# volume (this .env is separate) so a leak of the volume alone exposes no token.
+AEMAN_SESSION_KEY=
 
 # --- TLS (Caddy) ---
 # Domain Caddy serves and auto-issues a Let's Encrypt cert for. Point its DNS

--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -102,6 +102,7 @@ func runServe(args []string) error {
 			BaseURL:      baseURL,
 			Scopes:       os.Getenv("AEMAN_SCOPES"),
 			SessionFile:  os.Getenv("AEMAN_SESSION_FILE"),
+			SessionKey:   os.Getenv("AEMAN_SESSION_KEY"),
 		}
 	}
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,7 +46,7 @@ A user whose token can't read that board sees an access-denied screen rather tha
 
 ## Notes
 
-- **Sessions** are persisted to `AEMAN_SESSION_FILE` on the `aeman_sessions` volume, so restarts and redeploys keep users signed in. Unset the variable for in-memory sessions (lost on restart). Classic OAuth App tokens don't expire, so there is nothing to refresh; a session simply lasts up to 14 days.
+- **Sessions & the session store.** `AEMAN_SESSION_FILE` (on the `aeman_sessions` volume) always persists the dynamic MCP client registry. Sessions — the GitHub tokens — are written there only when `AEMAN_SESSION_KEY` is set, encrypted with it (AES-256-GCM); then restarts and redeploys keep users signed in and MCP tokens live. Without the key, sessions stay in memory and a restart signs everyone out — no plaintext token ever touches disk either way. Keep the key stable (changing or losing it just signs everyone out) and store it outside the session volume so a leak of that volume alone exposes nothing. Classic OAuth App tokens don't expire, so a session simply lasts up to 14 days.
 - **Scopes:** `AEMAN_SCOPES` defaults to `repo project` (Projects v2 + issues).
 - **Cert storage:** the `caddy_data` volume persists issued certificates across restarts.
 - **Local gh mode is unchanged:** without the `AEMAN_GITHUB_*` env vars the binary still runs as a single-user local tool using `gh auth token`.

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -42,9 +42,15 @@ type OAuthConfig struct {
 	Scopes string
 	// SessionFile, when set, persists the dynamic MCP client registry to this
 	// path so registered clients survive restarts. GitHub tokens (sessions) are
-	// never written here — they live only in memory — so a restart signs users
-	// out but leaks no credentials to disk.
+	// written here only when SessionKey is set — encrypted — so without a key a
+	// restart signs users out but leaks no credentials to disk.
 	SessionFile string
+	// SessionKey, when set, is a secret that encrypts the persisted sessions at
+	// rest (AES-256-GCM, key = SHA-256 of this value). With it, sessions and
+	// MCP tokens survive a restart; the on-disk file holds only ciphertext, so
+	// a leak of the file alone (backup, stray volume) exposes no token. Empty =
+	// sessions stay in memory only (signed out on restart).
+	SessionKey string
 }
 
 type oauthSession struct {
@@ -63,6 +69,10 @@ type oauthSession struct {
 type persistedState struct {
 	Sessions map[string]persistedSession `json:"sessions,omitempty"`
 	Clients  map[string]persistedClient  `json:"clients,omitempty"`
+	// EncSessions is the AES-256-GCM ciphertext of the sessions map (base64),
+	// written only when a SessionKey is configured. Legacy plaintext Sessions
+	// are read once (to scrub) but never written.
+	EncSessions string `json:"encSessions,omitempty"`
 }
 
 // persistedClient is the on-disk form of an oauthClient.
@@ -91,6 +101,9 @@ type authManager struct {
 	log    *slog.Logger
 	client *http.Client
 	path   string
+	// sessionKey is the AES-256 key sessions are encrypted with at rest (nil
+	// when no SessionKey is configured, i.e. sessions are memory-only).
+	sessionKey []byte
 
 	// GitHub endpoints. They default to the real GitHub URLs and are overridden
 	// in tests to point at a stub server.
@@ -204,6 +217,7 @@ func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 		log:            log,
 		client:         &http.Client{Timeout: 15 * time.Second},
 		path:           cfg.SessionFile,
+		sessionKey:     deriveSessionKey(cfg.SessionKey),
 		authorizeURL:   githubAuthorizeURL,
 		tokenURL:       githubTokenURL,
 		apiBase:        githubAPIBase,
@@ -220,10 +234,10 @@ func newAuthManager(cfg OAuthConfig, log *slog.Logger) *authManager {
 	return a
 }
 
-// load restores the persisted MCP client registry. Sessions are never restored
-// (GitHub tokens do not persist); if a legacy file carried them, it is rewritten
-// clients-only so the plaintext tokens are scrubbed from disk. No-op without a
-// SessionFile or when the file is absent.
+// load restores the persisted MCP client registry, and — when a SessionKey is
+// configured — the encrypted sessions too, so a restart keeps users signed in
+// and MCP tokens live. Legacy plaintext sessions are never restored; the file
+// is rewritten so they are scrubbed. No-op without a SessionFile or file.
 func (a *authManager) load() {
 	if a.path == "" {
 		return
@@ -231,26 +245,39 @@ func (a *authManager) load() {
 	data, err := os.ReadFile(a.path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			a.log.Error("client registry load failed", "err", err)
+			a.log.Error("session store load failed", "err", err)
 		}
 		return
 	}
 	var in persistedState
 	if err := json.Unmarshal(data, &in); err != nil {
-		a.log.Error("client registry load: parse failed", "err", err)
+		a.log.Error("session store load: parse failed", "err", err)
 		return
 	}
 	for id, c := range in.Clients {
 		a.clients[id] = oauthClient{redirectURIs: append([]string(nil), c.RedirectURIs...)}
 	}
-	a.log.Info("client registry restored", "clients", len(a.clients))
-	// Rewrite clients-only: scrubs any plaintext session tokens an older
-	// version may have left in the file.
+	if a.sessionKey != nil && in.EncSessions != "" {
+		if sessions, err := decryptSessions(a.sessionKey, in.EncSessions); err != nil {
+			a.log.Error("session decrypt failed (wrong AEMAN_SESSION_KEY?); signing everyone out", "err", err)
+		} else {
+			now := time.Now()
+			for sid, s := range sessions {
+				if now.Sub(s.Created) <= sessionTTL {
+					a.sessions[sid] = oauthSession{token: s.Token, login: s.Login, created: s.Created}
+				}
+			}
+		}
+	}
+	a.log.Info("session store restored", "sessions", len(a.sessions), "clients", len(a.clients))
+	// Rewrite in the current format: scrubs any legacy plaintext tokens and
+	// re-encrypts sessions under the configured key.
 	a.saveLocked()
 }
 
-// saveLocked writes the MCP client registry to disk (no sessions, so no GitHub
-// tokens ever reach the file). Callers must hold a.mu.
+// saveLocked persists the MCP client registry and, when a SessionKey is set,
+// the sessions encrypted with it — so the file never holds a plaintext GitHub
+// token. Callers must hold a.mu.
 func (a *authManager) saveLocked() {
 	if a.path == "" {
 		return
@@ -259,18 +286,29 @@ func (a *authManager) saveLocked() {
 	for id, c := range a.clients {
 		out.Clients[id] = persistedClient{RedirectURIs: append([]string(nil), c.redirectURIs...)}
 	}
+	if a.sessionKey != nil && len(a.sessions) > 0 {
+		sessions := make(map[string]persistedSession, len(a.sessions))
+		for sid, s := range a.sessions {
+			sessions[sid] = persistedSession{Token: s.token, Login: s.login, Created: s.created}
+		}
+		if enc, err := encryptSessions(a.sessionKey, sessions); err != nil {
+			a.log.Error("session encrypt failed; not persisting sessions", "err", err)
+		} else {
+			out.EncSessions = enc
+		}
+	}
 	data, err := json.Marshal(out)
 	if err != nil {
-		a.log.Error("client registry save: marshal failed", "err", err)
+		a.log.Error("session store save: marshal failed", "err", err)
 		return
 	}
 	tmp := a.path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		a.log.Error("client registry save: write failed", "err", err)
+		a.log.Error("session store save: write failed", "err", err)
 		return
 	}
 	if err := os.Rename(tmp, a.path); err != nil {
-		a.log.Error("client registry save: rename failed", "err", err)
+		a.log.Error("session store save: rename failed", "err", err)
 	}
 }
 

--- a/internal/server/sessioncrypt.go
+++ b/internal/server/sessioncrypt.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// deriveSessionKey turns the configured secret into a 32-byte AES-256 key, or
+// nil when no secret is set (sessions then stay in memory only).
+func deriveSessionKey(secret string) []byte {
+	if secret == "" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(secret))
+	return sum[:]
+}
+
+// encryptSessions serialises the sessions map and seals it with AES-256-GCM
+// under key, returning base64(nonce || ciphertext). The random nonce makes each
+// write distinct, so the file leaks nothing about unchanged sessions.
+func encryptSessions(key []byte, sessions map[string]persistedSession) (string, error) {
+	plain, err := json.Marshal(sessions)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nonce, nonce, plain, nil)
+	return base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// decryptSessions reverses encryptSessions. A wrong key or tampered file fails
+// the GCM auth check and returns an error, so the caller falls back to an empty
+// (memory-only) session set rather than trusting garbage.
+func decryptSessions(key []byte, enc string) (map[string]persistedSession, error) {
+	raw, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return nil, errors.New("encrypted sessions too short")
+	}
+	nonce, ciphertext := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt sessions: %w", err)
+	}
+	var sessions map[string]persistedSession
+	if err := json.Unmarshal(plain, &sessions); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/internal/server/sessioncrypt_test.go
+++ b/internal/server/sessioncrypt_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSessionEncryptRoundTrip(t *testing.T) {
+	key := deriveSessionKey("a-strong-secret")
+	in := map[string]persistedSession{
+		"sid1": {Token: "gh-tok-1", Login: "alice", Created: time.Now().UTC().Truncate(time.Second)},
+	}
+	enc, err := encryptSessions(key, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := decryptSessions(key, enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["sid1"].Token != "gh-tok-1" || out["sid1"].Login != "alice" {
+		t.Fatalf("round-trip lost data: %+v", out)
+	}
+	// A different key must not decrypt.
+	if _, err := decryptSessions(deriveSessionKey("other-secret"), enc); err == nil {
+		t.Fatal("a wrong key must fail to decrypt")
+	}
+}
+
+func quietAuth(t *testing.T, cfg OAuthConfig) *authManager {
+	t.Helper()
+	cfg.ClientID, cfg.ClientSecret, cfg.BaseURL = "id", "sec", "https://aeman.test"
+	return newAuthManager(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// With a SessionKey, sessions survive a restart (a fresh authManager over the
+// same file); without the key they do not, and a wrong key drops them safely.
+func TestSessionPersistenceAcrossRestart(t *testing.T) {
+	path := t.TempDir() + "/sessions.json"
+
+	a := quietAuth(t, OAuthConfig{SessionFile: path, SessionKey: "the-key"})
+	a.mu.Lock()
+	a.sessions["sid1"] = oauthSession{token: "gh-tok", login: "octocat", created: time.Now()}
+	a.saveLocked()
+	a.mu.Unlock()
+
+	// Restart with the same key → session restored.
+	b := quietAuth(t, OAuthConfig{SessionFile: path, SessionKey: "the-key"})
+	if s, ok := b.sessions["sid1"]; !ok || s.token != "gh-tok" || s.login != "octocat" {
+		t.Fatalf("session not restored with the right key: %+v", b.sessions)
+	}
+
+	// Restart with a wrong key → dropped, no crash.
+	c := quietAuth(t, OAuthConfig{SessionFile: path, SessionKey: "wrong-key"})
+	if _, ok := c.sessions["sid1"]; ok {
+		t.Fatal("a wrong key must not restore sessions")
+	}
+
+	// Restart with no key → sessions are not persisted/restored.
+	d := quietAuth(t, OAuthConfig{SessionFile: path})
+	if _, ok := d.sessions["sid1"]; ok {
+		t.Fatal("without a key sessions must stay in memory only")
+	}
+}
+
+// Without a SessionKey the file must never contain a session token.
+func TestNoKeyLeavesNoTokenOnDisk(t *testing.T) {
+	path := t.TempDir() + "/sessions.json"
+	a := quietAuth(t, OAuthConfig{SessionFile: path})
+	a.mu.Lock()
+	a.sessions["sid1"] = oauthSession{token: "secret-token-xyz", login: "octocat", created: time.Now()}
+	a.saveLocked()
+	a.mu.Unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "secret-token-xyz") {
+		t.Fatalf("token leaked to disk without a key: %s", data)
+	}
+}


### PR DESCRIPTION
The token-off-disk hardening (#44) kept sessions in memory only, so **every restart signed all web users out and invalidated MCP tokens** (which are session ids). aeman looked stateful when it should not.

Sessions can now survive a restart **without putting plaintext tokens on disk**:

- Set **`AEMAN_SESSION_KEY`** (any long random secret) and sessions are persisted **encrypted** with it — AES-256-GCM, key = SHA-256 of the secret. Restarts/redeploys keep users signed in and MCP tokens live.
- A leak of the session file alone (backup, stray volume) yields only ciphertext; the key lives in the environment, off that volume.
- **Without** a key, behaviour is unchanged (memory-only, signed out on restart). A wrong or rotated key **fails closed** — everyone re-signs-in — rather than crashing.

The MCP client registry is still persisted in the clear (no secrets), as before.

Tested: encrypt/decrypt round-trip + wrong-key rejection, and session survival across a simulated restart (right key restores, wrong key drops, no key stays in-memory, and no token reaches disk without a key). Docs + `.env.example` updated.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt