### PR TITLE
feat(ui): loading progress bar and collapsible notes pane

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,7 +92,12 @@ export function App() {
   const [viewAs, setViewAs] = useState<string | null>(null);
   const [users, setUsers] = useState<Record<string, GhUser>>({});
   const fetchedUsers = useRef<Set<string>>(new Set());
-  const [loading, setLoading] = useState(false);
+  // Count of in-flight data loads (initial load + per-view card fetches);
+  // any of them showing keeps the top progress bar visible.
+  const [pendingLoads, setPendingLoads] = useState(0);
+  const loading = pendingLoads > 0;
+  const beginLoad = useCallback(() => setPendingLoads((n) => n + 1), []);
+  const endLoad = useCallback(() => setPendingLoads((n) => n - 1), []);
   const [error, setError] = useState<string | null>(null);
   // Live selections of other users (login -> card uid), fed by Presence
   // watch frames; purely ephemeral shared-cursor state.
@@ -257,7 +262,7 @@ export function App() {
 
   const doLoad = useCallback(
     async (ownerArg: string, numberArg: number) => {
-      setLoading(true);
+      beginLoad();
       setError(null);
       try {
         // Identity + sprints AND the active view's cards together, swapped in
@@ -274,10 +279,10 @@ export function App() {
       } catch (err: unknown) {
         setError(errMessage(err));
       } finally {
-        setLoading(false);
+        endLoad();
       }
     },
-    [provider],
+    [provider, beginLoad, endLoad],
   );
 
   // Load the active view's cards whenever the selection (view/day/teams) changes
@@ -293,6 +298,7 @@ export function App() {
     }
     let cancelled = false;
     const addr = { owner: bOwner, number: bNumber };
+    beginLoad();
     Promise.all(activeQueriesRef.current.map((q) => provider.listCards(addr, q)))
       .then((lists) => {
         if (cancelled) {
@@ -304,11 +310,12 @@ export function App() {
         if (!cancelled) {
           setError(errMessage(err));
         }
-      });
+      })
+      .finally(endLoad);
     return () => {
       cancelled = true;
     };
-  }, [bOwner, bNumber, activeKey, provider]);
+  }, [bOwner, bNumber, activeKey, provider, beginLoad, endLoad]);
 
   // Locked board: auto-load the pinned project once authenticated. A user whose
   // token can't read it just gets a load error (the access-denied placeholder).
@@ -622,6 +629,9 @@ export function App() {
 
   return (
     <div className="app">
+      {loading && (
+        <div className="loading-bar" role="progressbar" aria-label="Loading data" />
+      )}
       <header className="app-header">
         <div className="brand">
           <Logo className="brand-logo" />

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -118,8 +118,10 @@ export function MeBoard({
   // MCP / API connect dialog.
   const [connectOpen, setConnectOpen] = useState(false);
 
-  // Notes fold to a header bar on narrow screens (like the Team weekly plan) and
-  // stay open as a side pane on wide ones; the breakpoint matches .me-panes.
+  // Notes fold to a header bar on narrow screens (like the Team weekly plan)
+  // and to a slim strip on wide ones; crossing the breakpoint resets to that
+  // width's default (collapsed when stacked, open as a side pane). The
+  // breakpoint matches .me-panes.
   const [notesCollapsed, setNotesCollapsed] = useState(
     () => window.matchMedia("(max-width: 820px)").matches,
   );

--- a/web/src/components/NotesPanel.tsx
+++ b/web/src/components/NotesPanel.tsx
@@ -146,7 +146,7 @@ function useNotesResize(collapsed: boolean) {
         ? { width }
         : {};
 
-  return { paneRef, style, onHandleDown };
+  return { paneRef, style, onHandleDown, stacked };
 }
 
 /** NotesPanel lists the day's notes and offers a composer for the selected card. */
@@ -179,7 +179,12 @@ export function NotesPanel({
   useEffect(() => {
     localStorage.setItem(NOTES_SHOWLOG_KEY, showLog ? "1" : "0");
   }, [showLog]);
-  const { paneRef, style: resizeStyle, onHandleDown } = useNotesResize(collapsed);
+  const {
+    paneRef,
+    style: resizeStyle,
+    onHandleDown,
+    stacked,
+  } = useNotesResize(collapsed);
   const listRef = useRef<HTMLDivElement>(null);
 
   const submit = () => {
@@ -410,7 +415,9 @@ export function NotesPanel({
             aria-label={collapsed ? "Expand notes" : "Collapse notes"}
             title={collapsed ? "Expand" : "Collapse"}
           >
-            {collapsed ? "▲" : "▼"}
+            {/* The arrow points where the pane will go: down/up when stacked
+                under the board, right/left as a desktop side pane. */}
+            {collapsed ? (stacked ? "▲" : "◀") : stacked ? "▼" : "▶"}
           </button>
         </div>
       </header>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1489,11 +1489,11 @@ button.card-age {
   gap: 8px;
 }
 
-/* The notes fold to just their header on narrow screens (where they stack under
-   the board), like the Team weekly plan. The toggle is hidden on wide screens,
-   where notes stay open as a side pane. */
+/* The notes fold to just their header bar on narrow screens (where they stack
+   under the board) and to a slim vertical strip on wide ones (side pane). */
 .notes-toggle {
-  display: none;
+  display: inline-flex;
+  align-items: center;
   border: 1px solid var(--line);
   border-radius: 4px;
   background: var(--bg);
@@ -1507,14 +1507,27 @@ button.card-age {
 
 .notes-collapsed .notes-list,
 .notes-collapsed .notes-composer,
-.notes-collapsed .notes-group-toggle {
+.notes-collapsed .notes-group-toggle,
+.notes-collapsed .notes-log-toggle {
   display: none;
 }
 
-@media (max-width: 820px) {
-  .notes-toggle {
-    display: inline-flex;
-    align-items: center;
+@media (min-width: 821px) {
+  .notes-collapsed {
+    width: 34px;
+    min-width: 34px;
+  }
+
+  .notes-collapsed .notes-header {
+    flex-direction: column-reverse;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 8px 4px;
+    border-bottom: none;
+  }
+
+  .notes-collapsed .notes-header > span {
+    writing-mode: vertical-rl;
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -50,6 +50,39 @@ button {
   border-bottom: 1px solid var(--line);
 }
 
+/* Thin indeterminate progress bar pinned to the top edge while data loads.
+   Fixed and pointer-events-free, so it never displaces or blocks content. */
+.loading-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 200;
+}
+
+.loading-bar::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 35%;
+  border-radius: 999px;
+  background: var(--accent);
+  animation: loading-bar-slide 1.1s ease-in-out infinite;
+}
+
+@keyframes loading-bar-slide {
+  0% {
+    left: -35%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
 .brand {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

- **Loading indicator**: a thin indeterminate progress bar pinned to the top edge whenever board data is in flight — both the initial load and the per-view card fetches (view/day/team switches), which previously gave no visual feedback at all. The bar is fixed, 3px tall and pointer-events-free, so it never displaces or blocks the content.
- **Collapsible notes on desktop**: the collapse toggle was mobile-only; the desktop side pane now folds to a slim vertical strip with a rotated label, giving the board the full width when notes are not needed. The toggle arrow follows the pane's orientation (up/down stacked, left/right as a side pane).

## Why

View switches over slow connections looked frozen — nothing indicated data was loading. And on desktop the notes pane permanently ate 300+px even when unused.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt