### PR TITLE
fix(review): land review cards in the reviewer's unplanned zone

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -655,12 +655,19 @@ func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
 	var in struct {
 		Reviewer string `json:"reviewer"`
 		Day      string `json:"day"`
+		// Zone places the review card explicitly (the Me board sends it to the
+		// reviewer's unplanned zone); empty keeps the original's zone.
+		Zone string `json:"zone"`
 	}
 	if !decodeJSON(w, r, &in) {
 		return
 	}
 	if in.Reviewer == "" {
 		writeJSONError(w, http.StatusUnprocessableEntity, "reviewer is required")
+		return
+	}
+	zone, ok := parseZone(w, in.Zone)
+	if !ok {
 		return
 	}
 	svc, owner, project, ok := s.service(w, r)
@@ -676,7 +683,7 @@ func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, c := range b.Cards {
 		if c.ReviewOf == uid {
-			if err := svc.ReassignReviewer(ctx, owner, project, uid, in.Reviewer, in.Day); err != nil {
+			if err := svc.ReassignReviewer(ctx, owner, project, uid, in.Reviewer, in.Day, zone); err != nil {
 				s.apiError(w, err)
 				return
 			}
@@ -684,7 +691,7 @@ func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	review, err := svc.SendToReview(ctx, owner, project, uid, in.Reviewer, in.Day)
+	review, err := svc.SendToReview(ctx, owner, project, uid, in.Reviewer, in.Day, zone)
 	if err != nil {
 		s.apiError(w, err)
 		return

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1079,8 +1079,9 @@ func (s *Service) syncReviewLink(ctx context.Context, b board.Board, card board.
 // --- Review linkage --------------------------------------------------------
 
 // SendToReview creates a linked review card for a reviewer (in the original's
-// zone/team) and puts the original on the review stage, returning the review
-// card. day = "" is today. It mirrors handleSendToReview in TeamBoard.tsx.
+// team, landing in the unplanned zone) and puts the original on the review
+// stage, returning the review card. day = "" is today. It mirrors
+// handleSendToReview in TeamBoard.tsx / MeBoard.tsx.
 func (s *Service) SendToReview(ctx context.Context, owner string, project int, itemID, reviewer, day string) (board.Card, error) {
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
@@ -1094,10 +1095,10 @@ func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Ca
 	if day == "" {
 		day = board.TodayIso()
 	}
-	zone := card.Zone
-	if zone == "" {
-		zone = board.ZoneGray
-	}
+	// The review card lands in the reviewer's unplanned (yellow) zone: for the
+	// reviewer this work popped up during the day, whatever zone the original
+	// occupies on its author's board.
+	zone := board.ZoneYellow
 	// A review card belongs to the SAME sprint as the card it reviews, not
 	// merely the team's current pointer — otherwise a card being reviewed in an
 	// older, not-yet-carried sprint would get a review card in a different

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1079,26 +1079,30 @@ func (s *Service) syncReviewLink(ctx context.Context, b board.Board, card board.
 // --- Review linkage --------------------------------------------------------
 
 // SendToReview creates a linked review card for a reviewer (in the original's
-// team, landing in the unplanned zone) and puts the original on the review
-// stage, returning the review card. day = "" is today. It mirrors
+// team) and puts the original on the review stage, returning the review card.
+// day = "" is today. zone places the review card explicitly — the Me board
+// sends the reviewer's copy to their unplanned zone — while "" keeps the
+// original's zone (the Team board's and MCP's behaviour). It mirrors
 // handleSendToReview in TeamBoard.tsx / MeBoard.tsx.
-func (s *Service) SendToReview(ctx context.Context, owner string, project int, itemID, reviewer, day string) (board.Card, error) {
+func (s *Service) SendToReview(ctx context.Context, owner string, project int, itemID, reviewer, day string, zone board.ZoneKey) (board.Card, error) {
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return board.Card{}, err
 	}
-	return s.sendToReview(ctx, b, card, reviewer, day)
+	return s.sendToReview(ctx, b, card, reviewer, day, zone)
 }
 
 // sendToReview is the create-review-card half of SendToReview over a loaded board.
-func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Card, reviewer, day string) (board.Card, error) {
+func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Card, reviewer, day string, zone board.ZoneKey) (board.Card, error) {
 	if day == "" {
 		day = board.TodayIso()
 	}
-	// The review card lands in the reviewer's unplanned (yellow) zone: for the
-	// reviewer this work popped up during the day, whatever zone the original
-	// occupies on its author's board.
-	zone := board.ZoneYellow
+	if zone == "" {
+		zone = card.Zone
+	}
+	if zone == "" {
+		zone = board.ZoneGray
+	}
 	// A review card belongs to the SAME sprint as the card it reviews, not
 	// merely the team's current pointer — otherwise a card being reviewed in an
 	// older, not-yet-carried sprint would get a review card in a different
@@ -1141,16 +1145,18 @@ func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Ca
 }
 
 // ReassignReviewer points a card's linked review card at another reviewer, or
-// sends the card to review when it has none yet (day = "" is today). It mirrors
+// sends the card to review when it has none yet (day = "" is today). zone
+// places a newly created review card like SendToReview's ("" = the original's
+// zone); an existing review card is never moved. It mirrors
 // handleSetReviewAssignee (non-null login) in TeamBoard.tsx.
-func (s *Service) ReassignReviewer(ctx context.Context, owner string, project int, itemID, reviewer, day string) error {
+func (s *Service) ReassignReviewer(ctx context.Context, owner string, project int, itemID, reviewer, day string, zone board.ZoneKey) error {
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return err
 	}
 	reviewCard, ok := findReviewCard(b, card.ItemID)
 	if !ok {
-		_, err := s.sendToReview(ctx, b, card, reviewer, day)
+		_, err := s.sendToReview(ctx, b, card, reviewer, day, zone)
 		return err
 	}
 	// Re-review: sending an already-passed card back to the SAME reviewer
@@ -1189,7 +1195,7 @@ func (s *Service) ReassignReviewer(ctx context.Context, owner string, project in
 	if err := s.backend.SetReviewOf(ctx, b, reviewCard, ""); err != nil {
 		return err
 	}
-	_, err = s.sendToReview(ctx, b, card, reviewer, day)
+	_, err = s.sendToReview(ctx, b, card, reviewer, day, zone)
 	return err
 }
 

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -584,7 +584,9 @@ func TestSendToReviewCreatesLinkedCardAndStagesOriginal(t *testing.T) {
 	if in.Title != "review: ship it" || in.Assignee != "carol" || in.ReviewOf != "orig" {
 		t.Fatalf("review create input = %+v", in)
 	}
-	if in.Zone != board.ZoneRed || in.Team != "alpha" || in.Start != day || in.SprintStart != "2026-06-20" {
+	// The review card lands in the reviewer's unplanned zone regardless of the
+	// original's zone (here red): for the reviewer it popped up unplanned.
+	if in.Zone != board.ZoneYellow || in.Team != "alpha" || in.Start != day || in.SprintStart != "2026-06-20" {
 		t.Fatalf("review create input = %+v", in)
 	}
 	if rev.ReviewOf != "orig" {

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -576,7 +576,7 @@ func TestSendToReviewCreatesLinkedCardAndStagesOriginal(t *testing.T) {
 	f := newFake([]board.Card{{ItemID: "orig", Title: "ship it", Team: "alpha", Zone: board.ZoneRed, Progress: 100}},
 		map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
 	day := "2026-06-25"
-	rev, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "carol", day)
+	rev, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "carol", day, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,9 +584,9 @@ func TestSendToReviewCreatesLinkedCardAndStagesOriginal(t *testing.T) {
 	if in.Title != "review: ship it" || in.Assignee != "carol" || in.ReviewOf != "orig" {
 		t.Fatalf("review create input = %+v", in)
 	}
-	// The review card lands in the reviewer's unplanned zone regardless of the
-	// original's zone (here red): for the reviewer it popped up unplanned.
-	if in.Zone != board.ZoneYellow || in.Team != "alpha" || in.Start != day || in.SprintStart != "2026-06-20" {
+	// Without an explicit zone the review card inherits the original's (the
+	// Team board's behaviour).
+	if in.Zone != board.ZoneRed || in.Team != "alpha" || in.Start != day || in.SprintStart != "2026-06-20" {
 		t.Fatalf("review create input = %+v", in)
 	}
 	if rev.ReviewOf != "orig" {
@@ -598,12 +598,25 @@ func TestSendToReviewCreatesLinkedCardAndStagesOriginal(t *testing.T) {
 	}
 }
 
+// The Me board sends the review card to the reviewer's unplanned zone
+// explicitly: for the reviewer it is work that popped up during the day.
+func TestSendToReviewWithExplicitZone(t *testing.T) {
+	f := newFake([]board.Card{{ItemID: "orig", Title: "ship it", Team: "alpha", Zone: board.ZoneRed}},
+		map[string]board.SprintState{"alpha": {Current: "2026-06-20"}})
+	if _, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "carol", "2026-06-25", board.ZoneYellow); err != nil {
+		t.Fatal(err)
+	}
+	if f.creates[0].Zone != board.ZoneYellow {
+		t.Fatalf("review create input = %+v", f.creates[0])
+	}
+}
+
 func TestReassignReviewerOnExistingReview(t *testing.T) {
 	f := newFake([]board.Card{
 		{ItemID: "orig", Title: "x"},
 		{ItemID: "rev", ReviewOf: "orig", Assignees: []string{"carol"}},
 	}, nil)
-	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", ""); err != nil {
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("CreateCard") != 0 {
@@ -616,7 +629,7 @@ func TestReassignReviewerOnExistingReview(t *testing.T) {
 
 func TestReassignReviewerWithoutReviewSendsToReview(t *testing.T) {
 	f := newFake([]board.Card{{ItemID: "orig", Title: "x", Team: "alpha"}}, nil)
-	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", "2026-06-25"); err != nil {
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "dave", "2026-06-25", ""); err != nil {
 		t.Fatal(err)
 	}
 	if f.count("CreateCard") != 1 || f.creates[0].Assignee != "dave" || f.creates[0].ReviewOf != "orig" {
@@ -1340,7 +1353,7 @@ func TestSendToReviewCopiesDescription(t *testing.T) {
 			Description: "context: https://github.com/acme/repo/issues/5"},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-06-20", ItemID: "s1"}})
 	svc := New(fake)
-	review, err := svc.SendToReview(context.Background(), "acme", 1, "c1", "lllamnyp", "2026-06-21")
+	review, err := svc.SendToReview(context.Background(), "acme", 1, "c1", "lllamnyp", "2026-06-21", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1414,7 +1427,7 @@ func TestReassignWorkedReviewerSpawnsNewCard(t *testing.T) {
 		{ItemID: "orig", Team: "alpha", Title: "Work", Stage: board.StageReview, Progress: 50},
 		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 40, Assignees: []string{"old"}},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
-	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10"); err != nil {
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10", ""); err != nil {
 		t.Fatal(err)
 	}
 	if !f.saw("SetReviewOf rev ") {
@@ -1434,7 +1447,7 @@ func TestReassignUntouchedReviewerInPlace(t *testing.T) {
 		{ItemID: "orig", Team: "alpha", Stage: board.StageReview, Progress: 50},
 		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Assignees: []string{"old"}},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
-	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10"); err != nil {
+	if err := f2svc(f).ReassignReviewer(ctx, "acme", 1, "orig", "new", "2026-01-10", ""); err != nil {
 		t.Fatal(err)
 	}
 	if len(f.creates) != 0 || !f.saw("SetAssignee rev new") {
@@ -1497,7 +1510,7 @@ func TestReReviewReactivatesReviewCard(t *testing.T) {
 		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 100, Assignees: []string{"bob"}},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
 	svc := f2svc(f)
-	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "bob", "2026-01-10"); err != nil {
+	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "bob", "2026-01-10", ""); err != nil {
 		t.Fatal(err)
 	}
 	orig := f.get("orig")
@@ -1510,7 +1523,7 @@ func TestReReviewReactivatesReviewCard(t *testing.T) {
 	}
 	// A second re-review advances to round 3.
 	f.get("rev").Progress = 100
-	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "bob", "2026-01-10"); err != nil {
+	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "bob", "2026-01-10", ""); err != nil {
 		t.Fatal(err)
 	}
 	if r := f.get("rev"); r.ReviewRound != 3 || r.Progress != 0 {
@@ -1526,7 +1539,7 @@ func TestReReviewDifferentReviewerDoesNotReactivate(t *testing.T) {
 		{ItemID: "rev", Team: "alpha", ReviewOf: "orig", Progress: 100, Assignees: []string{"bob"}},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-10", ItemID: "s1"}})
 	svc := f2svc(f)
-	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "carol", "2026-01-10"); err != nil {
+	if err := svc.ReassignReviewer(ctx, "acme", 1, "orig", "carol", "2026-01-10", ""); err != nil {
 		t.Fatal(err)
 	}
 	if !f.saw("SetReviewOf rev ") {
@@ -1580,7 +1593,7 @@ func TestSendToReviewUsesOriginalSprint(t *testing.T) {
 	f := newFake([]board.Card{
 		{ItemID: "orig", Team: "alpha", Title: "Work", SprintStart: "2026-01-01"},
 	}, map[string]board.SprintState{"alpha": {Current: "2026-01-08", ItemID: "s1"}})
-	rev, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "bob", "2026-01-08")
+	rev, err := f2svc(f).SendToReview(ctx, "acme", 1, "orig", "bob", "2026-01-08", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1791,7 +1804,7 @@ func TestReviewCycleRecordsEvents(t *testing.T) {
 	svc := f2svc(f)
 	actx := WithActor(ctx, "kvaps")
 
-	rev, err := svc.SendToReview(actx, "acme", 1, "orig", "lllamnyp", today)
+	rev, err := svc.SendToReview(actx, "acme", 1, "orig", "lllamnyp", today, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -428,7 +428,7 @@ func (h *server) sendToReview(ctx context.Context, _ *mcp.CallToolRequest, in se
 	if err != nil {
 		return nil, apiserver.Card{}, err
 	}
-	review, err := svc.SendToReview(ctx, owner, project, in.UID, in.Reviewer, in.Day)
+	review, err := svc.SendToReview(ctx, owner, project, in.UID, in.Reviewer, in.Day, "")
 	if err != nil {
 		return nil, apiserver.Card{}, err
 	}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -583,7 +583,7 @@ export function MeBoard({
     const prev = reviewCard.assignees;
     patchCard(reviewCard.itemId, { assignees: [login] });
     void provider
-      .sendToReview(board, card.itemId, login, selectedDate)
+      .sendToReview(board, card.itemId, login, selectedDate, "yellow")
       .then((updated) => {
         addCard(updated);
         // Re-sending a passed card to the same reviewer reactivates their
@@ -599,9 +599,10 @@ export function MeBoard({
   };
 
   // Send a card to review: one action — the server creates the linked review
-  // card (in the original's team, landing in the reviewer's unplanned zone)
-  // and puts the original on the review stage. Both effects are mirrored
-  // optimistically; the re-list converges the original's server-side state.
+  // card and puts the original on the review stage. From the Me board the
+  // review card lands in the reviewer's unplanned zone: for them it popped up
+  // during the day. Both effects are mirrored optimistically; the re-list
+  // converges the original's server-side state.
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
     const zone: ZoneKey = "yellow";
@@ -634,7 +635,7 @@ export function MeBoard({
       ...(card.progress === 100 ? { progress: 90 } : {}),
     });
     void provider
-      .sendToReview(board, card.itemId, reviewerLogin, selectedDate)
+      .sendToReview(board, card.itemId, reviewerLogin, selectedDate, zone)
       .then((created) => {
         removeCard(tempId);
         addCard(created);

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -599,12 +599,12 @@ export function MeBoard({
   };
 
   // Send a card to review: one action — the server creates the linked review
-  // card (in the original's zone/team) and puts the original on the review
-  // stage. Both effects are mirrored optimistically; the re-list converges
-  // the original's server-side state.
+  // card (in the original's team, landing in the reviewer's unplanned zone)
+  // and puts the original on the review stage. Both effects are mirrored
+  // optimistically; the re-list converges the original's server-side state.
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
-    const zone: ZoneKey = card.zone ?? "gray";
+    const zone: ZoneKey = "yellow";
     const sprintStart = currentSprint(board, team) ?? selectedDate;
     const title = `review: ${card.title}`;
     const tempId = `tmp-${new Date().toISOString()}`;

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1159,12 +1159,12 @@ export function TeamBoard({
   };
 
   // Send a card to review: one action — the server creates the linked review
-  // card (in the original's zone/team) and puts the original on the review
-  // stage. Both effects are mirrored optimistically; the re-list converges
-  // the original's server-side state.
+  // card (in the original's team, landing in the reviewer's unplanned zone)
+  // and puts the original on the review stage. Both effects are mirrored
+  // optimistically; the re-list converges the original's server-side state.
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
-    const zone: ZoneKey = card.zone ?? "gray";
+    const zone: ZoneKey = "yellow";
     const sprintStart = currentSprint(board, team) ?? selectedDate;
     const title = `review: ${card.title}`;
     const tempId = `tmp-${new Date().toISOString()}`;

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1159,12 +1159,12 @@ export function TeamBoard({
   };
 
   // Send a card to review: one action — the server creates the linked review
-  // card (in the original's team, landing in the reviewer's unplanned zone)
-  // and puts the original on the review stage. Both effects are mirrored
-  // optimistically; the re-list converges the original's server-side state.
+  // card (in the original's zone/team) and puts the original on the review
+  // stage. Both effects are mirrored optimistically; the re-list converges
+  // the original's server-side state.
   const handleSendToReview = (card: CardModel, reviewerLogin: string) => {
     const team = card.team ?? null;
-    const zone: ZoneKey = "yellow";
+    const zone: ZoneKey = card.zone ?? "gray";
     const sprintStart = currentSprint(board, team) ?? selectedDate;
     const title = `review: ${card.title}`;
     const tempId = `tmp-${new Date().toISOString()}`;

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -27,6 +27,7 @@ import type {
   NewCardInput,
   Note,
   Provider,
+  ZoneKey,
 } from "../types";
 
 // staleListener is notified whenever a response was served from a stale board
@@ -274,11 +275,13 @@ export const apiProvider: Provider = {
     uid: string,
     reviewer: string,
     day?: string,
+    zone?: ZoneKey,
   ): Promise<Card> {
     uid = await resolveCardId(uid);
     return cardFrom(board, "POST", `/cards/${uid}/actions/send-to-review`, {
       reviewer,
       day: day ?? "",
+      zone: zone ? semanticZone(zone) : "",
     });
   },
 

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -182,6 +182,8 @@ export interface Provider {
     uid: string,
     reviewer: string,
     day?: string,
+    /** Zone for the review card; omitted = the original's zone. */
+    zone?: ZoneKey,
   ): Promise<Card>;
   /** Delete the linked review card; returns the original. */
   removeReviewer(board: BoardAddr, uid: string): Promise<Card>;


### PR DESCRIPTION
Assigning a reviewer from the **Me board** now lands the review card in the reviewer's **unplanned (yellow) zone** — for the reviewer it is work that popped up during the day. The **Team board keeps its existing behaviour**: the review card inherits the original's zone, staying in the band the lead is looking at; MCP inherits too.

The zone is an explicit optional parameter of the send-to-review action (`zone`, empty = inherit the original's), so each surface states its intent.