### PR TITLE
fix(board): keep old sprint-less strays out of adoption and Me view

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -95,7 +95,10 @@ today while the card stays in its sprint). A "**next sprint**" create has **no
   any unfinished card).
 - A **sprint-less** day card (a "next sprint" create) shows from its
   `startDate` on — the sprint gate above would otherwise hide it right when its
-  day arrives — until a Carry Over adopts it into a sprint.
+  day arrives — until a Carry Over adopts it into a sprint. Only cards
+  scheduled into the sprint active on the viewed day or later
+  (`startDate >= activeSprint(team, day)`) qualify: an old sprint-less stray
+  stays on its own past days instead of resurfacing on current boards.
 - The team-focus "eye" toggle further narrows to the selected teams (not
   persisted, off by default).
 
@@ -112,10 +115,12 @@ today while the card stays in its sprint). A "**next sprint**" create has **no
   sprint it came from (see the Team / Me rules): Carry Over adds it to the new
   sprint without removing it from the previous one.
 - **Adoption**: unfinished **sprint-less** day cards ("next sprint" creates,
-  not plan cards) whose `startDate <= today` also get `sprintStart = today` —
-  they join the sprint this Carry Over opens, which is what "the next sprint"
-  meant when they were created. Ones still ahead of today wait for a later
-  Carry Over.
+  not plan cards) with `old sprint < startDate <= today` also get
+  `sprintStart = today` — they join the sprint this Carry Over opens, which is
+  what "the next sprint" meant when they were created. Ones still ahead of
+  today wait for a later Carry Over; ones scheduled **before** the closing
+  sprint (old sprint-less strays — report cards, legacy cards) are never
+  dragged in.
 
 ### Defer ("+1 day" / "+1 week")
 - The per-card control pushes **`startDate`** forward — counting from **today**

--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -90,15 +90,18 @@ func MeView(b Board, user, day string) []Card {
 			out = append(out, c)
 			continue
 		}
+		as := ActiveSprint(b, c.Team, day)
 		// A sprint-less day card (a "next sprint" create) stays visible from its
 		// scheduled day on — the sprint gate below would otherwise hide it right
-		// when its day arrives, until a carry-over adopts it into a sprint.
+		// when its day arrives, until a carry-over adopts it into a sprint. Only
+		// cards scheduled into the sprint active on the viewed day (or later)
+		// qualify: an old sprint-less stray stays on its own past days instead
+		// of resurfacing on today's board.
 		if c.SprintStart == "" && c.Plan == PlanNone && c.StartDate != "" &&
-			c.StartDate <= day {
+			c.StartDate <= day && c.StartDate >= as {
 			out = append(out, c)
 			continue
 		}
-		as := ActiveSprint(b, c.Team, day)
 		// A card shows on every day of the sprints it spans — from the one it
 		// started in up to the sprint it now belongs to — so a carried-over card
 		// still appears on the previous sprint's days it came from.

--- a/pkg/board/filters_test.go
+++ b/pkg/board/filters_test.go
@@ -91,6 +91,9 @@ func meBoard() Board {
 		// A "next sprint" create: sprint-less but scheduled — shows from its
 		// day on until a carry-over adopts it into a sprint.
 		{ItemID: "unext", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-27"},
+		// An old sprint-less stray, scheduled before the tracked sprints: it
+		// stays on its own past days and never resurfaces on current ones.
+		{ItemID: "ustray", Assignees: []string{"u"}, Team: "A", StartDate: "2026-06-15"},
 		// Someone else's current-sprint card.
 		{ItemID: "u4", Assignees: []string{"v"}, Team: "A", StartDate: "2026-06-26", SprintStart: "2026-06-26"},
 	})
@@ -107,7 +110,8 @@ func TestMeView(t *testing.T) {
 		{"sprint-less scheduled card shows from its day on", "u", "2026-06-27", []string{"u1", "unext"}},
 		{"deferred current-sprint card appears once its day arrives", "u", "2026-06-28", []string{"u1", "ufuture", "unext"}},
 		{"rolling back shows the previous sprint, hides the current", "u", "2026-06-22", []string{"uprev"}},
-		{"before the previous sprint nothing shows", "u", "2026-06-19", []string{}},
+		{"an old sprint-less stray lives on its own past days only", "u", "2026-06-19", []string{"ustray"}},
+		{"before the stray's day nothing shows", "u", "2026-06-14", []string{}},
 		{"empty user sees everyone in the active sprint", "", "2026-06-26", []string{"u1", "u4"}},
 	}
 	for _, c := range cases {

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -330,8 +330,12 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		}
 		// Adopt sprint-less day cards whose scheduled day has arrived (a "next
 		// sprint" create): they join the sprint this carry-over opens, which is
-		// what "the next sprint" meant when they were created.
+		// what "the next sprint" meant when they were created. Only cards
+		// scheduled PAST the closing sprint qualify — an old sprint-less stray
+		// (a report card, a pre-sprint legacy card) is not this sprint's work
+		// and must not be dragged in.
 		if c.SprintStart == "" && c.Plan == board.PlanNone && c.StartDate != "" &&
+			old != "" && c.StartDate > old &&
 			c.StartDate <= today && !board.Complete(c.Stage, c.Progress) {
 			carry = append(carry, c)
 			continue

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -429,6 +429,9 @@ func TestCarryOverAdoptsSprintlessDayCards(t *testing.T) {
 		{ItemID: "p1", Team: "alpha", Plan: board.PlanWed, Week: "2026-01-05"},
 		// Another team's sprint-less card is not this carry-over's business.
 		{ItemID: "n4", Team: "beta", StartDate: today},
+		// An old sprint-less stray (scheduled before the closing sprint even
+		// started — a report card, a legacy card) is not this sprint's work.
+		{ItemID: "n5", Team: "alpha", StartDate: "2025-12-15"},
 	}, map[string]board.SprintState{"alpha": {Current: old}})
 	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
 	if err != nil {
@@ -442,6 +445,9 @@ func TestCarryOverAdoptsSprintlessDayCards(t *testing.T) {
 	}
 	if f.get("n2").SprintStart != "" || f.get("n3").SprintStart != "" {
 		t.Fatalf("future/finished sprint-less cards must stay: %+v %+v", f.get("n2"), f.get("n3"))
+	}
+	if f.get("n5").SprintStart != "" {
+		t.Fatalf("a pre-sprint stray must not be adopted: %+v", f.get("n5"))
 	}
 }
 

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -224,13 +224,21 @@ export function MeBoard({
         ) {
           return true;
         }
+        const as = activeSprint(board, c.team ?? null, selectedDate);
         // A sprint-less day card (a "next sprint" create) stays visible from
         // its scheduled day on — the sprint gate below would otherwise hide it
-        // right when its day arrives, until a carry-over adopts it.
-        if (!c.sprintStart && !c.plan && c.startDate && c.startDate <= selectedDate) {
+        // right when its day arrives, until a carry-over adopts it. Only cards
+        // scheduled into the sprint active on the viewed day (or later)
+        // qualify: an old sprint-less stray stays on its own past days.
+        if (
+          !c.sprintStart &&
+          !c.plan &&
+          c.startDate &&
+          c.startDate <= selectedDate &&
+          c.startDate >= as
+        ) {
           return true;
         }
-        const as = activeSprint(board, c.team ?? null, selectedDate);
         const ss = c.sprintStart;
         // A card shows on every day of the sprints it spans — from the one it
         // started in up to the sprint it now belongs to — so a carried-over card

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1417,10 +1417,16 @@ export function TeamBoard({
       if (!sameTeam || isComplete(c) || c.itemId.startsWith("tmp-")) {
         continue;
       }
-      // Sprint-less day cards whose day has arrived ("next sprint" creates)
-      // are adopted by the sprint being started, mirroring CarryOver.
+      // Sprint-less day cards scheduled past the closing sprint whose day has
+      // arrived ("next sprint" creates) are adopted by the sprint being
+      // started, mirroring CarryOver; older sprint-less strays stay put.
       const adopted =
-        !c.sprintStart && !c.plan && !!c.startDate && c.startDate <= today;
+        !c.sprintStart &&
+        !c.plan &&
+        !!c.startDate &&
+        !!old &&
+        c.startDate > old &&
+        c.startDate <= today;
       if (adopted || (!!old && c.sprintStart === old)) {
         patchCard(c.itemId, { sprintStart: today });
       }


### PR DESCRIPTION
Carry-over adoption (the "next sprint" create support from #56) had no lower bound: any unfinished sprint-less card whose start date had passed was dragged into the sprint being opened — including report cards and legacy cards from weeks ago, which resurfaced on teams' boards (reported by the cozystack team today; confirmed via the activity log — adopted strays carry a sprint event with no previous value). The Me view's sprint-less visibility had the same hole.

Both are now bounded to the sprint horizon: adoption takes only cards scheduled past the closing sprint (`old < startDate <= today`), and the Me view shows a sprint-less card only when its start falls into the sprint active on the viewed day or later — old strays stay on their own past days.