### PR TITLE
feat(notes): cap a note's length like the description

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1010,7 +1010,8 @@ func (s *Server) apiError(w http.ResponseWriter, err error) {
 		writeJSONError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, ghprojects.ErrFieldNotFound), errors.Is(err, ghprojects.ErrNoContent),
 		errors.Is(err, boardservice.ErrInvalidStage),
-		errors.Is(err, boardservice.ErrDescriptionTooLong):
+		errors.Is(err, boardservice.ErrDescriptionTooLong),
+		errors.Is(err, boardservice.ErrNoteTooLong):
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 	default:
 		writeJSONError(w, http.StatusBadGateway, err.Error())

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -31,6 +31,14 @@ const MaxDescriptionLen = 16384
 // ErrDescriptionTooLong is returned when a description exceeds MaxDescriptionLen.
 var ErrDescriptionTooLong = fmt.Errorf("description is too long (max %d characters)", MaxDescriptionLen)
 
+// MaxNoteLen caps a single work note (in runes). A note is a short comment,
+// not a document — and notes share the same ~64K draft body as the description
+// and event log, so one oversized note would crowd out the rest.
+const MaxNoteLen = 4096
+
+// ErrNoteTooLong is returned when a note exceeds MaxNoteLen.
+var ErrNoteTooLong = fmt.Errorf("note is too long (max %d characters)", MaxNoteLen)
+
 // Service performs aeman's board actions. It is stateless: every method loads
 // the board through the backend, computes the change with internal/board logic,
 // then applies it through the backend setters.
@@ -1306,6 +1314,9 @@ func findNote(card board.Card, noteID string) (board.Note, bool) {
 // EditNote rewrites one of a card's work notes (ErrNoteNotFound when the note id
 // is not on the card).
 func (s *Service) EditNote(ctx context.Context, owner string, project int, itemID, noteID, text string) error {
+	if utf8.RuneCountInString(text) > MaxNoteLen {
+		return ErrNoteTooLong
+	}
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return err
@@ -1333,6 +1344,9 @@ func (s *Service) DeleteNote(ctx context.Context, owner string, project int, ite
 
 // AddNote appends a work note to a card.
 func (s *Service) AddNote(ctx context.Context, owner string, project int, itemID, text string) error {
+	if utf8.RuneCountInString(text) > MaxNoteLen {
+		return ErrNoteTooLong
+	}
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return err

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -2031,3 +2031,24 @@ func TestMoveCardBefore(t *testing.T) {
 		}
 	}
 }
+
+// A note over the cap is rejected before anything is written — add and edit
+// alike — mirroring the description guard.
+func TestNoteLengthLimit(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "c1", Team: "alpha",
+		Notes: []board.Note{{ID: "n1", Body: "hi"}}}}, nil)
+	svc := f2svc(f)
+	long := strings.Repeat("x", MaxNoteLen+1)
+	if err := svc.AddNote(ctx, "acme", 1, "c1", long); !errors.Is(err, ErrNoteTooLong) {
+		t.Fatalf("AddNote err = %v, want ErrNoteTooLong", err)
+	}
+	if err := svc.EditNote(ctx, "acme", 1, "c1", "n1", long); !errors.Is(err, ErrNoteTooLong) {
+		t.Fatalf("EditNote err = %v, want ErrNoteTooLong", err)
+	}
+	if f.count("AddNote") != 0 || f.count("EditNote") != 0 {
+		t.Fatal("nothing must be written on rejection")
+	}
+	if err := svc.AddNote(ctx, "acme", 1, "c1", strings.Repeat("x", MaxNoteLen)); err != nil {
+		t.Fatalf("at the limit must pass: %v", err)
+	}
+}

--- a/web/src/components/NotesPanel.tsx
+++ b/web/src/components/NotesPanel.tsx
@@ -326,6 +326,7 @@ export function NotesPanel({
             className="notes-textarea"
             rows={2}
             autoFocus
+            maxLength={4096}
             value={editDraft}
             onChange={(e) => setEditDraft(e.target.value)}
             onKeyDown={(e) => {
@@ -452,6 +453,7 @@ export function NotesPanel({
         <textarea
           className="notes-textarea"
           rows={3}
+          maxLength={4096}
           value={draft}
           placeholder="Write a note… (Enter to send, Shift+Enter for a new line)"
           onChange={(e) => setDraft(e.target.value)}


### PR DESCRIPTION
Descriptions were capped but notes were not, so one oversized note could crowd the shared ~64K draft body. `AddNote`/`EditNote` now reject a note over **4096 runes** (a note is a short comment, not a document) with `ErrNoteTooLong` (422); the composer and edit textareas carry the matching `maxLength`.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt