### PR TITLE
feat(board): ask current-vs-next sprint for ahead-of-sprint creates

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -8,7 +8,7 @@ code** whenever the rules change.
 Code that implements these rules:
 - Frontend: `web/src/components/{TeamBoard,MeBoard,Card}.tsx`, `web/src/date.ts`,
   `web/src/sprint.ts`.
-- Go: `internal/board/{filters,date,sprint}.go`, `internal/boardservice/service.go`.
+- Go: `pkg/board/{filters,date,sprint}.go`, `pkg/boardservice/service.go`.
 
 ## Two dates per card
 
@@ -34,7 +34,8 @@ Also:
 
 `startDate` and `sprintStart` differ whenever a card is created on a later day of
 its sprint, or deferred with "+1 day" / "+1 week" (which pushes `startDate` past
-today while the card stays in its sprint).
+today while the card stays in its sprint). A "**next sprint**" create has **no
+`sprintStart` at all** until a Carry Over adopts it (see Create / Carry Over).
 
 ## Concepts
 
@@ -56,6 +57,15 @@ today while the card stays in its sprint).
   view.
 - First sprint: if the team has none yet, creating records the viewed day as its
   first sprint on the sprint-state card.
+- **Ahead of the sprint** (Team board, `selectedDate > currentSprint(team)`):
+  the day is ambiguous — a later day of the running sprint (two-day sprints) or
+  the next one (daily sprints) — so the board **asks**. "Current sprint" keeps
+  the rules above; "**next sprint**" creates the card with **no `sprintStart`**
+  (`noSprint` on the create API): it lives on its own day only and the first
+  Carry Over whose day reaches its `startDate` adopts it (see Carry Over). It
+  never appears on the old sprint's window.
+- **Me board creates never ask**: an engineer's own card always joins the
+  current sprint, so a lead reviewing the day sees what came up mid-sprint.
 
 ### Team view — a card's days (`selectedDate`)
 - A **materialized** card (`startDate <= today`) shows on its sprint's start day
@@ -83,6 +93,9 @@ today while the card stays in its sprint).
 - A **deferred / future-scheduled** card (`startDate > today`) is hidden until
   that day, then shows from it on (the next Carry Over re-syncs its sprint like
   any unfinished card).
+- A **sprint-less** day card (a "next sprint" create) shows from its
+  `startDate` on — the sprint gate above would otherwise hide it right when its
+  day arrives — until a Carry Over adopts it into a sprint.
 - The team-focus "eye" toggle further narrows to the selected teams (not
   persisted, off by default).
 
@@ -98,6 +111,11 @@ today while the card stays in its sprint).
 - A carried card keeps its `startDate`, so it stays visible on the days of the
   sprint it came from (see the Team / Me rules): Carry Over adds it to the new
   sprint without removing it from the previous one.
+- **Adoption**: unfinished **sprint-less** day cards ("next sprint" creates,
+  not plan cards) whose `startDate <= today` also get `sprintStart = today` —
+  they join the sprint this Carry Over opens, which is what "the next sprint"
+  meant when they were created. Ones still ahead of today wait for a later
+  Carry Over.
 
 ### Defer ("+1 day" / "+1 week")
 - The per-card control pushes **`startDate`** forward — counting from **today**

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -325,6 +325,9 @@ type createCardRequest struct {
 	} `json:"plan"`
 	ReviewOf       string `json:"reviewOf"`
 	StartNewSprint *bool  `json:"startNewSprint"`
+	// NoSprint schedules the card for its day without joining any sprint (a
+	// "next sprint" create); the next carry-over to reach its day adopts it.
+	NoSprint bool `json:"noSprint"`
 }
 
 func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
@@ -353,6 +356,7 @@ func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
 		SprintStart:    in.Dates.Sprint,
 		ReviewOf:       in.ReviewOf,
 		StartNewSprint: in.StartNewSprint,
+		NoSprint:       in.NoSprint,
 	}
 	if len(in.Assignees) > 0 {
 		args.Assignee = in.Assignees[0]

--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -90,6 +90,14 @@ func MeView(b Board, user, day string) []Card {
 			out = append(out, c)
 			continue
 		}
+		// A sprint-less day card (a "next sprint" create) stays visible from its
+		// scheduled day on — the sprint gate below would otherwise hide it right
+		// when its day arrives, until a carry-over adopts it into a sprint.
+		if c.SprintStart == "" && c.Plan == PlanNone && c.StartDate != "" &&
+			c.StartDate <= day {
+			out = append(out, c)
+			continue
+		}
 		as := ActiveSprint(b, c.Team, day)
 		// A card shows on every day of the sprints it spans — from the one it
 		// started in up to the sprint it now belongs to — so a carried-over card

--- a/pkg/board/filters_test.go
+++ b/pkg/board/filters_test.go
@@ -88,6 +88,9 @@ func meBoard() Board {
 		{ItemID: "uold", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-10", SprintStart: "2026-06-10"},
 		// Assigned to u but never placed in a sprint — must never show.
 		{ItemID: "u3", Assignees: []string{"u"}, Team: "A"},
+		// A "next sprint" create: sprint-less but scheduled — shows from its
+		// day on until a carry-over adopts it into a sprint.
+		{ItemID: "unext", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-27"},
 		// Someone else's current-sprint card.
 		{ItemID: "u4", Assignees: []string{"v"}, Team: "A", StartDate: "2026-06-26", SprintStart: "2026-06-26"},
 	})
@@ -101,7 +104,8 @@ func TestMeView(t *testing.T) {
 		want      []string
 	}{
 		{"current-sprint card shows on its sprint day", "u", "2026-06-26", []string{"u1"}},
-		{"deferred current-sprint card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture"}},
+		{"sprint-less scheduled card shows from its day on", "u", "2026-06-27", []string{"u1", "unext"}},
+		{"deferred current-sprint card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture", "unext"}},
 		{"rolling back shows the previous sprint, hides the current", "u", "2026-06-22", []string{"uprev"}},
 		{"before the previous sprint nothing shows", "u", "2026-06-19", []string{}},
 		{"empty user sees everyone in the active sprint", "", "2026-06-26", []string{"u1", "u4"}},

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -167,6 +167,11 @@ type CreateCardArgs struct {
 	// ReviewOf marks the new card as the review of the given item.
 	ReviewOf       string
 	StartNewSprint *bool
+	// NoSprint schedules the card for its day without joining any sprint — a
+	// "next sprint" create: the card lives on its own day only until the first
+	// carry-over whose day has reached the card's start adopts it into the
+	// sprint it opens.
+	NoSprint bool
 }
 
 // CreateCard creates a card with two dates: StartDate (its scheduled day) is the
@@ -233,24 +238,31 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 	} else if day == "" {
 		day = start
 	}
-	cur := board.CurrentSprint(b, args.Team)
-	startNew := cur == ""
-	if args.StartNewSprint != nil {
-		startNew = *args.StartNewSprint || cur == ""
-	}
 	sprint := args.SprintStart
-	if startNew {
-		// Record the new sprint and have the card join it (previous = the old
-		// current, which is "" when the team had no sprint yet — matching the
-		// frontend's setSprintState(team, day, null)).
-		if sprint == "" {
-			sprint = day
+	if args.NoSprint {
+		// A "next sprint" create: the card is scheduled for its day but joins
+		// no sprint (and starts none) — the first carry-over whose day reaches
+		// the card's start adopts it into the sprint it opens.
+		sprint = ""
+	} else {
+		cur := board.CurrentSprint(b, args.Team)
+		startNew := cur == ""
+		if args.StartNewSprint != nil {
+			startNew = *args.StartNewSprint || cur == ""
 		}
-		if err := s.backend.SetSprintState(ctx, b, args.Team, sprint, cur); err != nil {
-			return board.Card{}, err
+		if startNew {
+			// Record the new sprint and have the card join it (previous = the old
+			// current, which is "" when the team had no sprint yet — matching the
+			// frontend's setSprintState(team, day, null)).
+			if sprint == "" {
+				sprint = day
+			}
+			if err := s.backend.SetSprintState(ctx, b, args.Team, sprint, cur); err != nil {
+				return board.Card{}, err
+			}
+		} else if sprint == "" {
+			sprint = cur
 		}
-	} else if sprint == "" {
-		sprint = cur
 	}
 	// Start is the scheduled day; SprintStart is the sprint the card belongs to.
 	card, err := s.backend.CreateCard(ctx, b, board.CreateInput{
@@ -313,7 +325,18 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 	// finished recurrent card stays behind and reseeds a fresh copy instead.
 	var carry, reseed, relocate []board.Card
 	for _, c := range b.Cards {
-		if c.Team != team || old == "" || c.SprintStart != old {
+		if c.Team != team {
+			continue
+		}
+		// Adopt sprint-less day cards whose scheduled day has arrived (a "next
+		// sprint" create): they join the sprint this carry-over opens, which is
+		// what "the next sprint" meant when they were created.
+		if c.SprintStart == "" && c.Plan == board.PlanNone && c.StartDate != "" &&
+			c.StartDate <= today && !board.Complete(c.Stage, c.Progress) {
+			carry = append(carry, c)
+			continue
+		}
+		if old == "" || c.SprintStart != old {
 			continue
 		}
 		if c.Stage == board.StageRecurrent && c.Progress >= 100 {

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -349,6 +349,36 @@ func TestCreateCardForceNewSprintDemotesCurrent(t *testing.T) {
 	}
 }
 
+func TestCreateCardNextSprint(t *testing.T) {
+	f := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	// A "next sprint" create: scheduled for its day, joins no sprint and never
+	// touches the pointer — the next carry-over to reach the day adopts it.
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", Day: "2026-06-21", NoSprint: true}); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 0 {
+		t.Fatalf("a no-sprint create must not touch the pointer; log=%v", f.log)
+	}
+	if f.creates[0].Start != "2026-06-21" || f.creates[0].SprintStart != "" {
+		t.Fatalf("want Start 2026-06-21 / no SprintStart; got %+v", f.creates[0])
+	}
+}
+
+func TestCreateCardNoSprintSkipsFirstSprintRecord(t *testing.T) {
+	f := newFake(nil, nil)
+	// Even a team with no sprint yet must not have one started by a
+	// "next sprint" create.
+	if _, err := f2svc(f).CreateCard(ctx, "acme", 1, CreateCardArgs{Team: "alpha", Title: "task", NoSprint: true}); err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintState") != 0 {
+		t.Fatalf("a no-sprint create must not record a first sprint; log=%v", f.log)
+	}
+	if f.creates[0].SprintStart != "" {
+		t.Fatalf("create input = %+v", f.creates[0])
+	}
+}
+
 // --- CarryOver -------------------------------------------------------------
 
 func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
@@ -382,6 +412,36 @@ func TestCarryOverAdvancesAndCarriesUnfinished(t *testing.T) {
 	}
 	if f.get("c5").SprintStart != "2027-01-01" {
 		t.Fatalf("future-dated c5 should not carry: %+v", f.get("c5"))
+	}
+}
+
+func TestCarryOverAdoptsSprintlessDayCards(t *testing.T) {
+	old := "2026-01-01"
+	today := board.TodayIso()
+	f := newFake([]board.Card{
+		// A "next sprint" create whose day has arrived: adopted.
+		{ItemID: "n1", Team: "alpha", StartDate: today},
+		// Still ahead of today: stays sprint-less for a later carry-over.
+		{ItemID: "n2", Team: "alpha", StartDate: "2999-01-01"},
+		// A finished sprint-less card is not work to adopt.
+		{ItemID: "n3", Team: "alpha", StartDate: today, Stage: board.StageDone},
+		// A plan card without dates has no sprint by design.
+		{ItemID: "p1", Team: "alpha", Plan: board.PlanWed, Week: "2026-01-05"},
+		// Another team's sprint-less card is not this carry-over's business.
+		{ItemID: "n4", Team: "beta", StartDate: today},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.count("SetSprintStart") != 1 || !f.saw(fmt.Sprintf("SetSprintStart n1 %s", today)) {
+		t.Fatalf("only n1 should be adopted; log=%v", f.log)
+	}
+	if rep.Carried != 1 {
+		t.Fatalf("Carried = %d, want 1", rep.Carried)
+	}
+	if f.get("n2").SprintStart != "" || f.get("n3").SprintStart != "" {
+		t.Fatalf("future/finished sprint-less cards must stay: %+v %+v", f.get("n2"), f.get("n3"))
 	}
 }
 

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -216,6 +216,12 @@ export function MeBoard({
         ) {
           return true;
         }
+        // A sprint-less day card (a "next sprint" create) stays visible from
+        // its scheduled day on — the sprint gate below would otherwise hide it
+        // right when its day arrives, until a carry-over adopts it.
+        if (!c.sprintStart && !c.plan && c.startDate && c.startDate <= selectedDate) {
+          return true;
+        }
         const as = activeSprint(board, c.team ?? null, selectedDate);
         const ss = c.sprintStart;
         // A card shows on every day of the sprints it spans — from the one it

--- a/web/src/components/SprintChoiceDialog.tsx
+++ b/web/src/components/SprintChoiceDialog.tsx
@@ -1,0 +1,87 @@
+interface SprintChoiceDialogProps {
+  title: string;
+  /** The day the card is being created on. */
+  day: string;
+  /** The team's current sprint day the card would otherwise join. */
+  sprint: string;
+  onClose: () => void;
+  /** Called with the choice: false = join the current sprint, true = wait for
+   *  the next one (no sprint; the next carry-over to reach the day adopts it). */
+  onSubmit: (noSprint: boolean) => void;
+}
+
+/** SprintChoiceDialog asks where a card created ahead of the team's current
+ *  sprint belongs: only the lead knows whether the day is a later day of the
+ *  running sprint or the start of the next one. */
+export function SprintChoiceDialog({
+  title,
+  day,
+  sprint,
+  onClose,
+  onSubmit,
+}: SprintChoiceDialogProps) {
+  const pick = (noSprint: boolean) => {
+    onSubmit(noSprint);
+    onClose();
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className="modal modal-narrow"
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onClose();
+          }
+        }}
+      >
+        <div className="modal-header">
+          <h2 className="modal-title">Which sprint?</h2>
+          <button
+            type="button"
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <p className="sprint-choice-text">
+            “{title}” is scheduled for {day}, ahead of the current sprint (
+            {sprint}).
+          </p>
+          <div className="sprint-choice-options">
+            <button
+              type="button"
+              className="btn sprint-choice-btn"
+              autoFocus
+              onClick={() => pick(false)}
+            >
+              <strong>Current sprint</strong>
+              <span>
+                A later day of the running sprint — it shows with the sprint's
+                work right away.
+              </span>
+            </button>
+            <button
+              type="button"
+              className="btn sprint-choice-btn"
+              onClick={() => pick(true)}
+            >
+              <strong>Next sprint</strong>
+              <span>
+                Waits on its own day and joins the sprint the next carry over
+                starts.
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -30,6 +30,7 @@ import { AddCard } from "./AddCard";
 import { Dropdown } from "./Dropdown";
 import { TeamChips } from "./TeamChips";
 import { TeamsModal } from "./TeamsModal";
+import { SprintChoiceDialog } from "./SprintChoiceDialog";
 import { SortableBoard, type BoardGroup, type DropResult } from "./SortableBoard";
 import { globalOrderFromGroups, afterIdFor } from "./dndOrder";
 
@@ -116,6 +117,15 @@ export function TeamBoard({
   const sprintRef = useRef<HTMLDivElement | null>(null);
   const [carryWeekOpen, setCarryWeekOpen] = useState(false);
   const carryWeekRef = useRef<HTMLDivElement | null>(null);
+  // A create on a day ahead of the team's current sprint waits here for the
+  // lead's current-vs-next-sprint choice (null = no dialog open).
+  const [sprintChoice, setSprintChoice] = useState<{
+    engineer: string;
+    zone: ZoneKey;
+    title: string;
+    team: string | null;
+    sprint: string;
+  } | null>(null);
   const [columnOrder, setColumnOrder] = useState<string[]>(() => {
     try {
       const v = localStorage.getItem("aeman.columnOrder");
@@ -1284,9 +1294,10 @@ export function TeamBoard({
     team: string | null,
     startDate: string,
     day: string,
+    noSprint = false,
   ) => {
     const sprint = currentSprint(board, team);
-    const firstSprint = sprint === null;
+    const firstSprint = !noSprint && sprint === null;
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
       itemId: tempId,
@@ -1296,7 +1307,7 @@ export function TeamBoard({
       zone,
       day,
       startDate,
-      sprintStart: sprint ?? startDate,
+      sprintStart: noSprint ? undefined : (sprint ?? startDate),
       team: team ?? undefined,
       createdAt: new Date().toISOString(),
       description: "",
@@ -1310,6 +1321,7 @@ export function TeamBoard({
       start: startDate,
       assigneeLogin: engineer || null,
       team,
+      noSprint: noSprint || undefined,
     });
     registerPendingCard(
       tempId,
@@ -1337,13 +1349,22 @@ export function TeamBoard({
 
   // Creating a Team card is scheduled for the viewed day as a one-day range —
   // a backdated create with day = today would stretch onto today's board. The
-  // sprint join (and the first-sprint record) happens server-side.
+  // sprint join (and the first-sprint record) happens server-side. A day ahead
+  // of the team's current sprint is ambiguous — a later day of the running
+  // sprint (two-day sprints) or the next one (daily sprints)? Only the lead
+  // knows, so ask; "next sprint" creates the card without a sprint and the
+  // next carry over to reach its day adopts it.
   const handleCreate = (
     engineer: string,
     zone: ZoneKey,
     title: string,
     team?: string | null,
   ) => {
+    const sprint = currentSprint(board, team ?? null);
+    if (sprint !== null && selectedDate > sprint) {
+      setSprintChoice({ engineer, zone, title, team: team ?? null, sprint });
+      return;
+    }
     createTeamCard(
       engineer,
       zone,
@@ -1391,13 +1412,15 @@ export function TeamBoard({
     // advanced sprint and blank the board. Only the closing (current) sprint's
     // unfinished cards carry, mirroring boardservice.CarryOver.
     for (const c of board.cards) {
-      if (
-        (team === null ? c.team == null : c.team === team) &&
-        !!old &&
-        c.sprintStart === old &&
-        !isComplete(c) &&
-        !c.itemId.startsWith("tmp-")
-      ) {
+      const sameTeam = team === null ? c.team == null : c.team === team;
+      if (!sameTeam || isComplete(c) || c.itemId.startsWith("tmp-")) {
+        continue;
+      }
+      // Sprint-less day cards whose day has arrived ("next sprint" creates)
+      // are adopted by the sprint being started, mirroring CarryOver.
+      const adopted =
+        !c.sprintStart && !c.plan && !!c.startDate && c.startDate <= today;
+      if (adopted || (!!old && c.sprintStart === old)) {
         patchCard(c.itemId, { sprintStart: today });
       }
     }
@@ -1880,6 +1903,25 @@ export function TeamBoard({
           onRemove={onRemoveTeam}
           onReorder={onReorderTeams}
           onClose={() => setTeamsModalOpen(false)}
+        />
+      )}
+      {sprintChoice && (
+        <SprintChoiceDialog
+          title={sprintChoice.title}
+          day={selectedDate}
+          sprint={sprintChoice.sprint}
+          onClose={() => setSprintChoice(null)}
+          onSubmit={(noSprint) =>
+            createTeamCard(
+              sprintChoice.engineer,
+              sprintChoice.zone,
+              sprintChoice.title,
+              sprintChoice.team,
+              selectedDate,
+              selectedDate,
+              noSprint,
+            )
+          }
         />
       )}
     </div>

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -210,6 +210,9 @@ export const apiProvider: Provider = {
     if (input.startNewSprint !== undefined) {
       body.startNewSprint = input.startNewSprint;
     }
+    if (input.noSprint) {
+      body.noSprint = true;
+    }
     return cardFrom(board, "POST", "/cards", body);
   },
 

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -92,6 +92,9 @@ export interface NewCardInput {
   reviewOf?: string | null;
   /** Force the team's sprint pointer to (re)start on the card's day. */
   startNewSprint?: boolean;
+  /** Schedule the card for its day without joining any sprint (a "next
+   * sprint" create); the next carry-over to reach its day adopts it. */
+  noSprint?: boolean;
 }
 
 /** SprintState is a team's explicit sprint pointer: its current and previous

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1936,6 +1936,36 @@ button.card-age {
   overflow: hidden;
 }
 
+.modal-narrow {
+  width: 440px;
+}
+
+.sprint-choice-text {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.sprint-choice-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sprint-choice-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  text-align: left;
+  padding: 10px 12px;
+}
+
+.sprint-choice-btn span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .modal-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

A Team-board card created on a day ahead of the team's current sprint is ambiguous: is it a later day of the running sprint (two-day sprints) or the next one (daily sprints)? It always joined the current sprint, so a card planned for tomorrow polluted the old sprint's window once its day arrived — right during the morning standup review. Only the lead knows the intent, so the Team board now asks: **Current sprint** keeps today's behaviour; **Next sprint** creates the card without a sprint (`noSprint` on the create API).

A sprint-less scheduled card lives on its own day, stays visible on the Me board from that day on, and is adopted by the first carry-over whose day reaches its start — joining the sprint it opens, which is what "the next sprint" meant at creation. Me-board creates are untouched: engineers' own cards always join the current sprint, so leads reviewing the day still see what came up mid-sprint.

`docs/dates.md` is updated with the new create, Me-view, and carry-over rules.