### PR TITLE
feat(web): add theme and colour-palette appearance picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - name: Build frontend
+      - name: Build & test frontend
         working-directory: web
         run: |
           npm ci
           npm run build
+          npm test
 
       - uses: actions/setup-go@v5
         with:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -701,16 +701,12 @@ export function App() {
             login={config?.login ?? null}
             appearance={appearance}
             onChange={setAppearance}
+            logoutUrl={
+              config?.mode === "oauth" && config.authenticated
+                ? (config.logoutUrl ?? "/auth/logout")
+                : null
+            }
           />
-          {config?.mode === "oauth" && config.authenticated && (
-            <a
-              className="login-logout"
-              href={config.logoutUrl ?? "/auth/logout"}
-              title="Sign out"
-            >
-              sign out
-            </a>
-          )}
         </div>
       </header>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { clientId, fetchConfig, type AppConfig } from "./api/client";
 import { apiProvider, setStaleListener } from "./providers/api/apiProvider";
 import {
@@ -18,6 +18,8 @@ import { Logo } from "./components/Logo";
 import { fetchUsers, type GhUser } from "./users";
 import { queryString, viewQueries, watchQuery } from "./viewquery";
 import { todayIso } from "./date";
+import { AppearanceMenu } from "./components/AppearanceMenu";
+import { applyAppearance, persistAppearance, readAppearance, type Appearance } from "./theme";
 
 type ViewMode = "me" | "team";
 
@@ -81,6 +83,25 @@ export function App() {
     () => localStorage.getItem(LS_PROJECT) ?? "",
   );
   const [view, setView] = useState<ViewMode>(readView);
+
+  // Appearance (theme mode + colour palette). Applied to <html> so the CSS
+  // theme/palette overrides repaint the app; persisted in localStorage like the
+  // app's other UI prefs. useLayoutEffect (not useEffect) so the attributes land
+  // before the browser paints — otherwise a returning user on a non-default
+  // appearance gets one frame of the default look on every load. When the mode
+  // is "system" we also follow live OS light/dark changes.
+  const [appearance, setAppearance] = useState<Appearance>(() => readAppearance(localStorage));
+  useLayoutEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const apply = () => applyAppearance(document.documentElement, appearance, mq.matches);
+    apply();
+    persistAppearance(localStorage, appearance);
+    if (appearance.mode !== "system") {
+      return;
+    }
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, [appearance]);
 
   const [board, setBoard] = useState<Board | null>(null);
   // The viewed day, shared by both boards and driving the lazy view fetch and
@@ -676,11 +697,11 @@ export function App() {
           {config && <span className="version">v{config.version}</span>}
         </div>
         <div className="account">
-          {config?.login ? (
-            <span className="login">@{config.login}</span>
-          ) : (
-            <span className="login login-anon">not signed in</span>
-          )}
+          <AppearanceMenu
+            login={config?.login ?? null}
+            appearance={appearance}
+            onChange={setAppearance}
+          />
           {config?.mode === "oauth" && config.authenticated && (
             <a
               className="login-logout"

--- a/web/src/components/AddCard.tsx
+++ b/web/src/components/AddCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { teamColor } from "../avatar";
+import { Dropdown } from "./Dropdown";
 
 interface AddCardProps {
   onCreate: (title: string, team?: string | null) => void;
@@ -31,6 +32,7 @@ export function AddCard({
   const [menuOpen, setMenuOpen] = useState(false);
   const formRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const teamRef = useRef<HTMLDivElement | null>(null);
 
   // The team picker is shown only when a roster is supplied and no team is forced.
   const showPicker = forcedTeam === undefined && teams !== undefined;
@@ -61,7 +63,13 @@ export function AddCard({
       return;
     }
     const onDocDown = (e: MouseEvent) => {
-      if (formRef.current && !formRef.current.contains(e.target as Node)) {
+      const t = e.target as Element;
+      // The team menu is portalled to <body> (so overflow ancestors cannot
+      // clip it) — a click inside it is part of the form, not an outside save.
+      if (t.closest?.(".add-card-team-menu")) {
+        return;
+      }
+      if (formRef.current && !formRef.current.contains(t)) {
         submitRef.current();
       }
     };
@@ -110,7 +118,7 @@ export function AddCard({
         }}
       />
       {showPicker && (
-        <div className="add-card-team">
+        <div className="add-card-team" ref={teamRef}>
           <button
             type="button"
             className="add-card-team-btn"
@@ -123,30 +131,33 @@ export function AddCard({
             <span className="add-card-team-label">{team ?? "no team"}</span>
             <span className="add-card-team-caret">▾</span>
           </button>
-          {menuOpen && (
-            <div className="add-card-team-menu">
-              {allowNoTeam && (
-                <button
-                  type="button"
-                  className="add-card-team-item"
-                  onClick={() => pickTeam(null)}
-                >
-                  no team
-                </button>
-              )}
-              {(teams ?? []).map((t) => (
-                <button
-                  key={t}
-                  type="button"
-                  className="add-card-team-item"
-                  onClick={() => pickTeam(t)}
-                >
-                  <span className="team-dot" style={{ background: teamColor(t) }} />
-                  {t}
-                </button>
-              ))}
-            </div>
-          )}
+          <Dropdown
+            open={menuOpen}
+            anchorRef={teamRef}
+            onClose={() => setMenuOpen(false)}
+            className="add-card-team-menu"
+          >
+            {allowNoTeam && (
+              <button
+                type="button"
+                className="add-card-team-item"
+                onClick={() => pickTeam(null)}
+              >
+                no team
+              </button>
+            )}
+            {(teams ?? []).map((t) => (
+              <button
+                key={t}
+                type="button"
+                className="add-card-team-item"
+                onClick={() => pickTeam(t)}
+              >
+                <span className="team-dot" style={{ background: teamColor(t) }} />
+                {t}
+              </button>
+            ))}
+          </Dropdown>
         </div>
       )}
     </div>

--- a/web/src/components/AppearanceMenu.tsx
+++ b/web/src/components/AppearanceMenu.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import { Dropdown } from "./Dropdown";
+import {
+  type Appearance,
+  type Palette,
+  type ThemeMode,
+} from "../theme";
+
+interface AppearanceMenuProps {
+  /** GitHub login to show as the trigger, or null when not signed in. */
+  login: string | null;
+  appearance: Appearance;
+  onChange: (next: Appearance) => void;
+}
+
+// On-screen labels are intentionally plain "appearance" wording. The palette
+// options carry the colour-vision support (see theme.ts) but nothing here names
+// it, so picking one says nothing about the person picking it.
+const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+const PALETTE_OPTIONS: { value: Palette; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "vivid", label: "Vivid" },
+  { value: "marine", label: "Marine" },
+];
+
+/**
+ * AppearanceMenu turns the header nickname into the trigger for a small
+ * appearance picker (theme mode + colour palette), rendered through the shared
+ * Dropdown so it is never clipped by the header.
+ */
+export function AppearanceMenu({ login, appearance, onChange }: AppearanceMenuProps) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on Escape while open. A document listener (rather than onKeyDown on
+  // the menu) works regardless of where focus sits, since opening does not move
+  // focus into the portalled menu.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <div className="appearance" ref={anchorRef}>
+      <button
+        type="button"
+        className={`login appearance-trigger${login ? "" : " login-anon"}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {login ? `@${login}` : "not signed in"}
+        <span className="appearance-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      <Dropdown
+        open={open}
+        anchorRef={anchorRef}
+        onClose={() => setOpen(false)}
+        className="appearance-menu"
+      >
+        <div role="menu" aria-label="Appearance" className="appearance-menu-inner">
+        <div className="appearance-group" role="group" aria-label="Theme">
+          <div className="appearance-label">Theme</div>
+          {THEME_OPTIONS.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={appearance.mode === o.value}
+              className="appearance-item"
+              onClick={() => onChange({ ...appearance, mode: o.value })}
+            >
+              <span className="appearance-check" aria-hidden="true">
+                {appearance.mode === o.value ? "✓" : ""}
+              </span>
+              {o.label}
+            </button>
+          ))}
+        </div>
+        <div className="appearance-group" role="group" aria-label="Colours">
+          <div className="appearance-label">Colours</div>
+          {PALETTE_OPTIONS.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={appearance.palette === o.value}
+              className="appearance-item"
+              onClick={() => onChange({ ...appearance, palette: o.value })}
+            >
+              <span className="appearance-check" aria-hidden="true">
+                {appearance.palette === o.value ? "✓" : ""}
+              </span>
+              {o.label}
+            </button>
+          ))}
+        </div>
+        </div>
+      </Dropdown>
+    </div>
+  );
+}

--- a/web/src/components/AppearanceMenu.tsx
+++ b/web/src/components/AppearanceMenu.tsx
@@ -11,6 +11,8 @@ interface AppearanceMenuProps {
   login: string | null;
   appearance: Appearance;
   onChange: (next: Appearance) => void;
+  /** Sign-out link target (OAuth mode); when set the menu offers it. */
+  logoutUrl?: string | null;
 }
 
 // On-screen labels are intentionally plain "appearance" wording. The palette
@@ -33,7 +35,12 @@ const PALETTE_OPTIONS: { value: Palette; label: string }[] = [
  * appearance picker (theme mode + colour palette), rendered through the shared
  * Dropdown so it is never clipped by the header.
  */
-export function AppearanceMenu({ login, appearance, onChange }: AppearanceMenuProps) {
+export function AppearanceMenu({
+  login,
+  appearance,
+  onChange,
+  logoutUrl,
+}: AppearanceMenuProps) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
@@ -110,6 +117,15 @@ export function AppearanceMenu({ login, appearance, onChange }: AppearanceMenuPr
             </button>
           ))}
         </div>
+        {logoutUrl && (
+          <div className="appearance-group" role="group" aria-label="Account">
+            <div className="appearance-sep" aria-hidden="true" />
+            <a role="menuitem" className="appearance-item" href={logoutUrl}>
+              <span className="appearance-check" aria-hidden="true" />
+              Sign out
+            </a>
+          </div>
+        )}
         </div>
       </Dropdown>
     </div>

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type Ref } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Ref,
+} from "react";
 import {
   cancelPendingCard,
   consumePendingCancel,
@@ -1010,11 +1018,15 @@ export function MeBoard({
                     key={group.key}
                     ref={dropRef as Ref<HTMLElement>}
                     className={`zone-area${isOver ? " zone-area-dragover" : ""}`}
-                    style={{ background: def.background, borderLeftColor: def.accent }}
+                    style={
+                      {
+                        background: def.background,
+                        borderLeftColor: def.accent,
+                        "--zone-accent": def.accent,
+                      } as CSSProperties
+                    }
                   >
-                    <span className="zone-spine" style={{ color: def.accent }}>
-                      {def.spine}
-                    </span>
+                    <span className="zone-spine">{def.spine}</span>
                     <div className="zone-cards">
                       {body}
                       <AddCard

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type Ref,
 } from "react";
 import {
@@ -1681,11 +1682,15 @@ export function TeamBoard({
               <div
                 ref={dropRef as Ref<HTMLDivElement>}
                 className={`zone-area${isOver ? " zone-area-dragover" : ""}`}
-                style={{ background: def.background, borderLeftColor: def.accent }}
+                style={
+                  {
+                    background: def.background,
+                    borderLeftColor: def.accent,
+                    "--zone-accent": def.accent,
+                  } as CSSProperties
+                }
               >
-                <span className="zone-spine" style={{ color: def.accent }}>
-                  {def.spine}
-                </span>
+                <span className="zone-spine">{def.spine}</span>
                 <div className="zone-cards">
                   {body}
                   <AddCard

--- a/web/src/stages.ts
+++ b/web/src/stages.ts
@@ -9,19 +9,23 @@ export interface StageDef {
   color: string;
 }
 
+// Colours are CSS custom properties (defined in styles.css) rather than literal
+// hex, so the opt-in colour-blind mode repaints stages through one palette
+// override. The stage name shown alongside the bar is the redundant channel
+// that carries the meaning when hues are hard to tell apart.
 export const STAGES: Record<StageKey, StageDef> = {
-  locked: { key: "locked", label: "Locked", color: "#cf222e" },
-  review: { key: "review", label: "Review", color: "#d4a72c" },
+  locked: { key: "locked", label: "Locked", color: "var(--stage-locked)" },
+  review: { key: "review", label: "Review", color: "var(--stage-review)" },
   // Recurrent marks a repeating task: unlike review/locked its progress spans
   // the full 0–100%, and Carry Over reseeds a finished one as a fresh copy.
-  recurrent: { key: "recurrent", label: "Recurrent", color: "#58a6ff" },
-  done: { key: "done", label: "Done", color: "#1f883d" },
+  recurrent: { key: "recurrent", label: "Recurrent", color: "var(--stage-recurrent)" },
+  done: { key: "done", label: "Done", color: "var(--stage-done)" },
 };
 
 export const STAGE_ORDER: StageKey[] = ["locked", "review", "recurrent", "done"];
 
 /** Progress bar colour for a stage; the default (no stage) bar is green. */
-export const DEFAULT_BAR_COLOR = "#3fb950";
+export const DEFAULT_BAR_COLOR = "var(--bar-default)";
 
 /** isComplete mirrors board.Complete: a card is finished when it has an explicit
  *  done stage, or is 100% with no stage, or is a recurrent card at 100%. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,3 +1,28 @@
+/* ============================================================================
+   Theming: two independent axes, each a data attribute on <html> (see theme.ts).
+     data-theme   = light | dark      (light is the default / no attribute)
+     data-palette = default | vivid | marine
+   Everything colour-valued is a CSS variable so the six (theme × palette) cells
+   below repaint the app without any component change.
+
+   Palettes (neutral names on screen; the accessibility purpose is documented
+   here, not shown to the user):
+     default  the standard look.
+     vivid    red-green-friendly. Warm, saturated, high-contrast — designed and
+              verified against a deuteranopia/protanopia colour-blindness
+              simulation so no two zones collapse together on the red-green axis.
+     marine   blue-yellow-friendly. Verified the same way against a tritanopia
+              simulation.
+   The zone/stage semantics are always also carried by text (zone spines, stage
+   names, progress %), so meaning never rests on colour alone.
+
+   Specificity note: light rules are :root / :root[data-palette]; dark base is
+   :root[data-theme="dark"] and beats them; each dark+palette combo has its own
+   :root[data-theme="dark"][data-palette] rule that beats the dark base. Every
+   reachable cell therefore has one clearly-winning rule regardless of order.
+   ============================================================================ */
+
+/* ---- light + default (the base; all variables are declared here) ---- */
 :root {
   --fg: #1f2328;
   --muted: #57606a;
@@ -7,8 +32,211 @@
   --bg: #ffffff;
   --bg-soft: #f6f8fa;
   --accent: #0969da;
+  /* Solid accent fill that carries white text (buttons, active segments). Split
+     from --accent because dark mode needs a lighter accent for text/icons but a
+     darker one behind white labels. In light both are the same blue. */
+  --accent-emphasis: #0969da;
   --danger: #cf222e;
+  /* Solid danger fill that carries white text (the delete-corner button on
+     hover). Split from --danger for the same reason as --accent-emphasis: dark
+     mode wants a lighter red for danger *text* but a deeper one behind white. */
+  --danger-emphasis: #cf222e;
   --radius: 6px;
+
+  /* Glyph/label colour on a saturated (accent/danger/avatar) fill. */
+  --on-accent: #fff;
+
+  /* Semantic surfaces that must flip for dark mode. */
+  --card-border: #d6dbe1;
+  --card-taken-bg: #f4f4f4;
+  --notes-bg: #fbfcfd;
+  --bg-raised: #fff;
+  --handle-bg: #fff;
+  --avatar-fg: #24292f;
+  --amber: #b8860b;
+  --band-wed: #3b82f6;
+  --band-fri: #8b5cf6;
+  --band-wed-bg: #eef4fb;
+  --band-fri-bg: #f3eefb;
+  --cal-range-bg: #dbeafe;
+  --warn-bg: #fff8c5;
+  --warn-line: #eac54f;
+  --err-bg: #ffebe9;
+  --err-line: #ff8182;
+
+  /* Shadows, scrims and overlays — tuned for dark-on-light; dark mode swaps
+     them for light-on-dark equivalents. */
+  --elev-1: rgba(27, 31, 36, 0.04);
+  --elev-2: rgba(27, 31, 36, 0.18);
+  --elev-3: rgba(27, 31, 36, 0.28);
+  --handle-shadow: rgba(27, 31, 36, 0.3);
+  --placeholder-border: rgba(27, 31, 36, 0.35);
+  --scrim: rgba(27, 31, 36, 0.45);
+  --code-bg: rgba(0, 0, 0, 0.06);
+  --dragover-outline: rgba(0, 0, 0, 0.28);
+  --drag-shadow: rgba(0, 0, 0, 0.14);
+  --accent-glow: rgba(9, 105, 218, 0.35);
+  --danger-tint: rgba(207, 34, 46, 0.1);
+  --hover-overlay: rgba(27, 31, 36, 0.08);
+  --hover-overlay-soft: rgba(27, 31, 36, 0.05);
+
+  /* Zone palette (accent = spine/border, bg = area tint). */
+  --zone-red-accent: #f85149;
+  --zone-red-bg: #fdecea;
+  --zone-yellow-accent: #d4a72c;
+  --zone-yellow-bg: #fdf6df;
+  --zone-gray-accent: #8b949e;
+  --zone-gray-bg: #f3f4f6;
+  --zone-green-accent: #3fb950;
+  --zone-green-bg: #eafaef;
+
+  /* Progress-bar / stage palette, consumed from JS via stages.ts. */
+  --stage-locked: #cf222e;
+  --stage-review: #d4a72c;
+  --stage-recurrent: #58a6ff;
+  --stage-done: #1f883d;
+  --bar-default: #3fb950;
+}
+
+/* ---- light + vivid (red-green-friendly) ----
+   Saturated fills, green pushed toward teal, so every pair of zone areas stays
+   apart under deuter-/protanopia; spine repainted near-black for legibility. */
+:root[data-palette="vivid"] {
+  --zone-red-accent: #d55e00; /* vermillion — urgent */
+  --zone-red-bg: #ff8f5a;
+  --zone-yellow-accent: #e69f00; /* orange — unplanned */
+  --zone-yellow-bg: #ffdd5e;
+  --zone-gray-accent: #6b7785; /* neutral gray — planned */
+  --zone-gray-bg: #edeff3;
+  --zone-green-accent: #009e73; /* teal-green — nice to have */
+  --zone-green-bg: #63d3d8;
+
+  --stage-locked: #d55e00;
+  --stage-review: #e69f00;
+  --stage-recurrent: #0072b2;
+  --stage-done: #007a59;
+  --bar-default: #009e73;
+}
+
+/* ---- light + marine (blue-yellow-friendly) ----
+   Verified against a tritanopia simulation. */
+:root[data-palette="marine"] {
+  --zone-red-accent: #d1453b;
+  --zone-red-bg: #ff9aa0;
+  --zone-yellow-accent: #c98a1e;
+  --zone-yellow-bg: #ffd98a;
+  --zone-gray-accent: #8b949e;
+  --zone-gray-bg: #e3e6ea;
+  --zone-green-accent: #2596b5; /* cyan */
+  --zone-green-bg: #6fcbe0;
+
+  --stage-locked: #cf222e;
+  --stage-review: #b07d1a;
+  --stage-recurrent: #1f6feb;
+  --stage-done: #2596b5;
+  --bar-default: #2596b5;
+}
+
+/* ---- dark base (dark + default) ----
+   Overrides the neutrals, surfaces, shadows and the default zone/stage palette
+   with dark-appropriate values. Dark zone fills are dark tints (light spine
+   text on top); their pairwise separation for the CVD palettes is carried by
+   both hue and lightness. */
+:root[data-theme="dark"] {
+  --fg: #e6edf3;
+  --muted: #9198a1;
+  --faint: #868f99;
+  --line: #30363d;
+  --line-soft: #21262d;
+  --bg: #0d1117;
+  --bg-soft: #161b22;
+  --accent: #4493f8;
+  --accent-emphasis: #1f6feb;
+  --danger: #f85149;
+  --danger-emphasis: #d5322c;
+
+  --on-accent: #fff;
+  --card-border: #30363d;
+  --card-taken-bg: #1c222b;
+  --notes-bg: #10151c;
+  --bg-raised: #21262d;
+  --handle-bg: #e6edf3;
+  --avatar-fg: #e6edf3;
+  --amber: #e3b341;
+  --band-wed: #4493f8;
+  --band-fri: #a371f7;
+  --band-wed-bg: #10233b;
+  --band-fri-bg: #241a3a;
+  --cal-range-bg: #163356;
+  --warn-bg: #2d2a10;
+  --warn-line: #7a6a1e;
+  --err-bg: #3a1a1a;
+  --err-line: #7a2a2a;
+
+  --elev-1: rgba(1, 4, 9, 0.5);
+  --elev-2: rgba(1, 4, 9, 0.6);
+  --elev-3: rgba(1, 4, 9, 0.7);
+  --handle-shadow: rgba(1, 4, 9, 0.6);
+  --placeholder-border: rgba(240, 246, 252, 0.25);
+  --scrim: rgba(1, 4, 9, 0.8);
+  --code-bg: rgba(240, 246, 252, 0.1);
+  --dragover-outline: rgba(240, 246, 252, 0.4);
+  --drag-shadow: rgba(1, 4, 9, 0.6);
+  --accent-glow: rgba(68, 147, 248, 0.4);
+  --danger-tint: rgba(248, 81, 73, 0.15);
+  --hover-overlay: rgba(240, 246, 252, 0.1);
+  --hover-overlay-soft: rgba(240, 246, 252, 0.06);
+
+  --zone-red-accent: #ff7b72;
+  --zone-red-bg: #4a2321;
+  --zone-yellow-accent: #e3b341;
+  --zone-yellow-bg: #463a17;
+  --zone-gray-accent: #7d8590;
+  --zone-gray-bg: #2b3138;
+  --zone-green-accent: #3fb950;
+  --zone-green-bg: #1a3d2a;
+
+  --stage-locked: #ff7b72;
+  --stage-review: #e3b341;
+  --stage-recurrent: #79c0ff;
+  --stage-done: #3fb950;
+  --bar-default: #3fb950;
+}
+
+/* ---- dark + vivid (red-green-friendly) ---- */
+:root[data-theme="dark"][data-palette="vivid"] {
+  --zone-red-accent: #ff8a50;
+  --zone-red-bg: #5c2410;
+  --zone-yellow-accent: #f0b429;
+  --zone-yellow-bg: #6b5510;
+  --zone-gray-accent: #8b98a6;
+  --zone-gray-bg: #242a30;
+  --zone-green-accent: #2ec4a6;
+  --zone-green-bg: #106f66;
+
+  --stage-locked: #ff8a50;
+  --stage-review: #f0b429;
+  --stage-recurrent: #58a6ff;
+  --stage-done: #2ec4a6;
+  --bar-default: #2ec4a6;
+}
+
+/* ---- dark + marine (blue-yellow-friendly) ---- */
+:root[data-theme="dark"][data-palette="marine"] {
+  --zone-red-accent: #ff9d8a;
+  --zone-red-bg: #8a3c1c;
+  --zone-yellow-accent: #e3b341;
+  --zone-yellow-bg: #6b5510;
+  --zone-gray-accent: #8b98a6;
+  --zone-gray-bg: #242a30;
+  --zone-green-accent: #56b6c2;
+  --zone-green-bg: #0e665c;
+
+  --stage-locked: #ff7b72;
+  --stage-review: #e3b341;
+  --stage-recurrent: #79c0ff;
+  --stage-done: #56b6c2;
+  --bar-default: #56b6c2;
 }
 
 * {
@@ -123,6 +351,94 @@ button {
   text-decoration: underline;
 }
 
+.account {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Appearance picker: the nickname doubles as the trigger for a theme + palette
+   menu. Kept visually just like the plain login text, with a caret hint. */
+.appearance {
+  position: relative;
+  display: inline-flex;
+}
+
+.appearance-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.appearance-caret {
+  font-size: 9px;
+  color: var(--faint);
+  line-height: 1;
+}
+
+.appearance-menu {
+  min-width: 148px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px var(--elev-2);
+  padding: 3px;
+}
+
+.appearance-menu-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.appearance-group + .appearance-group {
+  border-top: 1px solid var(--line-soft);
+  margin-top: 3px;
+  padding-top: 3px;
+}
+
+.appearance-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+  padding: 4px 8px 2px;
+}
+
+.appearance-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg);
+  text-align: left;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.appearance-item:hover {
+  background: var(--bg-soft);
+}
+
+.appearance-item[aria-checked="true"] {
+  font-weight: 600;
+}
+
+.appearance-check {
+  width: 12px;
+  flex: none;
+  color: var(--accent);
+  font-size: 11px;
+}
+
 /* ---- sign-in gate (OAuth mode) ---- */
 .signin {
   flex: 1;
@@ -162,18 +478,18 @@ button {
 }
 
 .banner-warning {
-  background: #fff8c5;
-  border-bottom: 1px solid #eac54f;
+  background: var(--warn-bg);
+  border-bottom: 1px solid var(--warn-line);
 }
 
 .banner-error {
-  background: #ffebe9;
-  border-bottom: 1px solid #ff8182;
+  background: var(--err-bg);
+  border-bottom: 1px solid var(--err-line);
 }
 
 .banner code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--code-bg);
   padding: 0 4px;
   border-radius: 4px;
 }
@@ -234,9 +550,9 @@ button {
 }
 
 .btn-primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  border-color: var(--accent-emphasis);
+  color: var(--on-accent);
   font-weight: 500;
 }
 
@@ -267,8 +583,8 @@ button {
 }
 
 .segment-active {
-  background: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  color: var(--on-accent);
   font-weight: 500;
 }
 
@@ -366,14 +682,14 @@ button {
   display: flex;
   align-items: stretch;
   gap: 6px;
-  border-left: 3px solid #ccc;
+  border-left: 3px solid var(--line);
   border-radius: 0;
   padding: 5px 6px;
   min-height: 40px;
 }
 
 .zone-area-dragover {
-  outline: 2px dashed rgba(0, 0, 0, 0.28);
+  outline: 2px dashed var(--dragover-outline);
   outline-offset: -2px;
 }
 
@@ -397,6 +713,30 @@ button {
   white-space: nowrap;
   pointer-events: none;
   opacity: 0.9;
+  /* Read the zone accent straight off the inherited --zone-accent that
+     .zone-area sets inline. Reading it here (not through a :root-declared
+     indirection) matters: a custom property that references --zone-accent must
+     be resolved on an element where --zone-accent actually exists, which is the
+     zone, not :root. The overrides below repaint it for the palettes/dark. */
+  color: var(--zone-accent);
+}
+
+/* The CVD palettes and dark mode paint the spine as the high-contrast
+   foreground instead of the zone accent, so the rotated label stays legible on
+   a saturated (CVD) or dark fill rather than fading into it. */
+[data-palette="vivid"] .zone-spine,
+[data-palette="marine"] .zone-spine,
+[data-theme="dark"] .zone-spine {
+  color: var(--fg);
+}
+
+/* In the CVD palettes the spine is the redundant text channel that must stay
+   readable, so drop the tint-driven fade and enlarge it a touch. */
+[data-palette="vivid"] .zone-spine,
+[data-palette="marine"] .zone-spine {
+  opacity: 1;
+  font-size: 9px;
+  font-weight: 800;
 }
 
 /* ---- dnd-kit drag styles ---- */
@@ -409,7 +749,7 @@ button {
    gap of card height so neighbouring cards visibly push apart toward it. */
 .sortable-card-placeholder .card {
   background: transparent;
-  border: 1px dashed rgba(27, 31, 36, 0.35);
+  border: 1px dashed var(--placeholder-border);
   box-shadow: none;
 }
 
@@ -423,7 +763,7 @@ button {
 }
 
 .dnd-overlay .card {
-  box-shadow: 0 8px 20px rgba(27, 31, 36, 0.28);
+  box-shadow: 0 8px 20px var(--elev-3);
   transform: scale(1.02);
   cursor: grabbing;
 }
@@ -456,9 +796,9 @@ button {
   flex: none;
   padding: 3px 8px 6px;
   background: var(--bg);
-  border: 1px solid #d6dbe1;
+  border: 1px solid var(--card-border);
   border-radius: 5px;
-  box-shadow: 0 1px 1px rgba(27, 31, 36, 0.04);
+  box-shadow: 0 1px 1px var(--elev-1);
   cursor: grab;
   user-select: none;
 }
@@ -469,7 +809,7 @@ button {
 
 .card-selected {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.35);
+  box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
 /* Plan-linked cards in working views get a coloured left stripe by band; review
@@ -487,20 +827,20 @@ button {
 }
 
 .card-plan-wed::before {
-  background: #3b82f6;
+  background: var(--band-wed);
 }
 
 .card-plan-fri::before {
-  background: #8b5cf6;
+  background: var(--band-fri);
 }
 
 .card-review::before {
-  background: #d4a72c;
+  background: var(--stage-review);
 }
 
 /* A plan card taken into work (assigned on the board) gets a light-blue tint. */
 .card-plan-taken {
-  background: #f4f4f4;
+  background: var(--card-taken-bg);
 }
 
 /* Team avatars are dimmed to 50% by default; only cards of the currently
@@ -518,7 +858,7 @@ button {
   border: none;
   border-radius: 50%;
   background: var(--faint);
-  color: #fff;
+  color: var(--on-accent);
   font-size: 12px;
   line-height: 14px;
   text-align: center;
@@ -534,7 +874,7 @@ button {
 }
 
 .card-delete:hover {
-  background: var(--danger);
+  background: var(--danger-emphasis);
 }
 
 /* Open: a round corner button over the top-right (mirror of the old delete). */
@@ -547,7 +887,7 @@ button {
   border: none;
   border-radius: 50%;
   background: var(--faint);
-  color: #fff;
+  color: var(--on-accent);
   font-size: 11px;
   line-height: 14px;
   text-align: center;
@@ -563,12 +903,12 @@ button {
 }
 
 .card-open:hover {
-  background: var(--accent);
+  background: var(--accent-emphasis);
 }
 
 .card-action-delete:hover {
   color: var(--danger);
-  background: rgba(207, 34, 46, 0.1);
+  background: var(--danger-tint);
 }
 
 /* lock-with-note popup inside the status menu */
@@ -744,7 +1084,7 @@ button {
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  color: #fff;
+  color: var(--on-accent);
   font-size: 9px;
   font-weight: 600;
   display: flex;
@@ -890,7 +1230,7 @@ button.team-avatar {
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(27, 31, 36, 0.18);
+  box-shadow: 0 4px 12px var(--elev-2);
   padding: 3px;
   z-index: 20;
   display: flex;
@@ -962,7 +1302,7 @@ button.team-avatar {
 }
 
 .impersonate-reset:hover {
-  color: #cf222e;
+  color: var(--danger);
 }
 
 .card-stage-item .avatar-img {
@@ -1069,24 +1409,24 @@ button.card-age {
 }
 
 .rcal-in {
-  background: #dbeafe;
+  background: var(--cal-range-bg);
   border-radius: 0;
 }
 
 .rcal-start,
 .rcal-end {
-  background: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  color: var(--on-accent);
   border-radius: 4px;
 }
 
 .card-dates-save {
   margin-top: 4px;
   padding: 3px 8px;
-  border: 1px solid var(--accent);
+  border: 1px solid var(--accent-emphasis);
   border-radius: 4px;
-  background: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  color: var(--on-accent);
   font-size: 12px;
   cursor: pointer;
 }
@@ -1152,7 +1492,7 @@ button.card-age {
   height: 16px;
   border-radius: 50%;
   background: var(--line);
-  color: #24292f;
+  color: var(--avatar-fg);
   font-size: 9px;
   font-weight: 600;
   display: flex;
@@ -1161,8 +1501,8 @@ button.card-age {
 }
 
 .avatar-me {
-  background: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  color: var(--on-accent);
 }
 
 .avatar-img {
@@ -1239,9 +1579,9 @@ button.card-age {
   width: 11px;
   height: 11px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--handle-bg);
   border: 2px solid var(--accent);
-  box-shadow: 0 1px 2px rgba(27, 31, 36, 0.3);
+  box-shadow: 0 1px 2px var(--handle-shadow);
   cursor: ew-resize;
   opacity: 0;
   transition: opacity 0.1s;
@@ -1297,7 +1637,7 @@ button.card-age {
 }
 
 .card-action:hover {
-  background: rgba(27, 31, 36, 0.08);
+  background: var(--hover-overlay);
   color: var(--fg);
 }
 
@@ -1333,7 +1673,7 @@ button.card-age {
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(27, 31, 36, 0.18);
+  box-shadow: 0 4px 12px var(--elev-2);
   padding: 3px;
   z-index: 10;
   display: flex;
@@ -1372,7 +1712,7 @@ button.card-age {
 
 /* "Send to review" sits apart from the stage options, with its amber accent. */
 .card-stage-send-review {
-  color: #b8860b;
+  color: var(--amber);
   border-top: 1px solid var(--line-soft);
   margin-top: 1px;
 }
@@ -1410,7 +1750,7 @@ button.card-age {
 }
 
 .add-card:hover {
-  background: rgba(27, 31, 36, 0.05);
+  background: var(--hover-overlay-soft);
   opacity: 1;
 }
 
@@ -1428,7 +1768,7 @@ button.card-age {
   width: 300px;
   flex: none;
   border-left: 1px solid var(--line);
-  background: #fbfcfd;
+  background: var(--notes-bg);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -1544,9 +1884,9 @@ button.card-age {
 }
 
 .notes-group-btn-on {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+  background: var(--accent-emphasis);
+  border-color: var(--accent-emphasis);
+  color: var(--on-accent);
 }
 
 /* "By card" grouping: a card-title sub-header above its notes. */
@@ -1659,7 +1999,7 @@ button.card-age {
 }
 
 .note-action-delete:hover {
-  color: #cf222e;
+  color: var(--danger);
 }
 
 .note-edit {
@@ -1810,7 +2150,7 @@ button.card-age {
 .team-weekly-progress-fill,
 .me-day-progress-fill {
   height: 100%;
-  background: #3fb950;
+  background: var(--bar-default);
   transition: width 0.2s;
 }
 
@@ -1835,11 +2175,11 @@ button.card-age {
 }
 
 .team-weekly-wed {
-  background: #eef4fb;
+  background: var(--band-wed-bg);
 }
 
 .team-weekly-fri {
-  background: #f3eefb;
+  background: var(--band-fri-bg);
   border-left: 1px dashed var(--line);
 }
 
@@ -1916,7 +2256,7 @@ button.card-age {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(27, 31, 36, 0.45);
+  background: var(--scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1930,7 +2270,7 @@ button.card-age {
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: 8px;
-  box-shadow: 0 12px 40px rgba(27, 31, 36, 0.28);
+  box-shadow: 0 12px 40px var(--elev-3);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -2121,8 +2461,8 @@ button.card-age {
 }
 
 .teams-manage-row-dragging {
-  background: #fff;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.14);
+  background: var(--bg-raised);
+  box-shadow: 0 2px 10px var(--drag-shadow);
   border-radius: 4px;
 }
 
@@ -2184,8 +2524,8 @@ button.card-age {
 }
 
 .teams-manage-del:hover:not(:disabled) {
-  color: #e5484d;
-  border-color: #e5484d;
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .teams-manage-add {
@@ -2314,7 +2654,7 @@ button.card-age {
 
 .card-peer-selected {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.35);
+  box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
 /* The presence wrapper must not occupy a flex slot in the card row (its gap
@@ -2339,9 +2679,9 @@ button.card-age {
   justify-content: center;
   width: 14px;
   height: 14px;
-  border: 1px solid #b8860b;
+  border: 1px solid var(--amber);
   border-radius: 50%;
-  color: #b8860b;
+  color: var(--amber);
   font-size: 9px;
   font-weight: 700;
   line-height: 1;
@@ -2361,7 +2701,7 @@ button.card-age {
 }
 .note-event-body {
   font-size: 11px;
-  color: #656d76;
+  color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
 
@@ -2403,22 +2743,22 @@ button.card-age {
 .modal-log-date {
   font-size: 11px;
   font-weight: 600;
-  color: #8c959f;
+  color: var(--faint);
   margin: 8px 0 2px;
 }
 .modal-log-row {
   font-size: 12px;
-  color: #1f2328;
+  color: var(--fg);
   padding: 1px 0;
   white-space: pre-wrap;
 }
 .modal-log-event {
-  color: #656d76;
+  color: var(--muted);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
 .modal-log-time {
-  color: #8c959f;
+  color: var(--faint);
   margin-right: 6px;
   font-variant-numeric: tabular-nums;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -24,6 +24,10 @@
 
 /* ---- light + default (the base; all variables are declared here) ---- */
 :root {
+  /* Tell the UA which scheme it renders native chrome in (form-control
+     backgrounds, the date-picker popup, scrollbars, caret): without this every
+     unstyled input and native widget stays light inside the dark theme. */
+  color-scheme: light;
   --fg: #1f2328;
   --muted: #57606a;
   --faint: #8c959f;
@@ -116,6 +120,14 @@
   --stage-recurrent: #0072b2;
   --stage-done: #007a59;
   --bar-default: #009e73;
+
+  /* Weekly-plan deadline bands. The default blue/violet pair collapses on the
+     red-green axis (violet minus its red content reads as blue), so the Fri
+     band moves to Okabe-Ito reddish-purple, pairwise safe against the blue. */
+  --band-wed: #0072b2;
+  --band-fri: #cc79a7;
+  --band-wed-bg: #e8f1f8;
+  --band-fri-bg: #f9edf4;
 }
 
 /* ---- light + marine (blue-yellow-friendly) ----
@@ -135,6 +147,14 @@
   --stage-recurrent: #1f6feb;
   --stage-done: #2596b5;
   --bar-default: #2596b5;
+
+  /* Weekly-plan deadline bands: under tritanopia violet drifts toward the
+     blues, so the Fri band moves to reddish-purple (red survives the missing
+     S-cone) while Wed stays blue. */
+  --band-wed: #0072b2;
+  --band-fri: #cc79a7;
+  --band-wed-bg: #e8f1f8;
+  --band-fri-bg: #f9edf4;
 }
 
 /* ---- dark base (dark + default) ----
@@ -143,6 +163,7 @@
    text on top); their pairwise separation for the CVD palettes is carried by
    both hue and lightness. */
 :root[data-theme="dark"] {
+  color-scheme: dark;
   --fg: #e6edf3;
   --muted: #9198a1;
   --faint: #868f99;
@@ -219,6 +240,12 @@
   --stage-recurrent: #58a6ff;
   --stage-done: #2ec4a6;
   --bar-default: #2ec4a6;
+
+  /* Weekly-plan bands, dark variants of the light-vivid pair. */
+  --band-wed: #58a9ff;
+  --band-fri: #e592c2;
+  --band-wed-bg: #10233b;
+  --band-fri-bg: #331b2b;
 }
 
 /* ---- dark + marine (blue-yellow-friendly) ---- */
@@ -237,6 +264,12 @@
   --stage-recurrent: #79c0ff;
   --stage-done: #56b6c2;
   --bar-default: #56b6c2;
+
+  /* Weekly-plan bands, dark variants of the light-marine pair. */
+  --band-wed: #58a9ff;
+  --band-fri: #e592c2;
+  --band-wed-bg: #10233b;
+  --band-fri-bg: #331b2b;
 }
 
 * {
@@ -261,6 +294,19 @@ body {
 
 button {
   font-family: inherit;
+  /* Buttons do not inherit text colour by default (UA buttontext is black);
+     inherit the themed foreground so dark mode never paints dark-on-dark. */
+  color: inherit;
+}
+
+/* Form fields follow the theme tokens; unstyled ones otherwise keep the UA
+   field look, which stays white inside the dark theme. Class rules still win
+   (element-level specificity), and in light mode this matches the UA colours. */
+input,
+textarea,
+select {
+  color: var(--fg);
+  background: var(--bg);
 }
 
 /* ---- shell ---- */
@@ -339,18 +385,6 @@ button {
   color: var(--faint);
 }
 
-.login-logout {
-  margin-left: 10px;
-  font-size: 12px;
-  color: var(--muted);
-  text-decoration: none;
-}
-
-.login-logout:hover {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
 .account {
   display: flex;
   align-items: center;
@@ -422,6 +456,13 @@ button {
   padding: 4px 8px;
   border-radius: 4px;
   cursor: pointer;
+  /* Items may be links (Sign out) as well as buttons. */
+  text-decoration: none;
+}
+
+.appearance-sep {
+  border-top: 1px solid var(--line-soft);
+  margin: 4px 0;
 }
 
 .appearance-item:hover {
@@ -1219,11 +1260,9 @@ button.team-avatar {
   flex: none;
 }
 
+/* Portalled to <body> via Dropdown (which positions it), so overflow/scroll
+   ancestors of the zone can never clip the roster. */
 .add-card-team-menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 3px;
   min-width: 130px;
   max-height: 220px;
   overflow-y: auto;
@@ -1232,7 +1271,6 @@ button.team-avatar {
   border-radius: 6px;
   box-shadow: 0 4px 12px var(--elev-2);
   padding: 3px;
-  z-index: 20;
   display: flex;
   flex-direction: column;
   gap: 1px;

--- a/web/src/theme-contrast.test.ts
+++ b/web/src/theme-contrast.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// These tests read the real stylesheet, resolve the theme/palette variable
+// cascade for each of the six (theme × palette) cells, and assert WCAG contrast.
+// They exist because the appearance palettes make concrete colour claims that a
+// code review can't verify by eye and that jsdom can't check (it doesn't resolve
+// var()); encoding them here turns the design intent into an enforced invariant.
+
+const css = readFileSync(fileURLToPath(new URL("./styles.css", import.meta.url)), "utf8");
+
+/** Parse every `selector { ... }` block into a map of its --custom: value pairs. */
+function blocks(): Map<string, Map<string, string>> {
+  const out = new Map<string, Map<string, string>>();
+  // Strip comments first: a comment before a rule would otherwise be captured as
+  // part of the following selector and break the exact-key lookups below.
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const re = /([^{}]+)\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(clean))) {
+    const sel = m[1].trim().replace(/\s+/g, " ");
+    const vars = new Map<string, string>();
+    for (const decl of m[2].split(";")) {
+      const mm = decl.match(/^\s*(--[a-z0-9-]+)\s*:\s*(.+?)\s*$/i);
+      if (mm) {
+        vars.set(mm[1], mm[2].trim());
+      }
+    }
+    if (vars.size) {
+      out.set(sel, vars);
+    }
+  }
+  return out;
+}
+
+const B = blocks();
+
+/** Merge the given selectors' variables in cascade order (later wins), then
+ *  resolve one variable, following at most a couple of var() hops to a hex. */
+function resolve(name: string, selectors: string[]): string {
+  const merged = new Map<string, string>();
+  for (const sel of selectors) {
+    const vars = B.get(sel);
+    if (vars) {
+      for (const [k, v] of vars) {
+        merged.set(k, v);
+      }
+    }
+  }
+  let value = merged.get(name);
+  for (let i = 0; i < 4 && value && value.startsWith("var("); i++) {
+    const ref = value.slice(4, value.indexOf(")")).split(",")[0].trim();
+    value = merged.get(ref);
+  }
+  if (!value || !/^#[0-9a-f]{3,6}$/i.test(value)) {
+    throw new Error(`could not resolve ${name} to a hex (got ${value})`);
+  }
+  return value;
+}
+
+function toRgb(hex: string): [number, number, number] {
+  let h = hex.slice(1);
+  if (h.length === 3) {
+    h = h.split("").map((c) => c + c).join("");
+  }
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function luminance(hex: string): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const [r, g, b] = toRgb(hex);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+const LIGHT = [":root"];
+const DARK = [":root", ':root[data-theme="dark"]'];
+const cell = {
+  "light default": LIGHT,
+  "light vivid": [":root", ':root[data-palette="vivid"]'],
+  "light marine": [":root", ':root[data-palette="marine"]'],
+  "dark default": DARK,
+  "dark vivid": [":root", ':root[data-palette="vivid"]', ':root[data-theme="dark"]', ':root[data-theme="dark"][data-palette="vivid"]'],
+  "dark marine": [":root", ':root[data-palette="marine"]', ':root[data-theme="dark"]', ':root[data-theme="dark"][data-palette="marine"]'],
+};
+const ZONE_BGS = ["--zone-red-bg", "--zone-yellow-bg", "--zone-gray-bg", "--zone-green-bg"];
+
+// AA is 4.5 for normal text, 3.0 for large/secondary. --fg is body text (held
+// to AAA 7), --muted is secondary text (AA 4.5). --faint is the dim tier
+// (placeholders, tiny uppercase captions): in light it is the app's long-
+// standing ~3:1 caption grey (AA-large), and dark must not undershoot it — dark
+// --faint is held to the stricter 4.5 since it was raised there to clear AA.
+describe("base text contrast", () => {
+  for (const [name, sels, faintMin] of [
+    ["light", LIGHT, 3.0],
+    ["dark", DARK, 4.5],
+  ] as const) {
+    it(`${name}: fg/muted/faint clear their contrast floor on the background`, () => {
+      const bg = resolve("--bg", sels);
+      expect(contrast(resolve("--fg", sels), bg)).toBeGreaterThanOrEqual(7);
+      expect(contrast(resolve("--muted", sels), bg)).toBeGreaterThanOrEqual(4.5);
+      expect(contrast(resolve("--faint", sels), bg)).toBeGreaterThanOrEqual(faintMin);
+    });
+  }
+});
+
+describe("white label on solid accent/danger fills", () => {
+  for (const [name, sels] of [["light", LIGHT], ["dark", DARK]] as const) {
+    it(`${name}: on-accent text clears AA on the emphasis fills`, () => {
+      const white = resolve("--on-accent", sels);
+      expect(contrast(white, resolve("--accent-emphasis", sels))).toBeGreaterThanOrEqual(4.5);
+      expect(contrast(white, resolve("--danger-emphasis", sels))).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});
+
+// The spine label is the only text that sits on a zone fill; in the CVD palettes
+// and dark mode it is painted --fg, and must stay readable on every zone.
+describe("zone spine contrast where the spine is --fg", () => {
+  for (const name of ["light vivid", "light marine", "dark default", "dark vivid", "dark marine"] as const) {
+    it(`${name}: --fg clears AA on all four zone fills`, () => {
+      const sels = cell[name];
+      const fg = resolve("--fg", sels);
+      for (const zoneBg of ZONE_BGS) {
+        expect(contrast(fg, resolve(zoneBg, sels)), `${name} ${zoneBg}`).toBeGreaterThanOrEqual(4.5);
+      }
+    });
+  }
+});
+
+// Regression guard for the var()-locality bug: the spine must read --zone-accent
+// directly (resolved on the zone, where it is set inline), never through a
+// :root-declared --zone-spine-color indirection (which resolves against a
+// missing --zone-accent on :root and silently falls back to inherited --fg).
+describe("spine colour wiring", () => {
+  it("reads --zone-accent directly and keeps no --zone-spine-color indirection", () => {
+    expect(css).not.toContain("--zone-spine-color");
+    const spineRule = css.slice(css.indexOf(".zone-spine {"));
+    const body = spineRule.slice(0, spineRule.indexOf("}"));
+    expect(body).toContain("color: var(--zone-accent)");
+  });
+});

--- a/web/src/theme.test.ts
+++ b/web/src/theme.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_APPEARANCE,
+  LS_MODE,
+  LS_PALETTE,
+  PALETTE_ATTR,
+  THEME_ATTR,
+  applyAppearance,
+  persistAppearance,
+  readAppearance,
+  resolveTheme,
+} from "./theme";
+
+function fakeStorage(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    read: (k: string) => map.get(k) ?? null,
+  };
+}
+
+function fakeRoot() {
+  const attrs = new Map<string, string>();
+  return {
+    setAttribute: (n: string, v: string) => void attrs.set(n, v),
+    get: (n: string) => attrs.get(n) ?? null,
+  };
+}
+
+describe("readAppearance", () => {
+  it("defaults to system + default when nothing is stored", () => {
+    expect(readAppearance(fakeStorage())).toEqual(DEFAULT_APPEARANCE);
+  });
+
+  it("reads valid stored values on both axes", () => {
+    const s = fakeStorage({ [LS_MODE]: "dark", [LS_PALETTE]: "vivid" });
+    expect(readAppearance(s)).toEqual({ mode: "dark", palette: "vivid" });
+  });
+
+  it("falls back per-axis for unrecognised values", () => {
+    expect(readAppearance(fakeStorage({ [LS_MODE]: "neon", [LS_PALETTE]: "marine" }))).toEqual({
+      mode: "system",
+      palette: "marine",
+    });
+    expect(readAppearance(fakeStorage({ [LS_MODE]: "light", [LS_PALETTE]: "garish" }))).toEqual({
+      mode: "light",
+      palette: "default",
+    });
+  });
+});
+
+describe("persistAppearance", () => {
+  it("round-trips through readAppearance", () => {
+    const s = fakeStorage();
+    persistAppearance(s, { mode: "light", palette: "marine" });
+    expect(s.read(LS_MODE)).toBe("light");
+    expect(s.read(LS_PALETTE)).toBe("marine");
+    expect(readAppearance(s)).toEqual({ mode: "light", palette: "marine" });
+  });
+
+  it("swallows storage failures instead of throwing", () => {
+    const throwing = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+    expect(() => persistAppearance(throwing, DEFAULT_APPEARANCE)).not.toThrow();
+  });
+});
+
+describe("resolveTheme", () => {
+  it("passes explicit light/dark through unchanged", () => {
+    expect(resolveTheme("light", true)).toBe("light");
+    expect(resolveTheme("dark", false)).toBe("dark");
+  });
+
+  it("follows the OS preference only for system mode", () => {
+    expect(resolveTheme("system", true)).toBe("dark");
+    expect(resolveTheme("system", false)).toBe("light");
+  });
+});
+
+describe("applyAppearance", () => {
+  it("writes the resolved theme and palette attributes", () => {
+    const root = fakeRoot();
+    applyAppearance(root, { mode: "system", palette: "vivid" }, true);
+    expect(root.get(THEME_ATTR)).toBe("dark");
+    expect(root.get(PALETTE_ATTR)).toBe("vivid");
+
+    applyAppearance(root, { mode: "light", palette: "default" }, true);
+    expect(root.get(THEME_ATTR)).toBe("light");
+    expect(root.get(PALETTE_ATTR)).toBe("default");
+  });
+});

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,72 @@
+// Appearance preferences: a light/dark theme mode and a colour palette. Both
+// are persisted in localStorage (like the app's other UI prefs) and applied as
+// data-theme / data-palette attributes on <html>, which styles.css keys on.
+//
+// The palette axis is where the accessibility support lives: `vivid` is a
+// red-green-friendly palette and `marine` a blue-yellow-friendly one, both
+// verified against colour-vision-deficiency simulations. The on-screen labels
+// stay purely aesthetic (Default / Vivid / Marine) so choosing one reveals
+// nothing about the person choosing it.
+
+export type ThemeMode = "light" | "dark" | "system";
+export type Palette = "default" | "vivid" | "marine";
+export type ResolvedTheme = "light" | "dark";
+
+export interface Appearance {
+  mode: ThemeMode;
+  palette: Palette;
+}
+
+export const LS_MODE = "aeman.themeMode";
+export const LS_PALETTE = "aeman.palette";
+export const THEME_ATTR = "data-theme";
+export const PALETTE_ATTR = "data-palette";
+
+export const THEME_MODES: readonly ThemeMode[] = ["light", "dark", "system"];
+export const PALETTES: readonly Palette[] = ["default", "vivid", "marine"];
+
+export const DEFAULT_APPEARANCE: Appearance = { mode: "system", palette: "default" };
+
+type StorageReader = Pick<Storage, "getItem">;
+type StorageWriter = Pick<Storage, "setItem">;
+type AttrRoot = Pick<Element, "setAttribute">;
+
+function oneOf<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T {
+  return (allowed as readonly string[]).includes(value ?? "") ? (value as T) : fallback;
+}
+
+/** readAppearance validates both axes against their allowed values, falling
+ *  back to the defaults for anything missing or unrecognised. */
+export function readAppearance(storage: StorageReader): Appearance {
+  return {
+    mode: oneOf(storage.getItem(LS_MODE), THEME_MODES, DEFAULT_APPEARANCE.mode),
+    palette: oneOf(storage.getItem(LS_PALETTE), PALETTES, DEFAULT_APPEARANCE.palette),
+  };
+}
+
+/** persistAppearance stores both axes, swallowing storage failures (quota,
+ *  private mode) the same way the rest of the app treats persisted prefs. */
+export function persistAppearance(storage: StorageWriter, appearance: Appearance): void {
+  try {
+    storage.setItem(LS_MODE, appearance.mode);
+    storage.setItem(LS_PALETTE, appearance.palette);
+  } catch {
+    // ignore persistence failures
+  }
+}
+
+/** resolveTheme turns the mode into a concrete light/dark, consulting the OS
+ *  preference only when the mode is "system". */
+export function resolveTheme(mode: ThemeMode, prefersDark: boolean): ResolvedTheme {
+  if (mode === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+  return mode;
+}
+
+/** applyAppearance writes the resolved theme and the palette onto the root
+ *  element as the attributes styles.css targets. */
+export function applyAppearance(root: AttrRoot, appearance: Appearance, prefersDark: boolean): void {
+  root.setAttribute(THEME_ATTR, resolveTheme(appearance.mode, prefersDark));
+  root.setAttribute(PALETTE_ATTR, appearance.palette);
+}

--- a/web/src/zones.ts
+++ b/web/src/zones.ts
@@ -15,38 +15,43 @@ export interface ZoneDef {
 //   green  - start only when every other zone is clear
 //   yellow - popped up unplanned during the day
 //   red    - must be resolved before the end of the working day
+//
+// Colours are CSS custom properties (defined in styles.css) rather than literal
+// hex so the opt-in colour-blind mode can repaint them via a single palette
+// override without any component change. accent drives spine/border; background
+// tints the area.
 export const ZONES: Record<ZoneKey, ZoneDef> = {
   gray: {
     key: "gray",
     title: "Planned",
     spine: "PLANNED",
     description: "Regular, planned work",
-    accent: "#8b949e",
-    background: "#f3f4f6",
+    accent: "var(--zone-gray-accent)",
+    background: "var(--zone-gray-bg)",
   },
   green: {
     key: "green",
     title: "If time left",
     spine: "NICE TO HAVE",
     description: "Start only when every other zone is clear",
-    accent: "#3fb950",
-    background: "#eafaef",
+    accent: "var(--zone-green-accent)",
+    background: "var(--zone-green-bg)",
   },
   yellow: {
     key: "yellow",
     title: "Unplanned",
     spine: "UNPLANNED",
     description: "Popped up unplanned during the day",
-    accent: "#d4a72c",
-    background: "#fdf6df",
+    accent: "var(--zone-yellow-accent)",
+    background: "var(--zone-yellow-bg)",
   },
   red: {
     key: "red",
     title: "Critical today",
     spine: "URGENT",
     description: "Must be resolved before the end of the day",
-    accent: "#f85149",
-    background: "#fdecea",
+    accent: "var(--zone-red-accent)",
+    background: "var(--zone-red-bg)",
   },
 };
 


### PR DESCRIPTION
## What

An appearance picker in the header, hanging off the nickname and styled like an ordinary theme menu. Two independent choices:

- **Theme** — Light / Dark / System (System follows the OS). Adds a full dark theme.
- **Colours** — Default / Vivid / Marine.

## Why

The board encodes zones (urgent / unplanned / planned / nice-to-have) and stages (locked / review / recurrent / done) with red / yellow / green, which several colour-vision deficiencies make hard to tell apart, and there was no dark theme. Vivid is a red-green-friendly palette and Marine a blue-yellow-friendly one; the on-screen labels stay purely aesthetic so picking one reveals nothing about the person picking it. Meaning never rests on colour alone — the zone spine labels and stage names carry it too.

## How it works

Two data attributes on `<html>` — `data-theme` and `data-palette` — that the stylesheet keys on. Every colour value became a CSS custom property, so the six theme-by-palette cells repaint the whole app with no component change; the light + default cell is byte-for-byte the previous look. The preference lives in `localStorage` and is applied before first paint.

The palette hex values were designed against colour-vision-deficiency simulations (deuteranopia / protanopia for Vivid, tritanopia for Marine) so no two zones collapse together on the relevant axis, and the dark theme's text/fill colours were checked for WCAG AA contrast.

## Testing

- `theme.ts` preference logic and the six-cell WCAG contrast invariants are unit-tested (the contrast test parses the real stylesheet and resolves the cascade for each cell); `typecheck` / `vitest` (26 pass) / `build` all green. CI now runs the web test suite.
- Reviewed by Opus and cross-checked with ChatGPT.

## Follow-ups (out of scope)

- A pre-mount inline script could remove the first-paint flash on load for dark users (the SPA is otherwise blank-until-JS).
- Arrow-key roving within the menu (Escape-to-close and `role="menu"` are in).
