### PR TITLE
feat(server): stale-while-revalidate board cache with live diff

### DIFF
--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -65,9 +66,17 @@ func clientIDFrom(ctx context.Context) string {
 // it from the backend, so edits made outside aeman eventually surface.
 const boardFreshFor = 30 * time.Second
 
-// authFreshFor bounds how long a login's proven read access is trusted before
-// a cache hit forces a fresh token-scoped load to re-authorize it — so access
-// revoked on GitHub takes effect within this window.
+// boardStaleMax bounds how old a snapshot a read-only request may still be
+// served while the store revalidates in the background. Past it (the first
+// visit of the morning) the read blocks on a fresh load instead of flashing
+// hours-old state.
+const boardStaleMax = 10 * time.Minute
+
+// authFreshFor bounds how long a login's proven read access backs a fresh
+// cache hit. An older proof (up to boardStaleMax) degrades the hit to stale:
+// still served to read paths, while the background reload re-checks the
+// token — so access revoked on GitHub takes effect within boardStaleMax, and
+// within this window for callers that cannot accept stale data.
 const authFreshFor = 60 * time.Second
 
 // boardEntry is the cached board plus its watcher set for one owner/project.
@@ -162,30 +171,60 @@ func (e *boardEntry) applyRecent(fresh board.Board) board.Board {
 	return fresh
 }
 
-// freshFor returns the cached board while it is loaded, within its TTL, and the
-// caller is allowed to see it. A named login (OAuth multi-user mode) must have
-// proven token-scoped access within authFreshFor; an empty login is the single
-// local user (no OAuth), always allowed. multiUser forces the login check even
-// if a login somehow arrives empty, so an OAuth deployment never serves the
-// cache without a recent per-user authorization.
-func (e *boardEntry) freshFor(login string, multiUser bool) (board.Board, bool) {
+// cacheState grades a cache lookup: a fresh hit is served to anyone allowed,
+// a stale one only to read paths that revalidate in the background, a miss
+// always loads.
+type cacheState int
+
+const (
+	cacheMiss cacheState = iota
+	cacheStale
+	cacheFresh
+)
+
+// cached returns the board and how usable it is for this caller. cacheFresh
+// needs both the board within boardFreshFor and, for a named login (OAuth
+// multi-user mode; an empty login is the single local user, always allowed),
+// token-scoped access proven within authFreshFor. Past either TTL — but with
+// the board loaded and the login's proof both within boardStaleMax — the hit
+// degrades to cacheStale: read paths may serve it while a background reload
+// with the caller's own token refreshes the board AND re-proves their access,
+// so a revoked token stops refreshing its proof and hard-fails within
+// boardStaleMax. A login that never proved access always misses — the shared
+// cache is keyed only by owner/project, and this gate is what keeps one
+// user's warm board from leaking to another. multiUser forces the login check
+// even if a login somehow arrives empty, so an OAuth deployment never serves
+// the cache without a per-user authorization.
+func (e *boardEntry) cached(login string, multiUser bool) (board.Board, cacheState) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if !e.loaded || time.Since(e.loadedAt) >= boardFreshFor {
-		return board.Board{}, false
+	if !e.loaded {
+		return board.Board{}, cacheMiss
 	}
+	age := time.Since(e.loadedAt)
+	if age >= boardStaleMax {
+		return board.Board{}, cacheMiss
+	}
+	authAge := time.Duration(0)
 	if multiUser || login != "" {
 		ts, ok := e.authed[login]
-		if login == "" || !ok || time.Since(ts) >= authFreshFor {
-			return board.Board{}, false
+		if login == "" || !ok {
+			return board.Board{}, cacheMiss
+		}
+		authAge = time.Since(ts)
+		if authAge >= boardStaleMax {
+			return board.Board{}, cacheMiss
 		}
 	}
-	return e.board, true
+	if age >= boardFreshFor || authAge >= authFreshFor {
+		return e.board, cacheStale
+	}
+	return e.board, cacheFresh
 }
 
 // markAuthed records that a login's own token just proved read access, and
-// sweeps expired entries so the map tracks only currently-active users. The
-// caller holds e.mu.
+// sweeps entries too old to back even a stale hit so the map tracks only
+// currently-active users. The caller holds e.mu.
 func (e *boardEntry) markAuthed(login string) {
 	if login == "" {
 		return
@@ -195,7 +234,7 @@ func (e *boardEntry) markAuthed(login string) {
 	}
 	now := time.Now()
 	for l, ts := range e.authed {
-		if now.Sub(ts) >= authFreshFor {
+		if now.Sub(ts) >= boardStaleMax {
 			delete(e.authed, l)
 		}
 	}
@@ -506,36 +545,147 @@ type storeBackend struct {
 
 var _ boardservice.Backend = (*storeBackend)(nil)
 
-// LoadBoard serves the cached board while it is fresh, otherwise reloads it from
-// the backend and caches it (single-flight: concurrent misses share one fetch).
-// External edits surface on the next reload.
+// LoadBoard serves the cached board while it is fresh. A stale-but-recent
+// board is still served instantly to read paths that opted in (staleControl in
+// ctx) while a background reload revalidates it — watchers then receive the
+// diff as ordinary events plus a Sync frame. Everything else (mutation reads,
+// cold or too-old caches, unauthorized logins) blocks on a fresh load
+// (single-flight: concurrent misses share one fetch).
 func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
 	e := b.store.entry(storeKey(owner, project))
 	login := board.ActorFrom(ctx)
-	if bd, ok := e.freshFor(login, b.multiUser); ok {
+	bd, state := e.cached(login, b.multiUser)
+	if state == cacheFresh {
 		return bd, nil
+	}
+	if state == cacheStale {
+		if sc := staleControlFrom(ctx); sc != nil {
+			b.revalidate(ctx, e, owner, project)
+			sc.served.Store(true)
+			return bd, nil
+		}
 	}
 	e.loadMu.Lock()
 	defer e.loadMu.Unlock()
 	// A concurrent loader may have refreshed the cache while we waited.
-	if bd, ok := e.freshFor(login, b.multiUser); ok {
+	if bd, state := e.cached(login, b.multiUser); state == cacheFresh {
 		return bd, nil
 	}
 	// The token-scoped backend load is the authorization check: GitHub rejects a
 	// token that can't read this board, so reaching a cached result requires
-	// having passed it (recorded per login below).
-	bd, err := b.inner.LoadBoard(ctx, owner, project)
+	// having passed it (recorded per login in install).
+	fresh, err := b.inner.LoadBoard(ctx, owner, project)
 	if err != nil {
 		return board.Board{}, err
 	}
+	return b.install(e, fresh, login), nil
+}
+
+// revalidate refreshes a stale cache in the background with the requesting
+// user's token (kept past the response via WithoutCancel). Single-flight: when
+// a load is already running its completion will broadcast, so this one backs
+// off instead of stacking a second upstream fetch.
+func (b *storeBackend) revalidate(ctx context.Context, e *boardEntry, owner string, project int) {
+	if !e.loadMu.TryLock() {
+		return
+	}
+	login := board.ActorFrom(ctx)
+	bctx := context.WithoutCancel(ctx)
+	go func() {
+		defer e.loadMu.Unlock()
+		fresh, err := b.inner.LoadBoard(bctx, owner, project)
+		if err != nil {
+			// The stale snapshot stays served; tell clients to drop their
+			// revalidation hold and let a later read retry.
+			e.mu.Lock()
+			e.syncBroadcast()
+			e.mu.Unlock()
+			return
+		}
+		b.install(e, fresh, login)
+	}()
+}
+
+// install replaces the cache with a freshly loaded board, records the loading
+// login's proven access, fans the diff against the previous snapshot out to
+// watchers as ordinary events, and closes with a Sync frame. Returns the
+// installed board (with recent local mutations re-applied).
+func (b *storeBackend) install(e *boardEntry, fresh board.Board, login string) board.Board {
 	e.mu.Lock()
-	bd = e.applyRecent(bd)
-	e.board = bd
+	defer e.mu.Unlock()
+	old := e.board
+	hadOld := e.loaded
+	fresh = e.applyRecent(fresh)
+	e.board = fresh
 	e.loaded = true
 	e.loadedAt = time.Now()
 	e.markAuthed(login)
-	e.mu.Unlock()
-	return bd, nil
+	if hadOld {
+		e.diffNotify(old)
+	}
+	e.syncBroadcast()
+	return fresh
+}
+
+// diffNotify announces everything a full reload changed against the previous
+// snapshot — external edits made outside aeman become watch events just like
+// aeman-mediated ones. The caller holds e.mu with the new board installed.
+func (e *boardEntry) diffNotify(old board.Board) {
+	oldByID := make(map[string]board.Card, len(old.Cards))
+	for _, c := range old.Cards {
+		oldByID[c.ItemID] = c
+	}
+	seen := make(map[string]bool, len(e.board.Cards))
+	for _, c := range e.board.Cards {
+		seen[c.ItemID] = true
+		prev, ok := oldByID[c.ItemID]
+		switch {
+		case !ok:
+			e.cardChanged("", c, "ADDED")
+		case !reflect.DeepEqual(prev, c):
+			e.cardChanged("", c, "MODIFIED")
+		}
+	}
+	for _, c := range old.Cards {
+		if !seen[c.ItemID] {
+			e.cardChanged("", c, "DELETED")
+		}
+	}
+	for team, st := range e.board.SprintStates {
+		if old.SprintStates[team] != st {
+			e.sprintChanged("", team)
+		}
+	}
+	for team := range old.SprintStates {
+		if _, ok := e.board.SprintStates[team]; !ok {
+			e.sprintChanged("", team)
+		}
+	}
+	orderChanged := len(old.Cards) != len(e.board.Cards)
+	if !orderChanged {
+		for i := range e.board.Cards {
+			if e.board.Cards[i].ItemID != old.Cards[i].ItemID {
+				orderChanged = true
+				break
+			}
+		}
+	}
+	if orderChanged {
+		e.orderingChanged("")
+	}
+}
+
+// syncBroadcast tells every watcher a full reload just finished. Clients that
+// were served a stale snapshot use it to drop their revalidation hold — the
+// data itself already arrived as the diff's ordinary events. The caller holds
+// e.mu.
+func (e *boardEntry) syncBroadcast() {
+	frame := watchFrame{Type: "MODIFIED", Kind: "Sync", Object: map[string]string{
+		"loadedAt": e.loadedAt.UTC().Format(time.RFC3339),
+	}}
+	for sub := range e.watchers {
+		sub.send(frame)
+	}
 }
 
 // LoadCards passes straight through: it is already a partial read.

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -355,26 +358,215 @@ func TestBoardCachePerUserAuthz(t *testing.T) {
 	}
 }
 
-// freshFor gates a cache hit on load freshness AND, in multi-user mode, the
-// caller having authorized within authFreshFor; local single-user mode (empty
-// login, multiUser=false) always serves a fresh cache.
-func TestFreshForAuthz(t *testing.T) {
+// swrBackend serves a configurable board and counts loads (mutex-guarded: the
+// background revalidation loads from its own goroutine).
+type swrBackend struct {
+	boardservice.Backend // nil: only LoadBoard is exercised
+	mu                   sync.Mutex
+	board                board.Board
+	loads                int
+}
+
+func (s *swrBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loads++
+	return s.board, nil
+}
+
+func (s *swrBackend) set(b board.Board) {
+	s.mu.Lock()
+	s.board = b
+	s.mu.Unlock()
+}
+
+func (s *swrBackend) loadCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loads
+}
+
+// waitFrame reads one frame, waiting for the background revalidation to emit it.
+func waitFrame(t *testing.T, sub *subscription) frame {
+	t.Helper()
+	select {
+	case data := <-sub.ch:
+		var f frame
+		if err := json.Unmarshal(data, &f); err != nil {
+			t.Fatalf("bad frame: %v (%s)", err, data)
+		}
+		return f
+	case <-time.After(5 * time.Second):
+		t.Fatal("no frame within 5s")
+		return frame{}
+	}
+}
+
+// A read that opted in (staleControl in ctx) gets the stale snapshot instantly
+// while a background reload revalidates; watchers then receive the external
+// change as an ordinary MODIFIED event followed by a Sync frame.
+func TestStaleServeRevalidates(t *testing.T) {
+	store := newBoardStore()
+	inner := &swrBackend{board: watchBoard()}
+	be := &storeBackend{inner: inner, store: store}
+
+	// Warm the cache, then age it past the fresh TTL.
+	if _, err := be.LoadBoard(context.Background(), "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+	e.mu.Lock()
+	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
+	e.mu.Unlock()
+
+	sub, cancel := store.subscribe("acme/1", "", nil, map[string]bool{"cards": true})
+	defer cancel()
+
+	// The upstream board changed outside aeman.
+	changed := watchBoard()
+	changed.Cards[0].Progress = 80
+	inner.set(changed)
+
+	ctx, sc := withStaleAllowed(context.Background())
+	got, err := be.LoadBoard(ctx, "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cards[0].Progress == 80 {
+		t.Fatal("expected the stale snapshot, got the fresh board")
+	}
+	if !sc.served.Load() {
+		t.Fatal("the stale serve was not recorded for the response header")
+	}
+
+	// The background revalidation delivers the diff, then the Sync frame.
+	f := waitFrame(t, sub)
+	if f.Type != "MODIFIED" || f.Kind != "Card" || frameUID(t, f) != "c1" {
+		t.Fatalf("want MODIFIED Card c1, got %s %s", f.Type, f.Kind)
+	}
+	if f = waitFrame(t, sub); f.Kind != "Sync" {
+		t.Fatalf("want Sync frame, got %s %s", f.Type, f.Kind)
+	}
+	if inner.loadCount() != 2 {
+		t.Fatalf("backend loads = %d, want 2", inner.loadCount())
+	}
+	// The cache is fresh now: the next read hits it without another load.
+	if got, err = be.LoadBoard(context.Background(), "acme", 1); err != nil || got.Cards[0].Progress != 80 {
+		t.Fatalf("revalidated board not served: %+v %v", got.Cards[0], err)
+	}
+	if inner.loadCount() != 2 {
+		t.Fatalf("backend loads = %d, want 2 (cache hit)", inner.loadCount())
+	}
+}
+
+// A read without the opt-in (every mutation's internal load) must never see a
+// stale snapshot: carry-over picks cards by the live sprint pointer, a move
+// resolves its anchor from the live order.
+func TestMutationReadsBlockForFresh(t *testing.T) {
+	store := newBoardStore()
+	inner := &swrBackend{board: watchBoard()}
+	be := &storeBackend{inner: inner, store: store}
+
+	if _, err := be.LoadBoard(context.Background(), "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+	e.mu.Lock()
+	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
+	e.mu.Unlock()
+
+	changed := watchBoard()
+	changed.Cards[0].Progress = 80
+	inner.set(changed)
+
+	got, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cards[0].Progress != 80 {
+		t.Fatal("a non-opted read was served a stale snapshot")
+	}
+}
+
+// The full HTTP path: a GET in the stale window is answered instantly from
+// the stale snapshot and flagged with X-Aeman-Stale; a cold GET is not.
+func TestStaleHeaderOnAPIRead(t *testing.T) {
+	srv := newTestServer(t)
+	inner := &swrBackend{board: watchBoard()}
+	srv.newService = func(*http.Request) (*boardservice.Service, error) {
+		return boardservice.New(&storeBackend{inner: inner, store: srv.store}), nil
+	}
+
+	get := func() *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/cards?owner=acme&project=1&view=all", nil)
+		srv.handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	rec := get()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cold read: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Aeman-Stale") != "" {
+		t.Fatal("a cold read must not be flagged stale")
+	}
+
+	e := srv.store.entry("acme/1")
+	e.mu.Lock()
+	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
+	e.mu.Unlock()
+
+	rec = get()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stale read: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Aeman-Stale") != "true" {
+		t.Fatalf("a read in the stale window must be flagged, headers: %v", rec.Header())
+	}
+}
+
+// cached gates a hit on load freshness AND, in multi-user mode, the caller's
+// proven access: a fresh hit needs both within their fresh TTLs, an older
+// board or proof (each up to boardStaleMax) degrades to a stale hit, and a
+// login that never proved access — or nothing within boardStaleMax — misses.
+// Local single-user mode (empty login, multiUser=false) skips the login gate.
+func TestCachedAuthz(t *testing.T) {
 	e := &boardEntry{loaded: true, loadedAt: time.Now()}
-	if _, ok := e.freshFor("", false); !ok {
+	if _, state := e.cached("", false); state != cacheFresh {
 		t.Fatal("local single-user mode should serve the fresh cache")
 	}
-	if _, ok := e.freshFor("alice", true); ok {
+	if _, state := e.cached("alice", true); state != cacheMiss {
 		t.Fatal("multi-user: unauthorized login must miss the cache")
 	}
 	e.markAuthed("alice")
-	if _, ok := e.freshFor("alice", true); !ok {
+	if _, state := e.cached("alice", true); state != cacheFresh {
 		t.Fatal("multi-user: authorized login must hit the fresh cache")
 	}
-	if _, ok := e.freshFor("", true); ok {
+	if _, state := e.cached("", true); state != cacheMiss {
 		t.Fatal("multi-user: an empty login must never hit the cache")
 	}
 	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
-	if _, ok := e.freshFor("alice", true); ok {
-		t.Fatal("a stale board must miss regardless of authorization")
+	if _, state := e.cached("alice", true); state != cacheStale {
+		t.Fatal("past the fresh TTL an authorized login must get a stale hit")
+	}
+	if _, state := e.cached("mallory", true); state != cacheMiss {
+		t.Fatal("a stale hit must still require per-login authorization")
+	}
+	// A fresh board with an aging proof degrades the same way: the background
+	// reload re-checks the token instead of blocking the read on it.
+	e.loadedAt = time.Now()
+	e.authed["alice"] = time.Now().Add(-2 * authFreshFor)
+	if _, state := e.cached("alice", true); state != cacheStale {
+		t.Fatal("an aged authorization must degrade a fresh board to a stale hit")
+	}
+	e.authed["alice"] = time.Now().Add(-boardStaleMax - time.Second)
+	if _, state := e.cached("alice", true); state != cacheMiss {
+		t.Fatal("an authorization older than boardStaleMax must miss")
+	}
+	e.markAuthed("alice")
+	e.loadedAt = time.Now().Add(-boardStaleMax - time.Second)
+	if _, state := e.cached("alice", true); state != cacheMiss {
+		t.Fatal("past boardStaleMax the cache must miss regardless of authorization")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,7 +117,7 @@ func New(opts Options) (*Server, error) {
 	}
 	s.registerAPI(mux)
 	mux.Handle("/", spaHandler(dist))
-	s.handler = logRequests(s.log, clientIDMiddleware(s.csrfGuard(s.actorMiddleware(mux))))
+	s.handler = logRequests(s.log, clientIDMiddleware(s.csrfGuard(s.actorMiddleware(staleMiddleware(mux)))))
 	return s, nil
 }
 

--- a/internal/server/stale.go
+++ b/internal/server/stale.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync/atomic"
+)
+
+// staleControl rides a read-only request's context down to the board store:
+// its presence marks the request as one that may accept a stale board snapshot
+// (the store then revalidates in the background), and served records that the
+// store actually used one, which the middleware surfaces as a response header
+// so the client can hold its progress indicator until the Sync watch frame.
+type staleControl struct {
+	served atomic.Bool
+}
+
+type staleCtxKey struct{}
+
+// withStaleAllowed marks the context as accepting a stale board snapshot.
+func withStaleAllowed(ctx context.Context) (context.Context, *staleControl) {
+	sc := &staleControl{}
+	return context.WithValue(ctx, staleCtxKey{}, sc), sc
+}
+
+// staleControlFrom returns the request's stale marker, or nil when the request
+// must be served current data (every mutation path).
+func staleControlFrom(ctx context.Context) *staleControl {
+	sc, _ := ctx.Value(staleCtxKey{}).(*staleControl)
+	return sc
+}
+
+// staleMiddleware lets read-only API requests be answered from a stale board
+// snapshot and reports that via the X-Aeman-Stale header. Mutations never see
+// stale state: their internal reads must be current (a carry-over picks cards
+// by the live sprint pointer, a move resolves its anchor from the live order),
+// so only GETs opt in. The watch endpoint hijacks the connection and opts in
+// on its own instead of going through the wrapped writer.
+func staleMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet ||
+			!strings.HasPrefix(r.URL.Path, "/api/v1") ||
+			r.URL.Path == "/api/v1/watch" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		ctx, sc := withStaleAllowed(r.Context())
+		next.ServeHTTP(&staleHeaderWriter{ResponseWriter: w, sc: sc}, r.WithContext(ctx))
+	})
+}
+
+// staleHeaderWriter stamps X-Aeman-Stale onto the response just before the
+// first byte goes out — by then the handler has run LoadBoard and the store
+// has recorded whether it served a stale snapshot.
+type staleHeaderWriter struct {
+	http.ResponseWriter
+	sc    *staleControl
+	wrote bool
+}
+
+func (w *staleHeaderWriter) WriteHeader(code int) {
+	if !w.wrote {
+		w.wrote = true
+		if w.sc.served.Load() {
+			w.Header().Set("X-Aeman-Stale", "true")
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *staleHeaderWriter) Write(p []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -59,8 +59,12 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// Warm the cache before subscribing: a scoped subscription seeds its
-	// membership from the cached board, and the client LISTs right after.
-	if _, err := svc.Board(r.Context(), owner, project); err != nil {
+	// membership from the cached board, and the client LISTs right after. A
+	// stale snapshot is fine here — the diff events that follow the background
+	// revalidation reconcile the membership (the middleware skips this endpoint
+	// because the connection is hijacked, so opt in explicitly).
+	warmCtx, _ := withStaleAllowed(r.Context())
+	if _, err := svc.Board(warmCtx, owner, project); err != nil {
 		s.apiError(w, err)
 		return
 	}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { clientId, fetchConfig, type AppConfig } from "./api/client";
-import { apiProvider } from "./providers/api/apiProvider";
+import { apiProvider, setStaleListener } from "./providers/api/apiProvider";
 import {
   resourceToCard,
   sprintStateFrom,
@@ -107,6 +107,28 @@ export function App() {
     },
     [beginLoad, endLoad],
   );
+  // A response served from a stale snapshot means the server is revalidating
+  // in the background: hold the progress bar until its Sync watch frame lands
+  // (one hold per revalidation; a failsafe timer releases a missed frame).
+  const revalTimer = useRef<number | null>(null);
+  const releaseReval = useCallback(() => {
+    if (revalTimer.current !== null) {
+      window.clearTimeout(revalTimer.current);
+      revalTimer.current = null;
+      endLoad();
+    }
+  }, [endLoad]);
+  const holdReval = useCallback(() => {
+    if (revalTimer.current !== null) {
+      return;
+    }
+    beginLoad();
+    revalTimer.current = window.setTimeout(releaseReval, 30_000);
+  }, [beginLoad, releaseReval]);
+  useEffect(() => {
+    setStaleListener(holdReval);
+    return () => setStaleListener(null);
+  }, [holdReval]);
   const [error, setError] = useState<string | null>(null);
   // Live selections of other users (login -> card uid), fed by Presence
   // watch frames; purely ephemeral shared-cursor state.
@@ -464,6 +486,12 @@ export function App() {
     let closed = false;
     let retry: number | undefined;
     const applyFrame = (frame: WatchFrame) => {
+      // The server finished a full board reload: any stale snapshot this tab
+      // was served has been reconciled by the frames before this one.
+      if (frame.kind === "Sync") {
+        releaseReval();
+        return;
+      }
       if (!frame.object) {
         return;
       }
@@ -570,6 +598,7 @@ export function App() {
     removeCard,
     patchCard,
     reorderCards,
+    releaseReval,
   ]);
 
   const onError = useCallback((message: string) => setError(message), []);

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -29,6 +29,16 @@ import type {
   Provider,
 } from "../types";
 
+// staleListener is notified whenever a response was served from a stale board
+// snapshot (X-Aeman-Stale): the server is revalidating in the background and
+// will close with a Sync watch frame — the App holds its progress bar between
+// the two.
+let staleListener: (() => void) | null = null;
+
+export function setStaleListener(fn: (() => void) | null): void {
+  staleListener = fn;
+}
+
 // api issues a request against /api/v1 for a given board. It carries the board
 // identity as query parameters (?owner=&project=) so the server resolves the
 // right board, sets a JSON content type when there is a body, and on a non-2xx
@@ -54,6 +64,9 @@ async function api<T>(
     init.body = JSON.stringify(body);
   }
   const res = await fetch(url, init);
+  if (res.headers.get("X-Aeman-Stale") === "true") {
+    staleListener?.();
+  }
   if (!res.ok) {
     let msg = res.statusText;
     try {


### PR DESCRIPTION
## What

Reads past the 30s board-cache TTL used to block on a full GitHub reload — refreshing the board after half a minute of quiet meant seconds of waiting. Read paths are now answered instantly from a snapshot up to 10 minutes old while a single background reload revalidates it; the resulting diff reaches every connected client as ordinary watch events, closed by a Sync frame. Stale responses carry `X-Aeman-Stale`, and the frontend keeps the progress bar up until the Sync frame lands — the board renders immediately while honestly showing a sync is in flight.

Mutations (and MCP) never see stale state: their internal reads still block for a fresh board.

## Why

Perceived load time after any idle period dropped from seconds to milliseconds, and external GitHub edits now propagate to all open tabs instead of only the client that triggered a reload.

## Security note

The per-user cache authorization softens deliberately: a login with proven access older than 60s (within 10 min) is served stale while the background reload re-checks its token, so revoked access hard-fails within 10 minutes. A login that never proved access still never sees the cache.

https://claude.ai/code/session_011v4Qn75TKERtJvkV5V87wt