### PR TITLE
feat(ui): show the progress bar during carry-over calls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -98,6 +98,15 @@ export function App() {
   const loading = pendingLoads > 0;
   const beginLoad = useCallback(() => setPendingLoads((n) => n + 1), []);
   const endLoad = useCallback(() => setPendingLoads((n) => n - 1), []);
+  // Boards wrap their slow server calls (carry over etc.) with this so the
+  // progress bar covers the operation itself, not just the refetch after it.
+  const trackLoad = useCallback(
+    <T,>(p: Promise<T>): Promise<T> => {
+      beginLoad();
+      return p.finally(endLoad);
+    },
+    [beginLoad, endLoad],
+  );
   const [error, setError] = useState<string | null>(null);
   // Live selections of other users (login -> card uid), fed by Presence
   // watch frames; purely ephemeral shared-cursor state.
@@ -806,6 +815,7 @@ export function App() {
             reorderCards={reorderCards}
             presence={presence}
             reload={reload}
+            track={trackLoad}
             onError={onError}
             onOpen={(c) => setDetailCard(c)}
           />

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -56,6 +56,8 @@ interface TeamBoardProps {
   removeCard: (itemId: string) => void;
   reorderCards: (orderedItemIds: string[]) => void;
   reload: () => void;
+  /** Wraps a slow server call so the App's progress bar shows while it runs. */
+  track: <T>(p: Promise<T>) => Promise<T>;
   /** Other users' live selections (login -> card uid) shown as avatars. */
   presence?: Record<string, string>;
   onError: (message: string) => void;
@@ -104,6 +106,7 @@ export function TeamBoard({
   removeCard,
   reorderCards,
   reload,
+  track,
   presence,
   onError,
   onOpen,
@@ -422,7 +425,7 @@ export function TeamBoard({
     void (async () => {
       let rep: CarryReport;
       try {
-        rep = await provider.carryWeek(board, team, currentWeek, true);
+        rep = await track(provider.carryWeek(board, team, currentWeek, true));
       } catch (err: unknown) {
         onError(errMessage(err));
         return;
@@ -464,7 +467,7 @@ export function TeamBoard({
         }
       }
       try {
-        await provider.carryWeek(board, team, currentWeek);
+        await track(provider.carryWeek(board, team, currentWeek));
       } catch (err: unknown) {
         onError(errMessage(err));
       }
@@ -1370,7 +1373,7 @@ export function TeamBoard({
     }
     let rep: CarryReport;
     try {
-      rep = await provider.carryOver(board, team, true);
+      rep = await track(provider.carryOver(board, team, true));
     } catch (err: unknown) {
       onError(errMessage(err));
       return;
@@ -1399,7 +1402,7 @@ export function TeamBoard({
       }
     }
     try {
-      await provider.carryOver(board, team);
+      await track(provider.carryOver(board, team));
     } catch (err: unknown) {
       onError(errMessage(err));
     }


### PR DESCRIPTION
## What

The top progress bar covered only the refetch after a carry over; the slow part — the server moving cards — ran with no feedback. Boards now wrap slow server calls (daily and weekly carry over, including their dry runs) in a tracker that feeds the same in-flight counter, so the bar stays up for the whole operation.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt