### PR TITLE
feat(server): write-behind mutations with a coalescing queue

### DIFF
--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -799,28 +800,118 @@ func (b *storeBackend) AppendEvent(ctx context.Context, bd board.Board, card boa
 	return nil
 }
 
+// Notes are write-behind like the field setters, with one extra wrinkle: a
+// note's real id is assigned upstream (a comment node id, or a draft body
+// line index), so the cached copy carries a synthetic ":wb:" id until the
+// queued write lands and the worker re-reads the card. Edits and deletes of
+// a note that is still synthetic resolve it upstream by its body at exec
+// time (FIFO guarantees the add was pushed first).
+
 func (b *storeBackend) AddNote(ctx context.Context, bd board.Board, card board.Card, text string) error {
-	if err := b.inner.AddNote(ctx, bd, card, text); err != nil {
-		return err
+	now := time.Now().UTC().Format(time.RFC3339)
+	note := board.Note{
+		ID:        card.ItemID + ":wb:" + now,
+		Body:      text,
+		CreatedAt: now,
+		Author:    board.ActorFrom(ctx),
+		Source:    "draft",
 	}
-	b.touched(ctx, bd, card.ItemID)
+	if !card.IsDraft {
+		note.Source = "comment"
+	}
+	b.mutateCard(ctx, bd, card.ItemID, "", "add a note on "+cardRef(card), func(c *board.Card) {
+		for _, n := range c.Notes {
+			if n.ID == note.ID || (n.Body == note.Body && n.Author == note.Author) {
+				return
+			}
+		}
+		c.Notes = append(c.Notes, note)
+	}, func(ctx context.Context) error {
+		if err := b.inner.AddNote(ctx, bd, card, text); err != nil {
+			return err
+		}
+		// Swap the synthetic note for the real one (and its real id).
+		b.touched(ctx, bd, card.ItemID)
+		return nil
+	})
 	return nil
 }
 
 func (b *storeBackend) EditNote(ctx context.Context, bd board.Board, card board.Card, note board.Note, text string) error {
-	if err := b.inner.EditNote(ctx, bd, card, note, text); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "", "edit a note on "+cardRef(card), func(c *board.Card) {
+		for i := range c.Notes {
+			if c.Notes[i].ID == note.ID ||
+				(c.Notes[i].Body == note.Body && c.Notes[i].Author == note.Author) {
+				c.Notes[i].Body = text
+				return
+			}
+		}
+	}, func(ctx context.Context) error {
+		real, err := b.resolveNote(ctx, bd, card.ItemID, note)
+		if err != nil {
+			return err
+		}
+		if err := b.inner.EditNote(ctx, bd, card, real, text); err != nil {
+			return err
+		}
+		b.touched(ctx, bd, card.ItemID)
+		return nil
+	})
 	return nil
 }
 
 func (b *storeBackend) DeleteNote(ctx context.Context, bd board.Board, card board.Card, note board.Note) error {
-	if err := b.inner.DeleteNote(ctx, bd, card, note); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "", "delete a note on "+cardRef(card), func(c *board.Card) {
+		kept := c.Notes[:0]
+		removed := false
+		for _, n := range c.Notes {
+			if !removed && (n.ID == note.ID || (n.Body == note.Body && n.Author == note.Author)) {
+				removed = true
+				continue
+			}
+			kept = append(kept, n)
+		}
+		c.Notes = kept
+	}, func(ctx context.Context) error {
+		real, err := b.resolveNote(ctx, bd, card.ItemID, note)
+		if err != nil {
+			return err
+		}
+		if err := b.inner.DeleteNote(ctx, bd, card, real); err != nil {
+			return err
+		}
+		// Draft note ids are body line indexes: deleting a line shifts the
+		// ones after it, so re-sync the cached ids right away.
+		b.touched(ctx, bd, card.ItemID)
+		return nil
+	})
 	return nil
+}
+
+// resolveNote maps a still-synthetic (":wb:") note reference onto the real
+// upstream note by matching its body, taking the newest match. A real id
+// passes through untouched.
+func (b *storeBackend) resolveNote(ctx context.Context, bd board.Board, itemID string, note board.Note) (board.Note, error) {
+	if !strings.Contains(note.ID, ":wb:") {
+		return note, nil
+	}
+	cards, err := b.inner.LoadCards(ctx, bd, []string{itemID})
+	if err != nil {
+		return note, err
+	}
+	if len(cards) == 0 {
+		return note, fmt.Errorf("card %s not found upstream", itemID)
+	}
+	found := -1
+	for i, n := range cards[0].Notes {
+		if n.Body == note.Body && (note.Author == "" || n.Author == "" || n.Author == note.Author) {
+			found = i
+		}
+	}
+	if found < 0 {
+		return note, fmt.Errorf("the note was not found upstream")
+	}
+	return cards[0].Notes[found], nil
 }
 
 // The field setters below are write-behind: the cache changes (and watchers

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -109,6 +109,13 @@ type boardEntry struct {
 	// touched within recentGrace are re-applied on top of every full reload.
 	recentCards map[string]time.Time
 	recentGone  map[string]time.Time
+	// pending is the write-behind queue: changes already live in this cache
+	// that GitHub has not confirmed yet (see writequeue.go). inflight is the
+	// op currently on the wire (still unconfirmed, so counters and reload
+	// replays include it); draining marks the background worker as running.
+	pending  []pendingOp
+	inflight *pendingOp
+	draining bool
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -398,23 +405,23 @@ func (s *boardStore) ClearPresence(key, clientID string) {
 	e.mu.Unlock()
 }
 
-// moveCardTo reorders the cached card to sit after afterID ("" = the top), so
-// snapshots keep serving the board in its real order after a move.
-func (e *boardEntry) moveCardTo(itemID, afterID string) {
+// moveCardAfter reorders cards so itemID sits after afterID ("" = the top),
+// keeping snapshots (and write-behind replays) in the board's real order.
+func moveCardAfter(cards []board.Card, itemID, afterID string) []board.Card {
 	idx := -1
-	for i := range e.board.Cards {
-		if e.board.Cards[i].ItemID == itemID {
+	for i := range cards {
+		if cards[i].ItemID == itemID {
 			idx = i
 			break
 		}
 	}
 	if idx < 0 {
-		return
+		return cards
 	}
-	card := e.board.Cards[idx]
-	rest := make([]board.Card, 0, len(e.board.Cards)-1)
-	rest = append(rest, e.board.Cards[:idx]...)
-	rest = append(rest, e.board.Cards[idx+1:]...)
+	card := cards[idx]
+	rest := make([]board.Card, 0, len(cards)-1)
+	rest = append(rest, cards[:idx]...)
+	rest = append(rest, cards[idx+1:]...)
 	pos := 0
 	if afterID != "" {
 		for i := range rest {
@@ -428,7 +435,7 @@ func (e *boardEntry) moveCardTo(itemID, afterID string) {
 	out = append(out, rest[:pos]...)
 	out = append(out, card)
 	out = append(out, rest[pos:]...)
-	e.board.Cards = out
+	return out
 }
 
 // upsertCard replaces the cached card with the same item id, or appends it.
@@ -509,6 +516,13 @@ func (s *boardStore) subscribe(key, clientID string, sel *apiserver.Selector, re
 		for _, entry := range e.presence {
 			sub.send(watchFrame{Type: "MODIFIED", Kind: "Presence", Object: entry})
 		}
+	}
+	// Seed the unsynced-changes counter: a tab opened while the write-behind
+	// queue is non-empty must show the number right away.
+	if len(e.pending) > 0 {
+		sub.send(watchFrame{Type: "MODIFIED", Kind: "Queue", Object: map[string]int{
+			"pending": len(e.pending),
+		}})
 	}
 	e.mu.Unlock()
 	return sub, func() {
@@ -617,6 +631,15 @@ func (b *storeBackend) install(e *boardEntry, fresh board.Board, login string) b
 	hadOld := e.loaded
 	fresh = e.applyRecent(fresh)
 	e.board = fresh
+	// Replay the write-behind queue on top (the in-flight op first): these
+	// changes are live in the cache but not confirmed by GitHub yet, so a
+	// fresh load — which predates them — must not roll them back.
+	if e.inflight != nil {
+		e.inflight.apply(&e.board)
+	}
+	for _, op := range e.pending {
+		op.apply(&e.board)
+	}
 	e.loaded = true
 	e.loadedAt = time.Now()
 	e.markAuthed(login)
@@ -624,7 +647,7 @@ func (b *storeBackend) install(e *boardEntry, fresh board.Board, login string) b
 		e.diffNotify(old)
 	}
 	e.syncBroadcast()
-	return fresh
+	return e.board
 }
 
 // diffNotify announces everything a full reload changed against the previous
@@ -738,24 +761,41 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 
 // MoveCard applies the new position to the cached order (so lists keep the
 // board's real order) and announces the new Ordering to other clients — the
-// originator already reordered optimistically.
+// originator already reordered optimistically. The GitHub write is queued.
 func (b *storeBackend) MoveCard(ctx context.Context, bd board.Board, card board.Card, afterID string) error {
-	if err := b.inner.MoveCard(ctx, bd, card, afterID); err != nil {
-		return err
-	}
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
-	e.moveCardTo(card.ItemID, afterID)
+	e.board.Cards = moveCardAfter(e.board.Cards, card.ItemID, afterID)
 	e.orderingChanged(clientIDFrom(ctx))
 	e.mu.Unlock()
+	b.enqueue(ctx, e, pendingOp{
+		key:  "move:" + card.ItemID,
+		desc: "move " + cardRef(card),
+		apply: func(target *board.Board) {
+			target.Cards = moveCardAfter(target.Cards, card.ItemID, afterID)
+		},
+		exec: func(ctx context.Context) error {
+			return b.inner.MoveCard(ctx, bd, card, afterID)
+		},
+	})
 	return nil
 }
 
-func (b *storeBackend) AppendEvent(ctx context.Context, bd board.Board, card board.Card, e board.Event) error {
-	if err := b.inner.AppendEvent(ctx, bd, card, e); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+func (b *storeBackend) AppendEvent(ctx context.Context, bd board.Board, card board.Card, ev board.Event) error {
+	// Synthesize a stable id for the cached copy (the real one appears on the
+	// next full read); the presence guard keeps the replayed append from
+	// duplicating the event once GitHub starts returning it.
+	ev.ID = card.ItemID + ":wb:" + ev.At + ":" + ev.Kind
+	b.mutateCard(ctx, bd, card.ItemID, "", "log a change on "+cardRef(card), func(c *board.Card) {
+		for _, x := range c.Events {
+			if x.Kind == ev.Kind && x.At == ev.At && x.From == ev.From && x.To == ev.To {
+				return
+			}
+		}
+		c.Events = append(c.Events, ev)
+	}, func(ctx context.Context) error {
+		return b.inner.AppendEvent(ctx, bd, card, ev)
+	})
 	return nil
 }
 
@@ -783,115 +823,136 @@ func (b *storeBackend) DeleteNote(ctx context.Context, bd board.Board, card boar
 	return nil
 }
 
+// The field setters below are write-behind: the cache changes (and watchers
+// hear about it) immediately, the GitHub write is queued — see writequeue.go.
+
 func (b *storeBackend) SetDescription(ctx context.Context, bd board.Board, card board.Card, description string) error {
-	if err := b.inner.SetDescription(ctx, bd, card, description); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "description", "edit the description of "+cardRef(card), func(c *board.Card) {
+		c.Description = description
+	}, func(ctx context.Context) error {
+		return b.inner.SetDescription(ctx, bd, card, description)
+	})
 	return nil
 }
 
 func (b *storeBackend) RenameCard(ctx context.Context, bd board.Board, card board.Card, title string) error {
-	if err := b.inner.RenameCard(ctx, bd, card, title); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "title", "rename "+cardRef(card), func(c *board.Card) {
+		c.Title = title
+	}, func(ctx context.Context) error {
+		return b.inner.RenameCard(ctx, bd, card, title)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetStage(ctx context.Context, bd board.Board, card board.Card, stage board.StageKey) error {
-	if err := b.inner.SetStage(ctx, bd, card, stage); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "stage", "set the stage on "+cardRef(card), func(c *board.Card) {
+		c.Stage = stage
+	}, func(ctx context.Context) error {
+		return b.inner.SetStage(ctx, bd, card, stage)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetProgress(ctx context.Context, bd board.Board, card board.Card, progress int) error {
-	if err := b.inner.SetProgress(ctx, bd, card, progress); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "progress", "set progress on "+cardRef(card), func(c *board.Card) {
+		c.Progress = progress
+	}, func(ctx context.Context) error {
+		return b.inner.SetProgress(ctx, bd, card, progress)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetZone(ctx context.Context, bd board.Board, card board.Card, zone board.ZoneKey) error {
-	if err := b.inner.SetZone(ctx, bd, card, zone); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "zone", "move "+cardRef(card)+" to another zone", func(c *board.Card) {
+		c.Zone = zone
+	}, func(ctx context.Context) error {
+		return b.inner.SetZone(ctx, bd, card, zone)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetDay(ctx context.Context, bd board.Board, card board.Card, day string) error {
-	if err := b.inner.SetDay(ctx, bd, card, day); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "day", "set the end date on "+cardRef(card), func(c *board.Card) {
+		c.Day = day
+	}, func(ctx context.Context) error {
+		return b.inner.SetDay(ctx, bd, card, day)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetStart(ctx context.Context, bd board.Board, card board.Card, date string) error {
-	if err := b.inner.SetStart(ctx, bd, card, date); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "start", "set the start date on "+cardRef(card), func(c *board.Card) {
+		c.StartDate = date
+	}, func(ctx context.Context) error {
+		return b.inner.SetStart(ctx, bd, card, date)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetSprintStart(ctx context.Context, bd board.Board, card board.Card, date string) error {
-	if err := b.inner.SetSprintStart(ctx, bd, card, date); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "sprint-start", "move "+cardRef(card)+" to another sprint", func(c *board.Card) {
+		c.SprintStart = date
+	}, func(ctx context.Context) error {
+		return b.inner.SetSprintStart(ctx, bd, card, date)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetPlan(ctx context.Context, bd board.Board, card board.Card, plan board.PlanBand) error {
-	if err := b.inner.SetPlan(ctx, bd, card, plan); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "plan", "set the plan band on "+cardRef(card), func(c *board.Card) {
+		c.Plan = plan
+	}, func(ctx context.Context) error {
+		return b.inner.SetPlan(ctx, bd, card, plan)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetWeek(ctx context.Context, bd board.Board, card board.Card, week string) error {
-	if err := b.inner.SetWeek(ctx, bd, card, week); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "week", "move "+cardRef(card)+" to another week", func(c *board.Card) {
+		c.Week = week
+	}, func(ctx context.Context) error {
+		return b.inner.SetWeek(ctx, bd, card, week)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetTeam(ctx context.Context, bd board.Board, card board.Card, team string) error {
-	if err := b.inner.SetTeam(ctx, bd, card, team); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "team", "move "+cardRef(card)+" to another team", func(c *board.Card) {
+		c.Team = team
+	}, func(ctx context.Context) error {
+		return b.inner.SetTeam(ctx, bd, card, team)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetAssignee(ctx context.Context, bd board.Board, card board.Card, login string) error {
-	if err := b.inner.SetAssignee(ctx, bd, card, login); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "assignee", "reassign "+cardRef(card), func(c *board.Card) {
+		if login == "" {
+			c.Assignees = nil
+		} else {
+			c.Assignees = []string{login}
+		}
+	}, func(ctx context.Context) error {
+		return b.inner.SetAssignee(ctx, bd, card, login)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetReviewOf(ctx context.Context, bd board.Board, card board.Card, reviewOf string) error {
-	if err := b.inner.SetReviewOf(ctx, bd, card, reviewOf); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "review-of", "relink the review "+cardRef(card), func(c *board.Card) {
+		c.ReviewOf = reviewOf
+	}, func(ctx context.Context) error {
+		return b.inner.SetReviewOf(ctx, bd, card, reviewOf)
+	})
 	return nil
 }
 
 func (b *storeBackend) SetReviewRound(ctx context.Context, bd board.Board, card board.Card, round int) error {
-	if err := b.inner.SetReviewRound(ctx, bd, card, round); err != nil {
-		return err
-	}
-	b.touched(ctx, bd, card.ItemID)
+	b.mutateCard(ctx, bd, card.ItemID, "review-round", "bump the review round on "+cardRef(card), func(c *board.Card) {
+		c.ReviewRound = round
+	}, func(ctx context.Context) error {
+		return b.inner.SetReviewRound(ctx, bd, card, round)
+	})
 	return nil
 }
 
@@ -906,13 +967,11 @@ func (b *storeBackend) ResolveIssueRef(ctx context.Context, link board.Link) (bo
 }
 
 // SetSprintState updates the cached pointer in place when the team's
-// sprint-state card already exists (its id is stable), announces the Sprint
-// change and re-diffs scoped memberships. A first pointer creates a state card
-// whose id the cache does not know, so that path reloads the board first.
+// sprint-state card already exists (its id is stable) and queues the GitHub
+// write — this is what makes Carry Over instant. A first pointer creates a
+// state card whose id the cache does not know, so that (rare) path stays
+// synchronous and reloads the board.
 func (b *storeBackend) SetSprintState(ctx context.Context, bd board.Board, team, current, previous string) error {
-	if err := b.inner.SetSprintState(ctx, bd, team, current, previous); err != nil {
-		return err
-	}
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
 	st, had := e.board.SprintStates[team]
@@ -921,8 +980,30 @@ func (b *storeBackend) SetSprintState(ctx context.Context, bd board.Board, team,
 		e.board.SprintStates[team] = st
 		e.sprintChanged(clientIDFrom(ctx), team)
 		e.mu.Unlock()
+		label := team
+		if label == "" {
+			label = "no team"
+		}
+		b.enqueue(ctx, e, pendingOp{
+			key:  "sprint:" + team,
+			desc: "advance the «" + label + "» sprint",
+			apply: func(target *board.Board) {
+				if s, ok := target.SprintStates[team]; ok {
+					s.Current, s.Previous = current, previous
+					target.SprintStates[team] = s
+				}
+			},
+			exec: func(ctx context.Context) error {
+				return b.inner.SetSprintState(ctx, bd, team, current, previous)
+			},
+		})
 		return nil
 	}
+	e.mu.Unlock()
+	if err := b.inner.SetSprintState(ctx, bd, team, current, previous); err != nil {
+		return err
+	}
+	e.mu.Lock()
 	e.loaded = false
 	e.mu.Unlock()
 	if _, err := b.LoadBoard(ctx, bd.Owner, bd.Number); err == nil {

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -719,6 +719,10 @@ func (b *storeBackend) LoadCards(ctx context.Context, bd board.Board, ids []stri
 
 // touched reloads the one card a mutation changed, updates the cache and emits a
 // MODIFIED event. Reload failures are swallowed: the periodic re-list reconciles.
+// The write-behind queue (in-flight op included) is replayed on top of the fresh
+// copy: this refresh runs while later queued writes to the same card may exist
+// (rapid note adds), and the upstream copy predates them — without the replay
+// their changes would vanish from the cache until the queue drains.
 func (b *storeBackend) touched(ctx context.Context, bd board.Board, itemID string) {
 	cards, err := b.inner.LoadCards(ctx, bd, []string{itemID})
 	if err != nil || len(cards) == 0 {
@@ -728,8 +732,19 @@ func (b *storeBackend) touched(ctx context.Context, bd board.Board, itemID strin
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
 	e.upsertCard(card)
+	if e.inflight != nil {
+		e.inflight.apply(&e.board)
+	}
+	for _, op := range e.pending {
+		op.apply(&e.board)
+	}
 	e.markRecent(card.ItemID)
-	e.cardChanged(clientIDFrom(ctx), card, "MODIFIED")
+	for i := range e.board.Cards {
+		if e.board.Cards[i].ItemID == itemID {
+			e.cardChanged(clientIDFrom(ctx), e.board.Cards[i], "MODIFIED")
+			break
+		}
+	}
 	e.mu.Unlock()
 }
 

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -253,7 +253,7 @@ func TestOrderingEvent(t *testing.T) {
 	defer cancel()
 
 	e.mu.Lock()
-	e.moveCardTo("c2", "")
+	e.board.Cards = moveCardAfter(e.board.Cards, "c2", "")
 	e.orderingChanged("")
 	e.mu.Unlock()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -197,11 +197,15 @@ func (s *Server) Run(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
+		// Flush the write-behind queue (in-flight op included) on its own
+		// generous budget first — a restart must not silently drop changes
+		// users already saw applied. The container's stop grace period has to
+		// exceed drain + shutdown.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		s.store.waitDrained(drainCtx)
+		drainCancel()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		// Give the write-behind queue a moment to reach GitHub — a restart
-		// must not silently drop changes users already saw applied.
-		s.store.waitDrained(shutdownCtx)
 		return httpServer.Shutdown(shutdownCtx)
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,6 +199,9 @@ func (s *Server) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+		// Give the write-behind queue a moment to reach GitHub — a restart
+		// must not silently drop changes users already saw applied.
+		s.store.waitDrained(shutdownCtx)
 		return httpServer.Shutdown(shutdownCtx)
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -111,6 +111,11 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return
 			}
+			// Keep the shared cache warm while anyone is watching: a stale
+			// cache revalidates in the background (single-flight, stale-
+			// allowed), so user fetches land fresh — no progress bar — and
+			// external GitHub edits keep arriving as ordinary diff events.
+			go func() { _, _ = svc.Board(warmCtx, owner, project) }()
 		}
 	}
 }

--- a/internal/server/writequeue.go
+++ b/internal/server/writequeue.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aenix-org/aeman/pkg/board"
+)
+
+// The write-behind queue: a mutation is applied to the shared board cache
+// immediately (the response and every watcher see it at once) and the actual
+// GitHub Projects write is queued and pushed in the background. Only a write
+// that still fails after retries rolls the board back — by reloading it from
+// GitHub (the authority) and telling every client what happened.
+//
+// pendingOp is one queued write. The change is already live in the cache;
+// exec pushes it upstream, and apply re-imposes it onto a freshly loaded
+// board — a full reload must not undo changes GitHub has not seen yet.
+type pendingOp struct {
+	// key coalesces queued writes, DeltaFIFO-style: a new op replaces a
+	// not-yet-executing queued op with the same key in place, so dragging a
+	// slider five times costs one GitHub write carrying the final value.
+	// "" never coalesces (log events are each their own write).
+	key string
+	// desc names the operation for the sync-error message ("set progress on
+	// «title»").
+	desc  string
+	apply func(bd *board.Board)
+	exec  func(ctx context.Context) error
+}
+
+// queueBackoff is the wait between upstream retries (variable for tests).
+var queueBackoff = []time.Duration{time.Second, 3 * time.Second}
+
+// enqueue applies the op to the cache (the caller already did that part),
+// appends it to the board's queue and makes sure a drain worker is running.
+// A queued (not yet executing) op with the same key is replaced in place —
+// its slot keeps the FIFO position, its payload becomes the newest value.
+// The context is detached so the upstream write survives the request.
+func (b *storeBackend) enqueue(ctx context.Context, e *boardEntry, op pendingOp) {
+	bctx := context.WithoutCancel(ctx)
+	e.mu.Lock()
+	merged := false
+	if op.key != "" {
+		for i := range e.pending {
+			if e.pending[i].key == op.key {
+				e.pending[i] = op
+				merged = true
+				break
+			}
+		}
+	}
+	if !merged {
+		e.pending = append(e.pending, op)
+		e.queueChanged()
+	}
+	starting := !e.draining
+	e.draining = true
+	e.mu.Unlock()
+	if starting {
+		go b.drain(bctx, e)
+	}
+}
+
+// drain pushes queued writes upstream one at a time (FIFO keeps dependent
+// changes to one card in order, and the modest pace stays clear of GitHub's
+// secondary rate limits). A write that fails after retries is dropped: every
+// client is told, and the board is reloaded from GitHub so the cache — with
+// the remaining queue replayed on top — matches reality again.
+func (b *storeBackend) drain(ctx context.Context, e *boardEntry) {
+	for {
+		e.mu.Lock()
+		if len(e.pending) == 0 {
+			e.draining = false
+			e.mu.Unlock()
+			return
+		}
+		// Pop before executing (so a same-key enqueue cannot coalesce into an
+		// op already on the wire) and keep it visible as in-flight — the
+		// counter and reload replays must still cover it.
+		op := e.pending[0]
+		e.pending = e.pending[1:]
+		e.inflight = &op
+		e.mu.Unlock()
+
+		err := execRetry(ctx, op)
+
+		e.mu.Lock()
+		e.inflight = nil
+		e.queueChanged()
+		owner, number := e.board.Owner, e.board.Number
+		if err != nil {
+			e.syncError(fmt.Sprintf("%s failed: %v", op.desc, err))
+			e.loaded = false
+		}
+		e.mu.Unlock()
+		if err != nil {
+			// Reload now (not on the next read) so every open board rolls
+			// back to GitHub's reality right away; the remaining queue is
+			// replayed on top by install.
+			_, _ = b.LoadBoard(ctx, owner, number)
+		}
+	}
+}
+
+// execRetry runs the upstream write with a few retries — a transient GitHub
+// hiccup (secondary rate limit, 502) must not roll a user's change back.
+func execRetry(ctx context.Context, op pendingOp) error {
+	var err error
+	for attempt := 0; ; attempt++ {
+		if err = op.exec(ctx); err == nil {
+			return nil
+		}
+		if attempt >= len(queueBackoff) {
+			return err
+		}
+		select {
+		case <-time.After(queueBackoff[attempt]):
+		case <-ctx.Done():
+			return err
+		}
+	}
+}
+
+// unsynced counts the writes GitHub has not confirmed yet, the in-flight one
+// included. The caller holds e.mu.
+func (e *boardEntry) unsynced() int {
+	n := len(e.pending)
+	if e.inflight != nil {
+		n++
+	}
+	return n
+}
+
+// queueChanged tells every watcher how many writes are still unsynced; the
+// UI shows the number and hides it at zero. The caller holds e.mu.
+func (e *boardEntry) queueChanged() {
+	frame := watchFrame{Type: "MODIFIED", Kind: "Queue", Object: map[string]int{
+		"pending": e.unsynced(),
+	}}
+	for sub := range e.watchers {
+		sub.send(frame)
+	}
+}
+
+// syncError announces a write that was lost after retries. No echo
+// suppression: the originator needs the rollback most of all. The caller
+// holds e.mu.
+func (e *boardEntry) syncError(message string) {
+	frame := watchFrame{Type: "ERROR", Kind: "SyncError", Object: map[string]string{
+		"message": message,
+	}}
+	for sub := range e.watchers {
+		sub.send(frame)
+	}
+}
+
+// mutateCard applies fn to the cached card, announces the change and queues
+// the upstream write: the instant half of a write-behind field mutation.
+// kind builds the coalescing key (kind per card; "" never coalesces),
+// desc/exec describe and perform the GitHub write; origin echo suppression
+// matches the direct-mutation path.
+func (b *storeBackend) mutateCard(ctx context.Context, bd board.Board, itemID, kind, desc string, fn func(c *board.Card), exec func(ctx context.Context) error) {
+	e := b.store.entry(storeKey(bd.Owner, bd.Number))
+	apply := func(target *board.Board) {
+		for i := range target.Cards {
+			if target.Cards[i].ItemID == itemID {
+				fn(&target.Cards[i])
+				return
+			}
+		}
+	}
+	e.mu.Lock()
+	apply(&e.board)
+	for i := range e.board.Cards {
+		if e.board.Cards[i].ItemID == itemID {
+			e.markRecent(itemID)
+			e.cardChanged(clientIDFrom(ctx), e.board.Cards[i], "MODIFIED")
+			break
+		}
+	}
+	e.mu.Unlock()
+	key := ""
+	if kind != "" {
+		key = kind + ":" + itemID
+	}
+	b.enqueue(ctx, e, pendingOp{key: key, desc: desc, apply: apply, exec: exec})
+}
+
+// waitDrained blocks until every board's write-behind queue is empty or the
+// context expires — the shutdown path calls it so a restart does not drop
+// changes users already saw applied.
+func (s *boardStore) waitDrained(ctx context.Context) {
+	for {
+		s.mu.Lock()
+		pending := 0
+		for _, e := range s.entries {
+			e.mu.Lock()
+			pending += e.unsynced()
+			e.mu.Unlock()
+		}
+		s.mu.Unlock()
+		if pending == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// cardRef names a card for sync-error messages.
+func cardRef(c board.Card) string {
+	if c.Title == "" {
+		return c.ItemID
+	}
+	return "«" + c.Title + "»"
+}

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -37,6 +37,20 @@ func (w *wbBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, 
 	return b, nil
 }
 
+func (w *wbBackend) LoadCards(_ context.Context, _ board.Board, ids []string) ([]board.Card, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var out []board.Card
+	for _, c := range w.board.Cards {
+		for _, id := range ids {
+			if c.ItemID == id {
+				out = append(out, c)
+			}
+		}
+	}
+	return out, nil
+}
+
 func (w *wbBackend) SetProgress(_ context.Context, _ board.Board, _ board.Card, _ int) error {
 	if w.gate != nil {
 		<-w.gate
@@ -215,6 +229,73 @@ func TestWriteBehindFailureRollsBack(t *testing.T) {
 	}
 	if !sawError {
 		t.Fatal("no SyncError frame reached the watcher")
+	}
+}
+
+// The single-card refresh after a note write must replay the queue too: with
+// several rapid note adds in flight, the upstream copy read back after the
+// first write predates the rest — without the replay they vanish from the
+// cache (and every open tab) until the queue drains.
+func TestTouchedPreservesQueuedNotes(t *testing.T) {
+	inner := &wbBackend{board: watchBoard()}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// Two note adds still queued (their writes have not reached upstream).
+	for _, text := range []string{"w", "e"} {
+		note := board.Note{ID: "c1:wb:" + text, Body: text, Source: "draft"}
+		e.mu.Lock()
+		e.pending = append(e.pending, pendingOp{
+			desc: "add a note",
+			apply: func(target *board.Board) {
+				for i := range target.Cards {
+					if target.Cards[i].ItemID != "c1" {
+						continue
+					}
+					for _, n := range target.Cards[i].Notes {
+						if n.ID == note.ID {
+							return
+						}
+					}
+					target.Cards[i].Notes = append(target.Cards[i].Notes, note)
+				}
+			},
+			exec: func(context.Context) error { return nil },
+		})
+		e.mu.Unlock()
+	}
+	e.mu.Lock()
+	for _, op := range e.pending {
+		op.apply(&e.board)
+	}
+	e.mu.Unlock()
+
+	// Upstream has only the first, already-written note ("q"): the refresh
+	// after its write must not erase the queued w/e from the cache.
+	upstream := watchBoard()
+	upstream.Cards[0].Notes = []board.Note{{ID: "c1:0", Body: "q", Source: "draft"}}
+	inner.mu.Lock()
+	inner.board = upstream
+	inner.mu.Unlock()
+	be.touched(context.Background(), bd, "c1")
+
+	e.mu.Lock()
+	var bodies []string
+	for _, c := range e.board.Cards {
+		if c.ItemID == "c1" {
+			for _, n := range c.Notes {
+				bodies = append(bodies, n.Body)
+			}
+		}
+	}
+	e.mu.Unlock()
+	if len(bodies) != 3 || bodies[0] != "q" || bodies[1] != "w" || bodies[2] != "e" {
+		t.Fatalf("cached notes after refresh = %v, want [q w e]", bodies)
 	}
 }
 

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-org/aeman/pkg/boardservice"
+)
+
+// wbBackend is an inner backend for write-behind tests: LoadBoard serves a
+// configurable board, SetProgress can block (gate) or fail, and every upstream
+// call is counted.
+type wbBackend struct {
+	boardservice.Backend // nil: only the methods below are exercised
+	mu                   sync.Mutex
+	board                board.Board
+	loads                int
+	progressCalls        int
+	gate                 chan struct{} // nil = no gating
+	fail                 bool
+}
+
+func (w *wbBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.loads++
+	// A fresh Cards slice per load, like a real backend: the store mutates its
+	// cached copy in place and must not reach the fixture through shared
+	// backing arrays.
+	b := w.board
+	b.Cards = append([]board.Card(nil), w.board.Cards...)
+	return b, nil
+}
+
+func (w *wbBackend) SetProgress(_ context.Context, _ board.Board, _ board.Card, _ int) error {
+	if w.gate != nil {
+		<-w.gate
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.progressCalls++
+	if w.fail {
+		return errors.New("github: boom")
+	}
+	return nil
+}
+
+func (w *wbBackend) counts() (loads, progress int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.loads, w.progressCalls
+}
+
+// waitFor polls until cond holds or the deadline passes.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// A field mutation returns instantly with the cache (and watchers) updated,
+// while the slow GitHub write drains in the background; the unsynced counter
+// rises and falls back to zero.
+func TestWriteBehindInstant(t *testing.T) {
+	inner := &wbBackend{board: watchBoard(), gate: make(chan struct{})}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub, cancel := store.subscribe("acme/1", "", nil, map[string]bool{"cards": true})
+	defer cancel()
+
+	start := time.Now()
+	if err := be.SetProgress(context.Background(), bd, bd.Cards[0], 80); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("SetProgress blocked on the upstream write: %v", elapsed)
+	}
+	// The cache already holds the change and the watcher heard about it.
+	e := store.entry("acme/1")
+	e.mu.Lock()
+	got := e.board.Cards[0].Progress
+	pending := e.unsynced()
+	e.mu.Unlock()
+	if got != 80 || pending != 1 {
+		t.Fatalf("cache progress = %d, unsynced = %d; want 80, 1", got, pending)
+	}
+	f := readFrame(t, sub)
+	if f.Kind != "Card" || f.Type != "MODIFIED" {
+		t.Fatalf("want a MODIFIED Card frame, got %s %s", f.Type, f.Kind)
+	}
+	if f = readFrame(t, sub); f.Kind != "Queue" {
+		t.Fatalf("want a Queue frame, got %s %s", f.Type, f.Kind)
+	}
+
+	// Release the gated write: the queue drains to zero.
+	close(inner.gate)
+	waitFor(t, "queue drain", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.unsynced() == 0
+	})
+	if _, progress := inner.counts(); progress != 1 {
+		t.Fatalf("upstream SetProgress calls = %d, want 1", progress)
+	}
+}
+
+// Same-key queued writes coalesce, DeltaFIFO-style: dragging a slider N times
+// while an earlier write is on the wire costs one more GitHub call carrying
+// the final value, not N.
+func TestWriteBehindCoalesces(t *testing.T) {
+	inner := &wbBackend{board: watchBoard(), gate: make(chan struct{})}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// First write goes on the wire (gated); the rest coalesce in the queue.
+	if err := be.SetProgress(context.Background(), bd, bd.Cards[0], 40); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "first write in flight", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.inflight != nil
+	})
+	for _, p := range []int{60, 80, 95} {
+		if err := be.SetProgress(context.Background(), bd, bd.Cards[0], p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e.mu.Lock()
+	queued := len(e.pending)
+	e.mu.Unlock()
+	if queued != 1 {
+		t.Fatalf("queued ops = %d, want 1 (coalesced)", queued)
+	}
+
+	close(inner.gate)
+	waitFor(t, "queue drain", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.unsynced() == 0
+	})
+	if _, progress := inner.counts(); progress != 2 {
+		t.Fatalf("upstream SetProgress calls = %d, want 2 (in-flight + merged)", progress)
+	}
+	e.mu.Lock()
+	got := e.board.Cards[0].Progress
+	e.mu.Unlock()
+	if got != 95 {
+		t.Fatalf("final cached progress = %d, want 95", got)
+	}
+}
+
+// A write that still fails after retries rolls the board back: every watcher
+// gets a SyncError and the board reloads from GitHub (the authority).
+func TestWriteBehindFailureRollsBack(t *testing.T) {
+	old := queueBackoff
+	queueBackoff = nil // fail fast: one attempt
+	defer func() { queueBackoff = old }()
+
+	inner := &wbBackend{board: watchBoard(), fail: true}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub, cancel := store.subscribe("acme/1", "", nil, map[string]bool{"cards": true})
+	defer cancel()
+
+	if err := be.SetProgress(context.Background(), bd, bd.Cards[0], 80); err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+	waitFor(t, "rollback reload", func() bool {
+		loads, _ := inner.counts()
+		return loads >= 2
+	})
+	waitFor(t, "cache rollback", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return len(e.pending) == 0 && e.board.Cards[0].Progress == 0
+	})
+
+	// Somewhere in the stream there must be the SyncError; drain the channel.
+	sawError := false
+	for i := 0; i < 10; i++ {
+		select {
+		case data := <-sub.ch:
+			var f frame
+			if json.Unmarshal(data, &f) == nil && f.Kind == "SyncError" {
+				sawError = true
+			}
+		default:
+		}
+	}
+	if !sawError {
+		t.Fatal("no SyncError frame reached the watcher")
+	}
+}
+
+// A full reload replays the still-pending queue on top of the fresh board, so
+// unconfirmed changes never roll back mid-flight.
+func TestReloadReplaysPending(t *testing.T) {
+	inner := &wbBackend{board: watchBoard()}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	if _, err := be.LoadBoard(context.Background(), "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+	e.mu.Lock()
+	e.pending = append(e.pending, pendingOp{
+		desc: "test",
+		apply: func(target *board.Board) {
+			for i := range target.Cards {
+				if target.Cards[i].ItemID == "c1" {
+					target.Cards[i].Progress = 55
+				}
+			}
+		},
+		exec: func(context.Context) error { return nil },
+	})
+	e.mu.Unlock()
+
+	got := be.install(e, watchBoard(), "")
+	for _, c := range got.Cards {
+		if c.ItemID == "c1" && c.Progress != 55 {
+			t.Fatalf("pending change lost on reload: %+v", c)
+		}
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { clientId, fetchConfig, type AppConfig } from "./api/client";
-import { apiProvider, setStaleListener } from "./providers/api/apiProvider";
+import { apiProvider } from "./providers/api/apiProvider";
 import {
   resourceToCard,
   sprintStateFrom,
@@ -128,28 +128,9 @@ export function App() {
     },
     [beginLoad, endLoad],
   );
-  // A response served from a stale snapshot means the server is revalidating
-  // in the background: hold the progress bar until its Sync watch frame lands
-  // (one hold per revalidation; a failsafe timer releases a missed frame).
-  const revalTimer = useRef<number | null>(null);
-  const releaseReval = useCallback(() => {
-    if (revalTimer.current !== null) {
-      window.clearTimeout(revalTimer.current);
-      revalTimer.current = null;
-      endLoad();
-    }
-  }, [endLoad]);
-  const holdReval = useCallback(() => {
-    if (revalTimer.current !== null) {
-      return;
-    }
-    beginLoad();
-    revalTimer.current = window.setTimeout(releaseReval, 30_000);
-  }, [beginLoad, releaseReval]);
-  useEffect(() => {
-    setStaleListener(holdReval);
-    return () => setStaleListener(null);
-  }, [holdReval]);
+  // Server-side writes not yet confirmed by GitHub (the write-behind queue),
+  // fed by Queue watch frames; shown as a small counter that trends to zero.
+  const [pendingSync, setPendingSync] = useState(0);
   const [error, setError] = useState<string | null>(null);
   // Live selections of other users (login -> card uid), fed by Presence
   // watch frames; purely ephemeral shared-cursor state.
@@ -507,10 +488,22 @@ export function App() {
     let closed = false;
     let retry: number | undefined;
     const applyFrame = (frame: WatchFrame) => {
-      // The server finished a full board reload: any stale snapshot this tab
-      // was served has been reconciled by the frames before this one.
+      // Sync marks a finished server-side reload; the diff already arrived as
+      // ordinary events, so there is nothing left to do here.
       if (frame.kind === "Sync") {
-        releaseReval();
+        return;
+      }
+      // The write-behind queue's depth: changes applied everywhere but not
+      // yet confirmed by GitHub.
+      if (frame.kind === "Queue") {
+        setPendingSync((frame.object as { pending?: number })?.pending ?? 0);
+        return;
+      }
+      // A write GitHub finally rejected: the board has been rolled back to
+      // the server's reloaded state; surface what was lost.
+      if (frame.kind === "SyncError") {
+        const msg = (frame.object as { message?: string })?.message;
+        setError(msg || "a change could not be written to GitHub");
         return;
       }
       if (!frame.object) {
@@ -572,8 +565,10 @@ export function App() {
       }
     };
     const connect = () => {
-      // A fresh connection replays the presence snapshot; drop stale marks.
+      // A fresh connection replays the presence and queue snapshots; drop
+      // stale marks (the queue may have drained while we were away).
       setPresenceMap({});
+      setPendingSync(0);
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       // Scope the watch to the active view: Me watches its day selection, Team
       // watches every card of the teams it shows (grid + weekly plan). A card
@@ -619,7 +614,6 @@ export function App() {
     removeCard,
     patchCard,
     reorderCards,
-    releaseReval,
   ]);
 
   const onError = useCallback((message: string) => setError(message), []);
@@ -776,6 +770,14 @@ export function App() {
           </>
         )}
 
+        {pendingSync > 0 && (
+          <span
+            className="sync-badge"
+            title={`${pendingSync} change(s) applied but not yet written to GitHub`}
+          >
+            {pendingSync}
+          </span>
+        )}
         <div className="segmented" role="tablist" aria-label="View">
           <button
             type="button"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { Logo } from "./components/Logo";
 import { fetchUsers, type GhUser } from "./users";
 import { queryString, viewQueries, watchQuery } from "./viewquery";
 import { todayIso } from "./date";
+import { mergeNotes } from "./notes";
 import { AppearanceMenu } from "./components/AppearanceMenu";
 import { applyAppearance, persistAppearance, readAppearance, type Appearance } from "./theme";
 
@@ -409,17 +410,30 @@ export function App() {
     }
   }, [board, doLoad]);
 
-  const patchCard = useCallback((itemId: string, patch: Partial<CardModel>) => {
-    setBoard((cur) => {
-      if (!cur) {
-        return cur;
-      }
-      return {
-        ...cur,
-        cards: cur.cards.map((c) => (c.itemId === itemId ? { ...c, ...patch } : c)),
-      };
-    });
-  }, []);
+  // patch is a plain partial, or an updater computing one from the card's
+  // CURRENT state — rapid successive changes (notes typed Enter-Enter-Enter)
+  // must not base themselves on a stale render's copy.
+  const patchCard = useCallback(
+    (
+      itemId: string,
+      patch: Partial<CardModel> | ((c: CardModel) => Partial<CardModel>),
+    ) => {
+      setBoard((cur) => {
+        if (!cur) {
+          return cur;
+        }
+        return {
+          ...cur,
+          cards: cur.cards.map((c) =>
+            c.itemId === itemId
+              ? { ...c, ...(typeof patch === "function" ? patch(c) : patch) }
+              : c,
+          ),
+        };
+      });
+    },
+    [],
+  );
 
   // addCard upserts by item id: the watch stream may deliver a created card
   // before (or after) the creator's own response lands, so both paths must
@@ -524,7 +538,14 @@ export function App() {
         if (existing?.notes !== undefined) {
           void provider
             .listLog({ owner: watchOwner, number: watchProject }, card.itemId)
-            .then(({ notes, events }) => patchCard(card.itemId, { notes, events }))
+            .then(({ notes, events }) =>
+              // Merge, don't replace: the response may predate a local
+              // optimistic note added while it was in flight.
+              patchCard(card.itemId, (c) => ({
+                notes: mergeNotes(notes, c.notes),
+                events,
+              })),
+            )
             .catch(() => {});
         }
         return;
@@ -775,6 +796,22 @@ export function App() {
             className="sync-badge"
             title={`${pendingSync} change(s) applied but not yet written to GitHub`}
           >
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M21 2v6h-6" />
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+              <path d="M3 22v-6h6" />
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+            </svg>
             {pendingSync}
           </span>
         )}

--- a/web/src/components/CardDetail.tsx
+++ b/web/src/components/CardDetail.tsx
@@ -15,7 +15,10 @@ interface CardDetailProps {
   provider: Provider;
   onClose: () => void;
   reload: () => void;
-  patchCard: (itemId: string, patch: Partial<CardModel>) => void;
+  patchCard: (
+    itemId: string,
+    patch: Partial<CardModel> | ((c: CardModel) => Partial<CardModel>),
+  ) => void;
 }
 
 /** CardDetail is a centered modal for editing a card's title and details. */

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -13,6 +13,7 @@ import {
   registerPendingCard,
 } from "../api/pending";
 import { isWorkable } from "../stages";
+import { mergeNotes } from "../notes";
 import type {
   Board,
   Card as CardModel,
@@ -55,7 +56,10 @@ interface MeBoardProps {
   onAddTeam: (team: string) => void;
   onRemoveTeam: (team: string) => void;
   onRenameTeam: (from: string, to: string) => void;
-  patchCard: (itemId: string, patch: Partial<CardModel>) => void;
+  patchCard: (
+    itemId: string,
+    patch: Partial<CardModel> | ((c: CardModel) => Partial<CardModel>),
+  ) => void;
   addCard: (card: CardModel) => void;
   removeCard: (itemId: string) => void;
   reorderCards: (orderedItemIds: string[]) => void;
@@ -829,34 +833,44 @@ export function MeBoard({
       source: selectedCard.isDraft ? "draft" : "comment",
     };
     const uid = selectedCard.itemId;
-    patchCard(uid, {
-      notes: [...(selectedCard.notes ?? []), optimistic],
-    });
+    // Functional updates: rapid Enter-Enter-Enter adds must each build on the
+    // card's CURRENT notes, not on this render's stale copy. The server's
+    // response list is merged the same way — it may predate optimistic notes
+    // added after this request left, and must not wipe them.
+    patchCard(uid, (c) => ({
+      notes: [...(c.notes ?? []), optimistic],
+    }));
     void provider
       .addNote(board, uid, text)
-      .then((notes) => patchCard(uid, { notes }))
+      .then((notes) =>
+        patchCard(uid, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+      )
       .catch(fail);
   };
 
   const handleEditNote = (note: Note, card: CardModel, text: string) => {
-    patchCard(card.itemId, {
-      notes: (card.notes ?? []).map((n) =>
+    patchCard(card.itemId, (c) => ({
+      notes: (c.notes ?? []).map((n) =>
         n.id === note.id ? { ...n, body: text } : n,
       ),
-    });
+    }));
     void provider
       .editNote(board, card.itemId, note.id, text)
-      .then((notes) => patchCard(card.itemId, { notes }))
+      .then((notes) =>
+        patchCard(card.itemId, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+      )
       .catch(fail);
   };
 
   const handleDeleteNote = (note: Note, card: CardModel) => {
-    patchCard(card.itemId, {
-      notes: (card.notes ?? []).filter((n) => n.id !== note.id),
-    });
+    patchCard(card.itemId, (c) => ({
+      notes: (c.notes ?? []).filter((n) => n.id !== note.id),
+    }));
     void provider
       .deleteNote(board, card.itemId, note.id)
-      .then((notes) => patchCard(card.itemId, { notes }))
+      .then((notes) =>
+        patchCard(card.itemId, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+      )
       .catch(fail);
   };
 

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -53,7 +53,10 @@ interface TeamBoardProps {
   onRemoveTeam: (team: string) => void;
   onRenameTeam: (from: string, to: string) => void;
   onReorderTeams: (ordered: string[]) => void;
-  patchCard: (itemId: string, patch: Partial<CardModel>) => void;
+  patchCard: (
+    itemId: string,
+    patch: Partial<CardModel> | ((c: CardModel) => Partial<CardModel>),
+  ) => void;
   addCard: (card: CardModel) => void;
   removeCard: (itemId: string) => void;
   reorderCards: (orderedItemIds: string[]) => void;

--- a/web/src/notes.ts
+++ b/web/src/notes.ts
@@ -1,0 +1,15 @@
+import type { Note } from "./providers/types";
+
+/** mergeNotes overlays a server note list with local optimistic notes the
+ *  response predates: a tmp- note not yet visible upstream (matched by body
+ *  and author) survives until its own request's response carries it back. */
+export function mergeNotes(server: Note[], local: Note[] | undefined): Note[] {
+  const extras = (local ?? []).filter(
+    (n) =>
+      n.id.startsWith("tmp-") &&
+      !server.some(
+        (s) => s.body === n.body && (s.author ?? "") === (n.author ?? ""),
+      ),
+  );
+  return extras.length ? [...server, ...extras] : server;
+}

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -30,16 +30,6 @@ import type {
   ZoneKey,
 } from "../types";
 
-// staleListener is notified whenever a response was served from a stale board
-// snapshot (X-Aeman-Stale): the server is revalidating in the background and
-// will close with a Sync watch frame — the App holds its progress bar between
-// the two.
-let staleListener: (() => void) | null = null;
-
-export function setStaleListener(fn: (() => void) | null): void {
-  staleListener = fn;
-}
-
 // api issues a request against /api/v1 for a given board. It carries the board
 // identity as query parameters (?owner=&project=) so the server resolves the
 // right board, sets a JSON content type when there is a body, and on a non-2xx
@@ -65,9 +55,6 @@ async function api<T>(
     init.body = JSON.stringify(body);
   }
   const res = await fetch(url, init);
-  if (res.headers.get("X-Aeman-Stale") === "true") {
-    staleListener?.();
-  }
   if (!res.ok) {
     let msg = res.statusText;
     try {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -597,6 +597,28 @@ select {
   cursor: default;
 }
 
+/* Unsynced-changes counter: server-applied writes GitHub has not confirmed
+   yet. Sits left of the Me/Team switch, trends to zero, hidden at zero. */
+.sync-badge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-line);
+  color: var(--fg);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.sync-badge + .segmented {
+  margin-left: 8px;
+}
+
 .segmented {
   margin-left: auto;
   display: inline-flex;


### PR DESCRIPTION
## What

Mutations used to block on GitHub Projects (1–2s per write; a carry over took 10–20s), and optimistic frontend state kept getting rolled back by slow confirmations and eventually-consistent reloads. Writes now land in the shared server cache instantly — the response and every watcher see them at once — while a per-board FIFO worker pushes them to GitHub in the background with retries. Carry over becomes instant for free: its N writes just enter the queue, and the lead can start dragging cards immediately.

- **Coalescing (DeltaFIFO-style)**: a queued, not-yet-executing write is replaced in place by a newer one with the same key (card × field) — dragging a slider five times costs one GitHub call carrying the final value.
- **Reload safety**: a full board reload replays the queue (in-flight op included) on top of the fresh load, so unconfirmed changes never roll back mid-flight; shutdown waits for the queue to drain.
- **Honest rollback**: only a write that still fails after retries rolls back — the board reloads from GitHub (the authority) and every client gets a `SyncError` frame surfaced in the error banner.
- **Notes too**: a note appears instantly (watchers included) under a synthetic id — the real one (comment node id / draft line index) is only assigned upstream — and the worker swaps it in after the write lands; edits/deletes of a still-synthetic note resolve it upstream by body at exec time.
- **Unsynced counter**: a quiet gray pill left of the Me/Team switch shows the queue depth (fed by `Queue` watch frames), trends to zero and hides at zero.
- **No progress bar for background rereads**: the bar no longer covers cache revalidation; watch connections keep the cache warm on their ping tick instead.

Create/delete stay synchronous (a create must return the real GitHub id).

## Measured

`PATCH` on a card and `POST` of a note: **~1–2ms** (was 1–2s); queued writes drain to GitHub within seconds, the final value and real note ids are confirmed upstream.