### PR TITLE
fix: anchor the board day to one configurable time zone

### DIFF
--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -17,11 +17,13 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata" // board timezone by name works even in scratch containers
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/aenix-org/aeman/internal/ghcli"
 	"github.com/aenix-org/aeman/internal/server"
+	"github.com/aenix-org/aeman/pkg/board"
 	"github.com/aenix-org/aeman/pkg/boardservice"
 	"github.com/aenix-org/aeman/pkg/mcpserver"
 )
@@ -37,6 +39,14 @@ func main() {
 }
 
 func run(args []string) error {
+	// The board's days live in ONE time zone for every user (AEMAN_TZ, IANA
+	// name): without it a teammate east of the server crosses their local
+	// midnight and starts seeing deferred "tomorrow" cards on today's board.
+	if tz := os.Getenv("AEMAN_TZ"); tz != "" {
+		if err := board.SetLocation(tz); err != nil {
+			return fmt.Errorf("AEMAN_TZ: %w", err)
+		}
+	}
 	if len(args) == 0 {
 		usage()
 		return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aenix-org/aeman/internal/ghcli"
+	"github.com/aenix-org/aeman/pkg/board"
 	"github.com/aenix-org/aeman/pkg/boardservice"
 	"github.com/aenix-org/aeman/web"
 )
@@ -304,6 +305,9 @@ type configResponse struct {
 	DefaultOwner   string `json:"defaultOwner,omitempty"`
 	DefaultProject int    `json:"defaultProject,omitempty"`
 	LockBoard      bool   `json:"lockBoard"`
+	// Tz is the board's day time zone (IANA name): the SPA computes "today"
+	// in it so every user sees the same board day.
+	Tz string `json:"tz"`
 }
 
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
@@ -312,6 +316,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		DefaultOwner:   s.opts.DefaultOwner,
 		DefaultProject: s.opts.DefaultProject,
 		LockBoard:      s.opts.LockBoard,
+		Tz:             board.LocationName(),
 	}
 	if s.auth != nil {
 		resp.Mode = "oauth"

--- a/pkg/board/date.go
+++ b/pkg/board/date.go
@@ -7,8 +7,31 @@ const isoLayout = "2006-01-02"
 
 // TodayIso returns today's date as a local yyyy-mm-dd string. It mirrors todayIso
 // in web/src/date.ts.
+// boardLocation is the time zone the BOARD's days live in — one zone for
+// every user and the server, or a Moscow teammate crossing their local
+// midnight starts seeing "tomorrow's" cards while the lead is still on
+// today's board. Defaults to the server's local zone; SetLocation installs
+// the configured one (AEMAN_TZ).
+var boardLocation = time.Local
+
+// SetLocation installs the board time zone (name per IANA, e.g.
+// "Europe/Berlin"). An unknown name is reported and leaves the zone as-is.
+func SetLocation(name string) error {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return err
+	}
+	boardLocation = loc
+	return nil
+}
+
+// LocationName reports the installed board time zone (IANA name or "Local").
+func LocationName() string {
+	return boardLocation.String()
+}
+
 func TodayIso() string {
-	return time.Now().Format(isoLayout)
+	return time.Now().In(boardLocation).Format(isoLayout)
 }
 
 // LocalDateIso returns the local yyyy-mm-dd date for an ISO timestamp, or "" when
@@ -18,7 +41,7 @@ func LocalDateIso(iso string) string {
 	if !ok {
 		return ""
 	}
-	return t.In(time.Local).Format(isoLayout)
+	return t.In(boardLocation).Format(isoLayout)
 }
 
 // ActiveOnDay reports whether `day` falls within a card's [start, finish] range.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,7 +17,7 @@ import { CardDetail } from "./components/CardDetail";
 import { Logo } from "./components/Logo";
 import { fetchUsers, type GhUser } from "./users";
 import { queryString, viewQueries, watchQuery } from "./viewquery";
-import { todayIso } from "./date";
+import { todayIso, setBoardTimezone } from "./date";
 import { mergeNotes } from "./notes";
 import { AppearanceMenu } from "./components/AppearanceMenu";
 import { applyAppearance, persistAppearance, readAppearance, type Appearance } from "./theme";
@@ -197,6 +197,9 @@ export function App() {
           return;
         }
         setConfig(cfg);
+        // The board's "today" runs in the server's zone for everyone.
+        setBoardTimezone(cfg.tz);
+        setSelectedDate(todayIso());
         setOwner((cur) => cur || cfg.defaultOwner || "");
         setProject((cur) => cur || (cfg.defaultProject ? String(cfg.defaultProject) : ""));
       })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -25,6 +25,9 @@ export interface AppConfig {
   defaultProject?: number;
   /** Pin the UI to defaultOwner/defaultProject and hide the board picker. */
   lockBoard?: boolean;
+  /** The board's day time zone (IANA name): "today" is computed in it so
+   *  every user sees the same board day. "Local" = server-local, unset zone. */
+  tz?: string;
 }
 
 export async function fetchConfig(): Promise<AppConfig> {

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -417,10 +417,29 @@ export function MeBoard({
 
   // Subtasks grouped by parent. The Me board's team-focus filter applies to
   // subtask rows the same way it applies to cards.
+  // Mirrors the server's subtaskOnDay: a subtask keeps its own day
+  // visibility even though it rides its parent — deferred to the future it
+  // hides until its day, and one left behind in an earlier sprint stays on
+  // that sprint's days. Without this an acked defer (addCard) would put the
+  // row right back under the parent on today's board.
+  const subtaskOnDay = (c: CardModel): boolean => {
+    const today = todayIso();
+    if (c.startDate && c.startDate > today && selectedDate < c.startDate) {
+      return false;
+    }
+    if (c.sprintStart) {
+      const as = activeSprint(board, c.team ?? null, selectedDate);
+      if (as && as > c.sprintStart) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   const childrenOf = useMemo(() => {
     const m = new Map<string, CardModel[]>();
     for (const c of mine) {
-      if (!c.parent) {
+      if (!c.parent || !subtaskOnDay(c)) {
         continue;
       }
       if (teamFocus && teamFilter && !teamFilter.includes(c.team ?? "")) {
@@ -431,7 +450,8 @@ export function MeBoard({
       m.set(c.parent, list);
     }
     return m;
-  }, [mine, teamFocus, teamFilter]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mine, teamFocus, teamFilter, selectedDate, board]);
 
   const subsOpen = (id: string) => expandedSubs.has(id);
 

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -681,17 +681,37 @@ export function TeamBoard({
 
   // Subtasks grouped by parent, from the full card state (children are
   // delivered alongside their parents by the view).
+  // Mirrors the server's subtaskOnDay: a subtask keeps its own day
+  // visibility even though it rides its parent — deferred to the future it
+  // hides until its day, and one left behind in an earlier sprint stays on
+  // that sprint's days. Without this an acked defer (addCard) would put the
+  // row right back under the parent on today's board.
+  const subtaskOnDay = (c: CardModel): boolean => {
+    const today = todayIso();
+    if (c.startDate && c.startDate > today && selectedDate < c.startDate) {
+      return false;
+    }
+    if (c.sprintStart) {
+      const as = activeSprint(board, c.team ?? null, selectedDate);
+      if (as && as > c.sprintStart) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   const childrenOf = useMemo(() => {
     const m = new Map<string, CardModel[]>();
     for (const c of board.cards) {
-      if (c.parent) {
+      if (c.parent && subtaskOnDay(c)) {
         const list = m.get(c.parent) ?? [];
         list.push(c);
         m.set(c.parent, list);
       }
     }
     return m;
-  }, [board.cards]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [board.cards, selectedDate, board]);
 
   const subsOpen = (id: string) => expandedSubs.has(id);
 

--- a/web/src/date.ts
+++ b/web/src/date.ts
@@ -1,18 +1,44 @@
-/** todayIso returns today's date as a local yyyy-mm-dd string. */
-export function todayIso(): string {
-  const now = new Date();
-  const off = now.getTimezoneOffset();
-  return new Date(now.getTime() - off * 60_000).toISOString().slice(0, 10);
+// The board's days live in ONE time zone for every user (the server's
+// AEMAN_TZ, delivered via /api/config): without it a user east of the server
+// crosses their local midnight and starts seeing deferred "tomorrow" cards on
+// today's board. Unset = the browser's own zone (single-zone teams).
+let boardTz: string | undefined;
+
+/** setBoardTimezone installs the board's day zone (an IANA name, "" = local). */
+export function setBoardTimezone(tz: string | undefined): void {
+  boardTz = tz && tz !== "Local" ? tz : undefined;
 }
 
-/** localDateIso returns the local yyyy-mm-dd date for an ISO timestamp. */
+// en-CA formats as yyyy-mm-dd; an invalid zone falls back to the browser's.
+function dayInBoardZone(d: Date): string {
+  try {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: boardTz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  } catch {
+    return new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  }
+}
+
+/** todayIso returns today's date as a yyyy-mm-dd string in the BOARD zone. */
+export function todayIso(): string {
+  return dayInBoardZone(new Date());
+}
+
+/** localDateIso returns the board-zone yyyy-mm-dd date for an ISO timestamp. */
 export function localDateIso(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) {
     return "";
   }
-  const off = d.getTimezoneOffset();
-  return new Date(d.getTime() - off * 60_000).toISOString().slice(0, 10);
+  return dayInBoardZone(d);
 }
 
 /** activeOnDay is true when `day` falls within a card's visible span. The span


### PR DESCRIPTION
## Summary

Deferred cards "stayed on today's board" for teammates east of the server: after their local midnight the SPA's browser-local "today" moved to the next day, the board opened on tomorrow, and cards deferred to tomorrow were legitimately visible there — while the lead (and the server) were still on the previous day. Every day-keyed rule (defer targets, created-today tests, carry-over adoption) suffered the same skew.

## What

- The server takes **`AEMAN_TZ`** (an IANA zone name); `board.TodayIso`/`LocalDateIso` compute in it. `time/tzdata` is embedded so named zones work in scratch containers. Unset = server-local, as before.
- `/api/config` exposes the zone (`tz`), and the SPA computes the board day (`todayIso`/`localDateIso`) in it via `Intl` — every user sees the same board "today" regardless of their location; the browser zone remains the fallback for single-zone setups.

## Deploy note

Prod should set `AEMAN_TZ=Europe/Berlin` in `/opt/aeman/.env` — the team's agreed board day (the 12:00 CET truth point).

## Also: a deferred subtask stayed on today's board

Subtask rows bypass the boards' day filters (they render from `childrenOf`), so deferring a subtask left its row visible under the parent — the defer ack put the server copy right back into client state and nothing gated it by day. The boards now mirror the server's `subtaskOnDay` rule, so the row disappears the moment the defer lands (and a subtask left behind in an earlier sprint shows only on that sprint's days).
