### PR TITLE
fix(web): drop the duplicate separator before Sign out

### DIFF
--- a/web/src/components/AppearanceMenu.tsx
+++ b/web/src/components/AppearanceMenu.tsx
@@ -119,7 +119,6 @@ export function AppearanceMenu({
         </div>
         {logoutUrl && (
           <div className="appearance-group" role="group" aria-label="Account">
-            <div className="appearance-sep" aria-hidden="true" />
             <a role="menuitem" className="appearance-item" href={logoutUrl}>
               <span className="appearance-check" aria-hidden="true" />
               Sign out

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -460,11 +460,6 @@ select {
   text-decoration: none;
 }
 
-.appearance-sep {
-  border-top: 1px solid var(--line-soft);
-  margin: 4px 0;
-}
-
 .appearance-item:hover {
   background: var(--bg-soft);
 }


### PR DESCRIPTION
Adjacent appearance-menu groups already draw a divider via CSS; the explicit separator element above the Account group doubled it.