### PR TITLE
fix(board): keep event-log lines out of descriptions; calm rapid-note UI

### DIFF
--- a/pkg/board/events.go
+++ b/pkg/board/events.go
@@ -117,6 +117,30 @@ func ParseEventBody(body string) (Event, bool) {
 // the attribution AddNote writes for the acting user.
 var noteAuthorRe = regexp.MustCompile(`^@([A-Za-z0-9][A-Za-z0-9-]*): ?`)
 
+// eventLineRe matches a whole event log line ("- [ts] :: kind | ...."): the
+// dated-line header followed by the machine event prefix. Nothing a person
+// writes as prose - the ":: " marker is aeman's own.
+var eventLineRe = regexp.MustCompile(`^[-*]?\s*\[[^\]]+\]\s*` + regexp.QuoteMeta(eventPrefix))
+
+// StripEventLines drops machine event-log lines from a description text.
+// Descriptions occasionally get them baked in - an agent copying a card's
+// visible text back, a description synced from a card whose body was damaged
+// by an old log migration - and they are never legitimate prose, so every
+// description write runs through this.
+func StripEventLines(text string) string {
+	if !strings.Contains(text, eventPrefix) {
+		return text
+	}
+	var kept []string
+	for _, line := range strings.Split(text, "\n") {
+		if eventLineRe.MatchString(strings.TrimSpace(line)) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
 // RenderNoteBody prepends the author attribution to a note body for storage
 // in the draft log ("@login: text"); an empty author stores the bare text.
 func RenderNoteBody(author, text string) string {

--- a/pkg/board/events_test.go
+++ b/pkg/board/events_test.go
@@ -111,3 +111,18 @@ func TestPlanShowsInWeekAt(t *testing.T) {
 		}
 	}
 }
+
+// StripEventLines removes machine event-log lines from description text while
+// leaving prose — including dated-looking checklist lines — untouched.
+func TestStripEventLines(t *testing.T) {
+	in := "- [2026-07-06T08:02:07Z] :: progress | bob | 0 | 20\n" +
+		"a real line\n" +
+		"- [x] checkbox stays\n" +
+		"- [2026-07-07T06:02:40Z] :: sprint | bob | a | b"
+	if got := StripEventLines(in); got != "a real line\n- [x] checkbox stays" {
+		t.Fatalf("StripEventLines = %q", got)
+	}
+	if got := StripEventLines("plain text"); got != "plain text" {
+		t.Fatalf("plain text changed: %q", got)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -451,8 +451,8 @@ func (s *Service) reseedRecurrent(ctx context.Context, b board.Board, c board.Ca
 	if err := s.backend.SetStage(ctx, b, created, board.StageRecurrent); err != nil {
 		return err
 	}
-	if c.Description != "" {
-		return s.backend.SetDescription(ctx, b, created, c.Description)
+	if desc := board.StripEventLines(c.Description); desc != "" {
+		return s.backend.SetDescription(ctx, b, created, desc)
 	}
 	return nil
 }
@@ -1133,10 +1133,11 @@ func (s *Service) sendToReview(ctx context.Context, b board.Board, card board.Ca
 	}
 	// The review card carries a copy of the original's description, so the
 	// reviewer sees the same context (and its links). A one-time copy at
-	// create — the reviewer may edit their own copy freely afterwards.
-	if card.Description != "" {
-		if setErr := s.backend.SetDescription(ctx, b, created, card.Description); setErr == nil {
-			created.Description = card.Description
+	// create — the reviewer may edit their own copy freely afterwards. Event
+	// lines that leaked into the original's description are not context.
+	if desc := board.StripEventLines(card.Description); desc != "" {
+		if setErr := s.backend.SetDescription(ctx, b, created, desc); setErr == nil {
+			created.Description = desc
 		}
 	}
 	// Put the original on review (ApplyStage also drops a 100% card to 90%).
@@ -1305,6 +1306,9 @@ func (s *Service) Rename(ctx context.Context, owner string, project int, itemID,
 // the linked counterpart — editing the original updates its review card and
 // vice versa, so both always show the same context. Notes stay per-card.
 func (s *Service) SetDescription(ctx context.Context, owner string, project int, itemID, description string) error {
+	// Machine event-log lines are never legitimate description prose; strip
+	// them so a copied-back visible text cannot bake the log into the body.
+	description = board.StripEventLines(description)
 	if utf8.RuneCountInString(description) > MaxDescriptionLen {
 		return ErrDescriptionTooLong
 	}

--- a/pkg/ghprojects/load.go
+++ b/pkg/ghprojects/load.go
@@ -142,7 +142,27 @@ func domainParseDraftBody(body, itemID string) (string, []board.Note) {
 		return "", nil
 	}
 	if idx := strings.Index(body, domainLogMarker); idx >= 0 {
-		return strings.TrimSpace(body[:idx]), domainParseNoteLines(body[idx+len(domainLogMarker):], itemID)
+		notes := domainParseNoteLines(body[idx+len(domainLogMarker):], itemID)
+		// Machine event lines stranded ABOVE the marker (left there by an old
+		// log migration, or baked in by a description write before writes were
+		// sanitized) belong to the log, not the description. Only exact event
+		// lines move — a prose line that merely looks dated (a checklist item,
+		// say) stays where the person wrote it.
+		var descLines []string
+		for i, line := range strings.Split(body[:idx], "\n") {
+			m := draftNoteRe.FindStringSubmatch(strings.TrimSpace(line))
+			if m != nil && strings.HasPrefix(m[2], ":: ") {
+				notes = append(notes, board.Note{
+					ID:        fmt.Sprintf("%s:h%d", itemID, i),
+					Body:      m[2],
+					CreatedAt: m[1],
+					Source:    "draft",
+				})
+				continue
+			}
+			descLines = append(descLines, line)
+		}
+		return strings.TrimSpace(strings.Join(descLines, "\n")), notes
 	}
 	// Legacy bodies without a marker: treat note-shaped lines as the log.
 	var descLines []string

--- a/pkg/ghprojects/mapping_test.go
+++ b/pkg/ghprojects/mapping_test.go
@@ -94,3 +94,27 @@ func TestParseNotesPrefersComments(t *testing.T) {
 		t.Fatalf("notes = %+v", notes)
 	}
 }
+
+// Event lines stranded above the log marker (an old migration's leftovers, or
+// a description write that baked them in) are log entries, not description.
+func TestParseDraftBodyMigratesStrandedEventLines(t *testing.T) {
+	body := "- [2026-07-06T08:02:07Z] :: progress | bob | 0 | 20\n" +
+		"real description line\n" +
+		"- [x] a checklist item stays\n" +
+		"\n<!-- aeman:log -->\n" +
+		"- [2026-07-07T05:56:09Z] a note\n" +
+		"- [2026-07-07T08:02:42Z] :: sprint | bob | 2026-07-06 | 2026-07-07"
+	desc, notes := domainParseDraftBody(body, "I_1")
+	if desc != "real description line\n- [x] a checklist item stays" {
+		t.Fatalf("description = %q", desc)
+	}
+	var eventBodies []string
+	for _, n := range notes {
+		if len(n.Body) >= 3 && n.Body[:3] == ":: " {
+			eventBodies = append(eventBodies, n.Body)
+		}
+	}
+	if len(eventBodies) != 2 {
+		t.Fatalf("migrated events = %v, want 2 (the stranded one and the logged one)", eventBodies)
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -131,7 +131,22 @@ export function App() {
   );
   // Server-side writes not yet confirmed by GitHub (the write-behind queue),
   // fed by Queue watch frames; shown as a small counter that trends to zero.
+  // Frames arrive on every enqueue/drain step — a rapid burst of edits would
+  // re-render the whole app dozens of times — so the badge updates at most a
+  // few times a second (trailing debounce keeps the final value accurate).
   const [pendingSync, setPendingSync] = useState(0);
+  const pendingSyncNext = useRef(0);
+  const pendingSyncTimer = useRef<number | null>(null);
+  const queuePendingSync = useCallback((n: number) => {
+    pendingSyncNext.current = n;
+    if (pendingSyncTimer.current !== null) {
+      return;
+    }
+    pendingSyncTimer.current = window.setTimeout(() => {
+      pendingSyncTimer.current = null;
+      setPendingSync(pendingSyncNext.current);
+    }, 300);
+  }, []);
   const [error, setError] = useState<string | null>(null);
   // Live selections of other users (login -> card uid), fed by Presence
   // watch frames; purely ephemeral shared-cursor state.
@@ -422,14 +437,21 @@ export function App() {
         if (!cur) {
           return cur;
         }
-        return {
-          ...cur,
-          cards: cur.cards.map((c) =>
-            c.itemId === itemId
-              ? { ...c, ...(typeof patch === "function" ? patch(c) : patch) }
-              : c,
-          ),
-        };
+        // An empty patch (an updater deciding nothing changed) keeps the
+        // exact same state object, so React bails out of the re-render.
+        let changed = false;
+        const cards = cur.cards.map((c) => {
+          if (c.itemId !== itemId) {
+            return c;
+          }
+          const p = typeof patch === "function" ? patch(c) : patch;
+          if (!p || Object.keys(p).length === 0) {
+            return c;
+          }
+          changed = true;
+          return { ...c, ...p };
+        });
+        return changed ? { ...cur, cards } : cur;
       });
     },
     [],
@@ -510,7 +532,7 @@ export function App() {
       // The write-behind queue's depth: changes applied everywhere but not
       // yet confirmed by GitHub.
       if (frame.kind === "Queue") {
-        setPendingSync((frame.object as { pending?: number })?.pending ?? 0);
+        queuePendingSync((frame.object as { pending?: number })?.pending ?? 0);
         return;
       }
       // A write GitHub finally rejected: the board has been rolled back to
@@ -589,7 +611,7 @@ export function App() {
       // A fresh connection replays the presence and queue snapshots; drop
       // stale marks (the queue may have drained while we were away).
       setPresenceMap({});
-      setPendingSync(0);
+      queuePendingSync(0);
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       // Scope the watch to the active view: Me watches its day selection, Team
       // watches every card of the teams it shows (grid + weekly plan). A card
@@ -635,6 +657,7 @@ export function App() {
     removeCard,
     patchCard,
     reorderCards,
+    queuePendingSync,
   ]);
 
   const onError = useCallback((message: string) => setError(message), []);

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -13,7 +13,7 @@ import {
   registerPendingCard,
 } from "../api/pending";
 import { isWorkable } from "../stages";
-import { mergeNotes } from "../notes";
+import { mergeNotes, sameNotes } from "../notes";
 import type {
   Board,
   Card as CardModel,
@@ -843,7 +843,7 @@ export function MeBoard({
     void provider
       .addNote(board, uid, text)
       .then((notes) =>
-        patchCard(uid, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+        patchCard(uid, (c) => { const merged = mergeNotes(notes, c.notes); return sameNotes(c.notes, merged) ? {} : { notes: merged }; }),
       )
       .catch(fail);
   };
@@ -857,7 +857,7 @@ export function MeBoard({
     void provider
       .editNote(board, card.itemId, note.id, text)
       .then((notes) =>
-        patchCard(card.itemId, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+        patchCard(card.itemId, (c) => { const merged = mergeNotes(notes, c.notes); return sameNotes(c.notes, merged) ? {} : { notes: merged }; }),
       )
       .catch(fail);
   };
@@ -869,7 +869,7 @@ export function MeBoard({
     void provider
       .deleteNote(board, card.itemId, note.id)
       .then((notes) =>
-        patchCard(card.itemId, (c) => ({ notes: mergeNotes(notes, c.notes) })),
+        patchCard(card.itemId, (c) => { const merged = mergeNotes(notes, c.notes); return sameNotes(c.notes, merged) ? {} : { notes: merged }; }),
       )
       .catch(fail);
   };

--- a/web/src/components/NotesPanel.tsx
+++ b/web/src/components/NotesPanel.tsx
@@ -340,6 +340,7 @@ export function NotesPanel({
   // In "by card" grouping, selecting a card scrolls its group into view within
   // the list (only the list scrolls, not the page), so the card you picked on
   // the board lines up with its notes.
+  const scrolledTo = useRef<string | null>(null);
   useEffect(() => {
     if (
       pane !== "log" ||
@@ -350,11 +351,18 @@ export function NotesPanel({
     ) {
       return;
     }
+    // Scroll only when the SELECTION changes — the feed itself changes on
+    // every added note, and chasing it would yank the list around while the
+    // user is typing.
+    if (scrolledTo.current === selectedCard.itemId) {
+      return;
+    }
     const list = listRef.current;
     const target = list.querySelector<HTMLElement>(
       `[data-card-id="${selectedCard.itemId}"]`,
     );
     if (target) {
+      scrolledTo.current = selectedCard.itemId;
       list.scrollTop +=
         target.getBoundingClientRect().top - list.getBoundingClientRect().top - 8;
     }

--- a/web/src/notes.ts
+++ b/web/src/notes.ts
@@ -13,3 +13,13 @@ export function mergeNotes(server: Note[], local: Note[] | undefined): Note[] {
   );
   return extras.length ? [...server, ...extras] : server;
 }
+
+/** sameNotes reports whether two note lists are content-identical (same ids
+ *  and bodies in the same order) — used to skip no-op state updates. */
+export function sameNotes(a: Note[] | undefined, b: Note[]): boolean {
+  const x = a ?? [];
+  return (
+    x.length === b.length &&
+    x.every((n, i) => n.id === b[i].id && n.body === b[i].body)
+  );
+}


### PR DESCRIPTION
## What

**Event lines in descriptions** (reported on «review: automated VPN site to site»): draft bodies damaged by the old log migration carry machine event lines ABOVE the `<!-- aeman:log -->` marker, so the parser served them as the description — and the review-copy plus live-sync paths spread the text further. The parser now migrates exact event lines (`- [ts] :: …`) from the description region into the log — prose that merely looks dated (checklist items) stays put — and every description write runs through `StripEventLines`, so copied-back visible text can never bake the log in. Damaged cards display clean immediately, no data surgery needed.

**Rapid-note UI lag**: every write-behind queue step broadcast a `Queue` frame that re-rendered the whole app (a burst of edits meant dozens of full renders of a heavy grid), the notes list chased every feed change with a scroll, and no-op response merges still produced state updates. The unsynced badge now updates on a 300ms trailing debounce (final value stays accurate), the list scrolls only when the selection changes, and an empty patch keeps the exact same state object so React bails out of the render.