### PR TITLE
fix(server): keep recent writes from rolling back on stale reads

### DIFF
--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -118,6 +119,9 @@ type boardEntry struct {
 	pending  []pendingOp
 	inflight *pendingOp
 	draining bool
+	// recentMove is when a local reorder last touched this board: within
+	// recentGrace the cached order outweighs a fresh (possibly stale) read.
+	recentMove time.Time
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -167,9 +171,24 @@ func (e *boardEntry) applyRecent(fresh board.Board) board.Board {
 		fresh.Cards = kept
 	}
 	if len(e.recentCards) > 0 {
+		// A recently-written card's CACHED copy outweighs the fresh read for
+		// the whole grace window: GitHub's read replicas lag its writes by
+		// seconds, so a revalidation right after the queue drained would
+		// otherwise install the pre-write values — the user's progress/stage
+		// silently rolled back, then came back on a later reload.
+		oldByID := make(map[string]board.Card, len(e.board.Cards))
+		for _, c := range e.board.Cards {
+			oldByID[c.ItemID] = c
+		}
 		have := map[string]bool{}
-		for _, c := range fresh.Cards {
-			have[c.ItemID] = true
+		for i := range fresh.Cards {
+			have[fresh.Cards[i].ItemID] = true
+			if _, recent := e.recentCards[fresh.Cards[i].ItemID]; !recent {
+				continue
+			}
+			if old, ok := oldByID[fresh.Cards[i].ItemID]; ok {
+				fresh.Cards[i] = old
+			}
 		}
 		for _, old := range e.board.Cards {
 			if _, recent := e.recentCards[old.ItemID]; recent && !have[old.ItemID] {
@@ -177,7 +196,44 @@ func (e *boardEntry) applyRecent(fresh board.Board) board.Board {
 			}
 		}
 	}
+	// The same lag rolls back the ORDER a local move just wrote: while a
+	// recent move is inside the grace window, the cached order wins for the
+	// cards both sides know; fresh-only cards keep their fetched positions.
+	if !e.recentMove.IsZero() && now.Sub(e.recentMove) <= recentGrace {
+		rank := make(map[string]int, len(e.board.Cards))
+		for i, c := range e.board.Cards {
+			rank[c.ItemID] = i
+		}
+		known := make([]board.Card, 0, len(fresh.Cards))
+		fixed := map[int]board.Card{}
+		for i, c := range fresh.Cards {
+			if _, ok := rank[c.ItemID]; ok {
+				known = append(known, c)
+			} else {
+				fixed[i] = c
+			}
+		}
+		sortCardsByRank(known, rank)
+		merged := make([]board.Card, 0, len(fresh.Cards))
+		ki := 0
+		for i := 0; i < len(fresh.Cards); i++ {
+			if c, ok := fixed[i]; ok {
+				merged = append(merged, c)
+				continue
+			}
+			merged = append(merged, known[ki])
+			ki++
+		}
+		fresh.Cards = merged
+	}
 	return fresh
+}
+
+// sortCardsByRank orders cards by their previous cache positions (stable).
+func sortCardsByRank(cards []board.Card, rank map[string]int) {
+	sort.SliceStable(cards, func(i, j int) bool {
+		return rank[cards[i].ItemID] < rank[cards[j].ItemID]
+	})
 }
 
 // cacheState grades a cache lookup: a fresh hit is served to anyone allowed,
@@ -783,11 +839,13 @@ func (b *storeBackend) MoveCard(ctx context.Context, bd board.Board, card board.
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
 	e.board.Cards = moveCardAfter(e.board.Cards, card.ItemID, afterID)
+	e.recentMove = time.Now()
 	e.orderingChanged(clientIDFrom(ctx))
 	e.mu.Unlock()
 	b.enqueue(ctx, e, pendingOp{
-		key:  "move:" + card.ItemID,
-		desc: "move " + cardRef(card),
+		key:    "move:" + card.ItemID,
+		itemID: card.ItemID,
+		desc:   "move " + cardRef(card),
 		apply: func(target *board.Board) {
 			target.Cards = moveCardAfter(target.Cards, card.ItemID, afterID)
 		},

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -190,10 +190,36 @@ func (e *boardEntry) applyRecent(fresh board.Board) board.Board {
 				fresh.Cards[i] = old
 			}
 		}
-		for _, old := range e.board.Cards {
-			if _, recent := e.recentCards[old.ItemID]; recent && !have[old.ItemID] {
-				fresh.Cards = append(fresh.Cards, old)
+		// A recent card the lagging read hasn't caught up with is restored
+		// AT ITS CACHED SLOT — right after the nearest cached predecessor the
+		// fresh read knows — not appended at the end: the append made every
+		// revalidation shortly after a create visibly throw the new card (and
+		// everything below it) to the bottom of the board.
+		pos := make(map[string]int, len(fresh.Cards))
+		for i, c := range fresh.Cards {
+			pos[c.ItemID] = i
+		}
+		for ci, old := range e.board.Cards {
+			if _, recent := e.recentCards[old.ItemID]; !recent || have[old.ItemID] {
+				continue
 			}
+			at := 0
+			for j := ci - 1; j >= 0; j-- {
+				if p, ok := pos[e.board.Cards[j].ItemID]; ok {
+					at = p + 1
+					break
+				}
+			}
+			fresh.Cards = append(fresh.Cards, board.Card{})
+			copy(fresh.Cards[at+1:], fresh.Cards[at:])
+			fresh.Cards[at] = old
+			have[old.ItemID] = true
+			for id, p := range pos {
+				if p >= at {
+					pos[id] = p + 1
+				}
+			}
+			pos[old.ItemID] = at
 		}
 	}
 	// The same lag rolls back the ORDER a local move just wrote: while a

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -814,6 +814,22 @@ func (b *storeBackend) touched(ctx context.Context, bd board.Board, itemID strin
 	card := cards[0]
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
+	// Refresh, never resurrect: the card may have been deleted while this
+	// op drained, and GitHub's lagging read replicas can still return it —
+	// upserting would bring it back AND markRecent below would strip its
+	// recentGone protection, so the ghost then survives every reload for
+	// the whole grace window.
+	known := false
+	for i := range e.board.Cards {
+		if e.board.Cards[i].ItemID == card.ItemID {
+			known = true
+			break
+		}
+	}
+	if !known {
+		e.mu.Unlock()
+		return
+	}
 	e.upsertCard(card)
 	if e.inflight != nil {
 		e.inflight.apply(&e.board)

--- a/internal/server/writequeue.go
+++ b/internal/server/writequeue.go
@@ -34,6 +34,12 @@ type pendingOp struct {
 	desc  string
 	apply func(bd *board.Board)
 	exec  func(ctx context.Context) error
+	// itemID names the card the op writes, so a FAILED write can drop that
+	// card's recent-guard before the rollback reload (or the guard would keep
+	// re-imposing the value GitHub just refused).
+	itemID string
+	// requeues counts fresh-node-lag retries (unresolved node, see drain).
+	requeues int
 }
 
 // queueBackoff is the wait between upstream retries (variable for tests).
@@ -98,10 +104,19 @@ func (b *storeBackend) drain(ctx context.Context, e *boardEntry) {
 		e.mu.Unlock()
 
 		err := execRetry(ctx, op)
-		// The target node is gone (deleted mid-queue) or still settling on
-		// GitHub's read path: the cache already reflects the user's intent,
-		// and rolling the whole board back over it would wipe fresher state.
+		// An unresolvable node id is either a target deleted mid-queue (drop
+		// the write: the cache already matches the user's intent) or a FRESH
+		// node GitHub's read path has not caught up with yet — requeue that
+		// with a longer pause instead of silently losing the write, or the
+		// order/fields roll back on the next full reload.
 		if ghprojects.IsUnresolvedNode(err) {
+			e.mu.Lock()
+			_, gone := e.recentGone[op.itemID]
+			if !gone && op.requeues < 3 {
+				op.requeues++
+				e.pending = append(e.pending, op)
+			}
+			e.mu.Unlock()
 			err = nil
 		}
 
@@ -112,6 +127,12 @@ func (b *storeBackend) drain(ctx context.Context, e *boardEntry) {
 		if err != nil {
 			e.syncError(fmt.Sprintf("%s failed: %v", op.desc, err))
 			e.loaded = false
+			// The failed write's card must NOT keep outweighing the reload:
+			// GitHub refused the value, so GitHub's truth wins for it.
+			if op.itemID != "" {
+				delete(e.recentCards, op.itemID)
+			}
+			e.recentMove = time.Time{}
 		}
 		e.mu.Unlock()
 		if err != nil {
@@ -209,7 +230,7 @@ func (b *storeBackend) mutateCardOp(ctx context.Context, bd board.Board, itemID,
 	if kind != "" {
 		key = kind + ":" + itemID
 	}
-	b.enqueue(ctx, e, pendingOp{key: key, desc: desc, compose: compose, apply: apply, exec: exec})
+	b.enqueue(ctx, e, pendingOp{key: key, desc: desc, compose: compose, apply: apply, exec: exec, itemID: itemID})
 }
 
 // waitDrained blocks until every board's write-behind queue is empty or the

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -507,3 +507,38 @@ func TestRevalidateRestoresCreatedCardInPlace(t *testing.T) {
 		t.Fatalf("restored order = %v, want [c1 cNew c2]", ids)
 	}
 }
+
+// The single-card refresh after a note write must not resurrect a card
+// deleted while the op drained: GitHub's lagging replicas still return it,
+// and the old unconditional upsert also stripped its recentGone protection,
+// so the ghost survived every reload for the whole grace window.
+func TestTouchedSkipsDeletedCard(t *testing.T) {
+	inner := &wbBackend{board: watchBoard()}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// The user deleted c1; the fixture backend (the "stale replica") still
+	// serves it to LoadCards.
+	e.mu.Lock()
+	e.removeCard("c1")
+	e.markGone("c1")
+	e.mu.Unlock()
+
+	be.touched(context.Background(), bd, "c1")
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, c := range e.board.Cards {
+		if c.ItemID == "c1" {
+			t.Fatal("touched resurrected the deleted card")
+		}
+	}
+	if _, gone := e.recentGone["c1"]; !gone {
+		t.Fatal("touched stripped the card's recentGone protection")
+	}
+}

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -423,3 +423,49 @@ func TestWriteBehindMergesDraftBodyOps(t *testing.T) {
 		t.Fatalf("final body write: desc=%q notes=%d events=%d; want the plan/3/1", desc, notes, evs)
 	}
 }
+
+func (w *wbBackend) MoveCard(_ context.Context, _ board.Board, _ board.Card, _ string) error {
+	return nil
+}
+
+// A background revalidation that reads GitHub's lagging replicas must not
+// roll back writes the queue already confirmed: within the grace window the
+// cached field values and card order outweigh the stale fresh read.
+func TestRevalidateKeepsRecentWrites(t *testing.T) {
+	inner := &wbBackend{board: watchBoard()}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// Confirmed writes: progress on c1, and c2 moved to the front.
+	if err := be.SetProgress(context.Background(), bd, bd.Cards[0], 80); err != nil {
+		t.Fatal(err)
+	}
+	if err := be.MoveCard(context.Background(), bd, bd.Cards[1], ""); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "queue drain", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.unsynced() == 0
+	})
+
+	// The fixture backend never mutated its stored board, so its next read
+	// IS the stale replica: progress 0, original order. Install it exactly
+	// like a background revalidation would.
+	stale, err := inner.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := be.install(e, stale, "")
+	if got.Cards[0].ItemID != "c2" || got.Cards[1].ItemID != "c1" {
+		t.Fatalf("order rolled back: got %s, %s", got.Cards[0].ItemID, got.Cards[1].ItemID)
+	}
+	if p := got.Cards[1].Progress; p != 80 {
+		t.Fatalf("progress rolled back: got %d, want 80", p)
+	}
+}

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -469,3 +469,41 @@ func TestRevalidateKeepsRecentWrites(t *testing.T) {
 		t.Fatalf("progress rolled back: got %d, want 80", p)
 	}
 }
+
+// A revalidation whose fresh read predates a just-created card must restore
+// it at its cached slot, not append it to the bottom of the board — the
+// append re-ordered everything below it on every reload right after a create.
+func TestRevalidateRestoresCreatedCardInPlace(t *testing.T) {
+	inner := &wbBackend{board: watchBoard()}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	if _, err := be.LoadBoard(context.Background(), "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// A card born between c1 and c2 (as CreateCard + the slotting move leave
+	// it), known to the recency guard.
+	e.mu.Lock()
+	cards := e.board.Cards
+	inserted := make([]board.Card, 0, len(cards)+1)
+	inserted = append(inserted, cards[0], board.Card{ItemID: "cNew", Team: "alpha"})
+	inserted = append(inserted, cards[1:]...)
+	e.board.Cards = inserted
+	e.markRecent("cNew")
+	e.mu.Unlock()
+
+	// The lagging replica still serves the board without the new card.
+	stale, err := inner.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := be.install(e, stale, "")
+	ids := make([]string, len(got.Cards))
+	for i, c := range got.Cards {
+		ids[i] = c.ItemID
+	}
+	if len(ids) != 3 || ids[0] != "c1" || ids[1] != "cNew" || ids[2] != "c2" {
+		t.Fatalf("restored order = %v, want [c1 cNew c2]", ids)
+	}
+}


### PR DESCRIPTION
## Problem

A team lead moves a card and drags its progress bar; moments later both snap back to the previous position and value, then return on a later reload.

Root cause: the server confirms writes through the write-behind queue, but GitHub's read replicas lag its writes by seconds. A background revalidation landing right after the queue drained installed the pre-write board over the already-confirmed state. The recency guard only restored recently created cards that were missing from the fresh read — it did not protect field values or ordering of cards present in it.

## Fix

- **Field grace**: within the recency window, a recently written card's cached copy outweighs the fresh read, so lagging reads cannot roll back confirmed values.
- **Order grace**: after a recent move, the cached card order wins for cards both sides know; cards only present in the fresh read keep their fetched positions.
- **No silent drops**: writes failing on an unresolvable node id (fresh nodes GitHub has not caught up with) are requeued with backoff instead of being discarded; only ops targeting recently deleted cards are dropped.
- **Failure still rolls back**: a write GitHub genuinely refuses drops its card's recency guard, so the rollback reload can land GitHub's truth (existing behavior preserved, covered by tests).

## Testing

- New regression test: a stale revalidation read does not roll back a just-written progress value or card order.
- Full test suite and golangci-lint pass.