### PR TITLE
fix: band drops aim at the plan; subtask notes; steady derived bar

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -182,7 +182,9 @@ today while the card stays in its sprint). A "**next sprint**" create has **no
 - A subtask **scheduled for the future** (startDate past today — the calendar
   or defer) is hidden under its parent until its day arrives, like any
   deferred card; the next Carry Over drags it (it is open) but the future
-  startDate keeps hiding it until the day comes.
+  startDate keeps hiding it until the day comes. The hiding is the CLIENT's
+  rendering rule — the views deliver ALL of a parent's subtasks, so the
+  client's derived-progress math always matches the server's.
 
 ### Calendar (explicit dates)
 - The date picker on a card moves its **real dates**: `startDate = start` and

--- a/pkg/apiserver/views.go
+++ b/pkg/apiserver/views.go
@@ -148,9 +148,11 @@ func FilterCards(b board.Board, sel Selector) []board.Card {
 // withSubtasks appends the subtasks of every delivered parent, so a view is
 // self-contained for a client nesting them under their cards. The me/all team
 // gate and the focus filter apply to subtasks the same way they apply to
-// top-level cards, and on the day views (team/me) a subtask keeps its own
-// day visibility: scheduled for the future it stays hidden until its day,
-// and finished in an earlier sprint it stays on that sprint's days.
+// top-level cards. ALL of a parent's subtasks are delivered — per-day
+// visibility (a deferred subtask hiding until its day, a done one staying on
+// its old sprint's days) is the CLIENT's rendering rule: the client needs the
+// full set anyway, or its optimistic derived-progress math diverges from the
+// server's and the parent's bar jumps on every reload.
 func withSubtasks(b board.Board, out []board.Card, sel Selector) []board.Card {
 	present := make(map[string]bool, len(out))
 	for _, c := range out {
@@ -165,9 +167,6 @@ func withSubtasks(b board.Board, out []board.Card, sel Selector) []board.Card {
 			continue
 		}
 		if sel.Focus && !board.Workable(c) {
-			continue
-		}
-		if (sel.View == "team" || sel.View == "me") && !subtaskOnDay(b, c, sel.Day) {
 			continue
 		}
 		extra[c.Parent] = append(extra[c.Parent], c)
@@ -185,24 +184,6 @@ func withSubtasks(b board.Board, out []board.Card, sel Selector) []board.Card {
 		merged = append(merged, extra[c.ItemID]...)
 	}
 	return merged
-}
-
-// subtaskOnDay reports whether a subtask belongs on a day view: hidden while
-// deferred to the future (startDate past today, day not reached), and — once
-// left behind by a carry-over (a done subtask stays in the sprint it was
-// finished in) — shown only on days its own sprint was active, mirroring the
-// sprint-span rule of MeView.
-func subtaskOnDay(b board.Board, c board.Card, day string) bool {
-	today := board.TodayIso()
-	if c.StartDate != "" && c.StartDate > today && day < c.StartDate {
-		return false
-	}
-	if c.SprintStart != "" {
-		if as := board.ActiveSprint(b, c.Team, day); as != "" && as > c.SprintStart {
-			return false
-		}
-	}
-	return true
 }
 
 // withLinkedReviews appends each card's linked review card (reviewOf == its id),

--- a/pkg/apiserver/views_test.go
+++ b/pkg/apiserver/views_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aenix-org/aeman/pkg/board"
 )
 
-func TestWithSubtasksDayGate(t *testing.T) {
+func TestWithSubtasksDeliversAllChildren(t *testing.T) {
 	today := board.TodayIso()
 	old := board.AddDays(today, -5)
 	future := board.AddDays(today, 3)
@@ -14,13 +14,13 @@ func TestWithSubtasksDayGate(t *testing.T) {
 		Cards: []board.Card{
 			// Carried from the old sprint: startDate keeps its history day.
 			{ItemID: "p", Team: "alpha", StartDate: old, SprintStart: today},
-			// Open subtask riding the current sprint: visible today.
 			{ItemID: "open", Team: "alpha", Parent: "p", SprintStart: today},
-			// Done subtask left behind in the previous sprint by carry-over:
-			// hidden today, visible on the old sprint's days.
+			// Done subtask left behind in the previous sprint by carry-over,
+			// and a deferred one: BOTH still ride with the parent — per-day
+			// visibility is the client's rendering rule, and the client needs
+			// the full set for its derived-progress math.
 			{ItemID: "done", Team: "alpha", Parent: "p", SprintStart: old,
 				Progress: 100},
-			// Deferred subtask: hidden until its future day arrives.
 			{ItemID: "later", Team: "alpha", Parent: "p", SprintStart: today,
 				StartDate: future},
 		},
@@ -32,21 +32,9 @@ func TestWithSubtasksDayGate(t *testing.T) {
 	for _, c := range FilterCards(b, Selector{View: "team", Team: "alpha", Day: today}) {
 		got[c.ItemID] = true
 	}
-	if !got["p"] || !got["open"] {
-		t.Fatalf("parent/open missing today: %v", got)
-	}
-	if got["done"] {
-		t.Fatal("done subtask from the previous sprint shown today")
-	}
-	if got["later"] {
-		t.Fatal("future-scheduled subtask shown today")
-	}
-	// The old sprint's day still shows the done subtask under the parent.
-	oldDay := map[string]bool{}
-	for _, c := range FilterCards(b, Selector{View: "team", Team: "alpha", Day: old}) {
-		oldDay[c.ItemID] = true
-	}
-	if !oldDay["done"] {
-		t.Fatalf("done subtask missing on its own sprint day: %v", oldDay)
+	for _, id := range []string{"p", "open", "done", "later"} {
+		if !got[id] {
+			t.Fatalf("%s missing from the view: %v", id, got)
+		}
 	}
 }

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -399,8 +399,12 @@ export function MeBoard({
       .catch(() => {});
   };
 
+  // Subtasks are selectable rows too but never appear in myCards: fall back
+  // to the full board state so the notes composer works on them.
   const selectedCard =
-    myCards.find((c) => c.itemId === selectedCardId) ?? null;
+    myCards.find((c) => c.itemId === selectedCardId) ??
+    board.cards.find((c) => c.itemId === selectedCardId && c.parent) ??
+    null;
 
   const fail = (err: unknown) => {
     onError(err instanceof Error ? err.message : String(err));

--- a/web/src/components/SortableBoard.tsx
+++ b/web/src/components/SortableBoard.tsx
@@ -43,6 +43,10 @@ export interface DropResult<Meta> {
    *  the placeholder previewed it (indent level, Todoist-style), or null for
    *  a standalone drop. */
   groupUnder: string | null;
+  /** True when groupUnder came purely from the slot position (inside a
+   *  block) with no held gesture — a band drop treats that as aiming at the
+   *  PLAN, not at the block. */
+  groupPositional: boolean;
 }
 
 interface SortableBoardProps<Meta> {
@@ -369,12 +373,15 @@ export function SortableBoard<Meta>({
   //  - below the LAST subtask of a block, or below any plain card, the indent
   //    decides — held to the right nests, flush left stays standalone.
   // The drop commits exactly this resolution, so the preview never lies.
-  const nestPreview = (work: LocalGroups<Meta> | null): string | null => {
+  const nestPreview = (
+    work: LocalGroups<Meta> | null,
+  ): { id: string; positional: boolean } | null => {
     if (!activeId || !work) {
       return null;
     }
     if (nestUnder !== null) {
-      return cardById.get(nestUnder)?.itemId ?? null;
+      const t = cardById.get(nestUnder)?.itemId;
+      return t ? { id: t, positional: false } : null;
     }
     const entry = work.find((g) => g.ids.includes(activeId));
     if (!entry) {
@@ -393,10 +400,12 @@ export function SortableBoard<Meta>({
     // The exit gesture: dragged FAR left of the rows and parked there.
     const leaving = strongDedent.current && slotArmed.current;
     let target: CardModel | undefined;
+    let positional = false;
     if (below?.parent) {
       // Strictly inside a block: subtasks continue below, so the slot can
       // only be one of them — the dedent gesture exists on the last slot only.
       target = cardById.get(below.parent);
+      positional = !indentOn;
     } else if (above.parent) {
       if (above.parent === active.parent) {
         // The own block's last slot: a subtask STAYS a subtask unless it is
@@ -430,12 +439,12 @@ export function SortableBoard<Meta>({
       return null;
     }
     if (active.parent === target.itemId) {
-      return target.itemId; // staying among its own siblings
+      return { id: target.itemId, positional }; // staying among its siblings
     }
     if (canGroup && !canGroup(active, target)) {
       return null;
     }
-    return target.itemId;
+    return { id: target.itemId, positional };
   };
 
   // closestCorners with a grouping band: while the dragged card's centre is
@@ -720,12 +729,14 @@ export function SortableBoard<Meta>({
       return;
     }
 
+    const nest = nestPreview(next);
     onDrop({
       card,
       fromMeta: fromGroup.meta,
       toMeta: toEntry.meta,
       groups: next.map((g) => ({ meta: g.meta, ids: g.ids })),
-      groupUnder: nestPreview(next),
+      groupUnder: nest?.id ?? null,
+      groupPositional: nest?.positional ?? false,
     });
     reset();
   };
@@ -737,6 +748,7 @@ export function SortableBoard<Meta>({
   // The placeholder previews at the indent exactly when the drop would nest.
   const nestPreviewId =
     activeId !== null && nestPreview(local) !== null ? activeId : null;
+
 
   // Render each group as a node, keyed by group.key, so a custom layout can
   // arrange them (Team groups cells into engineer columns); default is flat.

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -853,12 +853,15 @@ export function TeamBoard({
     toMeta,
     groups: g,
     groupUnder,
+    groupPositional,
   }: DropResult<TeamMeta>) => {
     // Drops that involve a weekly-plan band.
     if (fromMeta.kind === "band" || toMeta.kind === "band") {
-      // A drop whose slot nests it under a weekly parent groups it — the
-      // server hands a plan card's slot to the parent (SetParent).
-      if (!card.parent && toMeta.kind === "band" && groupUnder) {
+      // A drop whose slot nests it under a weekly parent groups it — but
+      // ONLY as a held gesture (indent / middle-band dwell): a band drop
+      // that merely lands inside an expanded block aims at the PLAN, and
+      // silently grouping it was how "take into plan" seemed broken.
+      if (!card.parent && toMeta.kind === "band" && groupUnder && !groupPositional) {
         handleGroup(card, groupUnder);
         return;
       }


### PR DESCRIPTION
## Summary

Three subtask follow-ups from live testing:

- **"Cannot take a card into the weekly plan"**: a grid card dropped into a band whose top is an expanded weekly parent silently became that parent's **subtask** — the positional inside-a-block nesting rule fired on the drop slot. Positional nesting no longer applies to band drops: grouping there requires a held gesture (rightward indent or the middle-band dwell), and a plain band drop takes the card into the plan. Reproduced and verified with a scripted browser drag: control card and a parent-with-subtasks both land in the plan now.
- **Notes on a subtask**: the Me board resolved the selected card from its top-level list only, so the composer said "select a card" for subtask rows. It falls back to the full board state.
- **Jumping/rolling-back parent bar**: the views day-gated delivered subtasks, so the client's optimistic derived-progress math ran on a subset while the server used all children — the bar corrected itself on every reload. Views now deliver ALL of a parent's subtasks; the per-day visibility stays a client rendering rule (added in #66).

Also switch the prod board zone to Europe/Prague (env change, no code).