### PR TITLE
chore: move the module to github.com/aenix-io/aeman

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ AEMAN_DOMAIN=aeman.example.com
 # --- Optional: lock to one board ---
 # Set all three to pin the UI to a single project and hide the picker. Users
 # whose token can't read it get an access-denied screen.
-# AEMAN_OWNER=aenix-org
+# AEMAN_OWNER=acme
 # AEMAN_PROJECT=37
 # AEMAN_LOCK_BOARD=true
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,4 +46,4 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/aenix-org/aeman
+        - github.com/aenix-io/aeman

--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/internal/ghcli"
-	"github.com/aenix-org/aeman/internal/server"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/mcpserver"
+	"github.com/aenix-io/aeman/internal/ghcli"
+	"github.com/aenix-io/aeman/internal/server"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/mcpserver"
 )
 
 // version is overridden at build time via -ldflags "-X main.version=...".

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -23,7 +23,7 @@ Generate a client secret. Keep the **Client ID** and **Client secret**.
 ## 3. Configure and run
 
 ```sh
-git clone https://github.com/aenix-org/aeman.git
+git clone https://github.com/aenix-io/aeman.git
 cd aeman
 cp .env.example .env
 # fill AEMAN_GITHUB_CLIENT_ID / _SECRET, AEMAN_BASE_URL, AEMAN_DOMAIN
@@ -37,7 +37,7 @@ Caddy issues the certificate on first start (needs DNS + ports 80/443 already in
 To pin every visitor to a single project and hide the board picker, set in `.env`:
 
 ```sh
-AEMAN_OWNER=aenix-org
+AEMAN_OWNER=acme
 AEMAN_PROJECT=37
 AEMAN_LOCK_BOARD=true
 ```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -28,12 +28,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/aenix-org/aeman/pkg/mcpserver"
+	"github.com/aenix-io/aeman/pkg/mcpserver"
 )
 
 func main() {
 	srv := mcpserver.New(mcpserver.Config{
-		Owner:   "aenix-org",
+		Owner:   "acme",
 		Project: 37,
 		Version: "my-mcp-0.1",
 		// The token never leaves this process: the backend talks to
@@ -59,14 +59,14 @@ client := ghprojects.New(os.Getenv("GITHUB_TOKEN"))
 svc := boardservice.New(client)
 
 // Everything the board can do, with admission applied:
-cards, _ := svc.Board(ctx, "aenix-org", 37)      // load
-_ = svc.Defer(ctx, "aenix-org", 37, uid, 1)      // the +1d rule, incl. same-day relocation
-_ = svc.Remove(ctx, "aenix-org", 37, uid, "grid") // demote / release / delete by board rules
-rep, _ := svc.CarryOver(ctx, "aenix-org", 37, "team", false)
+cards, _ := svc.Board(ctx, "acme", 37)      // load
+_ = svc.Defer(ctx, "acme", 37, uid, 1)      // the +1d rule, incl. same-day relocation
+_ = svc.Remove(ctx, "acme", 37, uid, "grid") // demote / release / delete by board rules
+rep, _ := svc.CarryOver(ctx, "acme", 37, "team", false)
 ```
 
 For read-side shapes (semantic zones, derived status, view selectors) use `pkg/apiserver`: `apiserver.CardResource`, `apiserver.FilterCards`, `apiserver.ListCards`.
 
 ## Versioning
 
-The module is pre-1.0: minor versions may move things around. Pin a tag (`go get github.com/aenix-org/aeman@vX.Y.Z`) and read the [behavior matrix](design/behavior-matrix.md) — it enumerates every rule the contract carries, with the test that pins it.
+The module is pre-1.0: minor versions may move things around. Pin a tag (`go get github.com/aenix-io/aeman@vX.Y.Z`) and read the [behavior matrix](design/behavior-matrix.md) — it enumerates every rule the contract carries, with the test that pins it.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aenix-org/aeman
+module github.com/aenix-io/aeman
 
 go 1.26
 

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/ghprojects"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 )
 
 // errMissingBoard is returned when neither query parameters nor server defaults

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/boardservice/boardservicetest"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/boardservice/boardservicetest"
 )
 
 // apiServer wires an aeman Server whose /api/v1 board service is backed by the

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
 )
 
 // watchFrame is one event on the watch stream: a typed change to a Card,

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
 )
 
 // frame decodes one marshalled watch frame from a subscription channel.

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -8,8 +8,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/mcpserver"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/mcpserver"
 )
 
 // mcpTokenCtxKey carries the caller's GitHub token down to the tool handlers'

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aenix-org/aeman/internal/ghcli"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/web"
+	"github.com/aenix-io/aeman/internal/ghcli"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/web"
 )
 
 // githubAPIBase is the upstream the proxy forwards GitHub requests to.

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // scopedQueryKeys are the query parameters that turn a watch into a scoped

--- a/internal/server/writequeue.go
+++ b/internal/server/writequeue.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/ghprojects"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 )
 
 // The write-behind queue: a mutation is applied to the shared board cache

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
 )
 
 // wbBackend is an inner backend for write-behind tests: LoadBoard serves a

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 func testBoard() board.Board {

--- a/pkg/apiserver/types.go
+++ b/pkg/apiserver/types.go
@@ -8,7 +8,7 @@ package apiserver
 import (
 	"sort"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // Zones are addressed by meaning in the API, not colour. The domain (and the

--- a/pkg/apiserver/views.go
+++ b/pkg/apiserver/views.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // Selector scopes a card LIST or watch subscription. View selectors reproduce

--- a/pkg/apiserver/views_test.go
+++ b/pkg/apiserver/views_test.go
@@ -3,7 +3,7 @@ package apiserver
 import (
 	"testing"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 func TestWithSubtasksDeliversAllChildren(t *testing.T) {

--- a/pkg/board/links_test.go
+++ b/pkg/board/links_test.go
@@ -7,15 +7,15 @@ import (
 
 func TestExtractLinksClassifiesAndOrders(t *testing.T) {
 	desc := "See https://example.com/docs first.\n" +
-		"Fix: https://github.com/aenix-org/aeman/issues/12, then\n" +
-		"review https://github.com/aenix-org/aeman/pull/34#discussion_r1 and\n" +
+		"Fix: https://github.com/acme/webapp/issues/12, then\n" +
+		"review https://github.com/acme/webapp/pull/34#discussion_r1 and\n" +
 		"read http://blog.example.com/post."
 	got := ExtractLinks(desc)
 	want := []Link{
-		{URL: "https://github.com/aenix-org/aeman/issues/12", Kind: "issue",
-			Owner: "aenix-org", Repo: "aeman", Number: 12},
-		{URL: "https://github.com/aenix-org/aeman/pull/34#discussion_r1", Kind: "pull",
-			Owner: "aenix-org", Repo: "aeman", Number: 34},
+		{URL: "https://github.com/acme/webapp/issues/12", Kind: "issue",
+			Owner: "acme", Repo: "webapp", Number: 12},
+		{URL: "https://github.com/acme/webapp/pull/34#discussion_r1", Kind: "pull",
+			Owner: "acme", Repo: "webapp", Number: 34},
 		{URL: "https://example.com/docs", Kind: "link"},
 		{URL: "http://blog.example.com/post", Kind: "link"},
 	}
@@ -56,8 +56,8 @@ func TestParseGitHubRef(t *testing.T) {
 
 func TestFallbackTitle(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/aenix-org/cozyportal/issues/1060": "Issue: aenix-org/cozyportal#1060",
-		"https://github.com/acme/repo/pull/34":                "Pull: acme/repo#34",
+		"https://github.com/acme/webapp/issues/1060": "Issue: acme/webapp#1060",
+		"https://github.com/acme/repo/pull/34":       "Pull: acme/repo#34",
 	}
 	for url, want := range cases {
 		ref, ok := ParseGitHubRef(url)

--- a/pkg/boardservice/actor.go
+++ b/pkg/boardservice/actor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // WithActor returns a context carrying the acting user's GitHub login. The

--- a/pkg/boardservice/backend.go
+++ b/pkg/boardservice/backend.go
@@ -8,7 +8,7 @@ package boardservice
 import (
 	"context"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // Backend abstracts the storage backend a board lives in (GitHub Projects v2

--- a/pkg/boardservice/boardservicetest/fake.go
+++ b/pkg/boardservice/boardservicetest/fake.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
 )
 
 // Backend is an in-memory boardservice.Backend. It logs every call and mutates

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -10,7 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // ErrCardNotFound is returned when an item id is not on the loaded board.

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/ghprojects"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 )
 
 // *ghprojects.Client must satisfy Backend structurally (no boardservice import in
@@ -1349,12 +1349,12 @@ func TestCreateCardFromPullURLUnresolved(t *testing.T) {
 	fake := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20", ItemID: "s1"}})
 	svc := New(fake)
 	card, err := svc.CreateCard(context.Background(), "acme", 1, CreateCardArgs{
-		Team: "alpha", Title: "https://github.com/aenix-org/cozyportal/pull/1234",
+		Team: "alpha", Title: "https://github.com/acme/webapp/pull/1234",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if card.Title != "Pull: aenix-org/cozyportal#1234" {
+	if card.Title != "Pull: acme/webapp#1234" {
 		t.Fatalf("title = %q, want the pull fallback label", card.Title)
 	}
 }

--- a/pkg/boardservice/subtasks.go
+++ b/pkg/boardservice/subtasks.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // ErrSubtaskDepth is returned when grouping would nest deeper than one level:

--- a/pkg/boardservice/subtasks_test.go
+++ b/pkg/boardservice/subtasks_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 func TestSetParentGroupsAndSyncsSprint(t *testing.T) {

--- a/pkg/ghprojects/client_test.go
+++ b/pkg/ghprojects/client_test.go
@@ -327,7 +327,7 @@ func TestLoadBoardOrgMissingProject(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := New("test-token", WithEndpoint(srv.URL))
-	_, err := client.LoadProjectBoard(context.Background(), "aenix-org", 999999)
+	_, err := client.LoadProjectBoard(context.Background(), "acme", 999999)
 	if !errors.Is(err, ErrBoardNotFound) {
 		t.Fatalf("err = %v, want ErrBoardNotFound", err)
 	}

--- a/pkg/ghprojects/events.go
+++ b/pkg/ghprojects/events.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // eventLogCap bounds a card's stored event log: the oldest events beyond it

--- a/pkg/ghprojects/links.go
+++ b/pkg/ghprojects/links.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // ResolveIssueRef fills a GitHub issue/PR link with its live title and state.

--- a/pkg/ghprojects/load.go
+++ b/pkg/ghprojects/load.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // LoadBoard loads a project board and maps it into the domain board.Board the

--- a/pkg/ghprojects/load_test.go
+++ b/pkg/ghprojects/load_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // domainBoardJSON is a raw project exercising the domain mapping: a normal card

--- a/pkg/ghprojects/notes.go
+++ b/pkg/ghprojects/notes.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // draftBody fetches a draft issue's current markdown body.

--- a/pkg/ghprojects/setters.go
+++ b/pkg/ghprojects/setters.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aenix-org/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/board"
 )
 
 // domainFieldCache memoises fields the domain setters lazily create, keyed by

--- a/pkg/mcpserver/mcpserver.go
+++ b/pkg/mcpserver/mcpserver.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/ghprojects"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 )
 
 // Config configures the MCP server.

--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
-	"github.com/aenix-org/aeman/pkg/boardservice/boardservicetest"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/boardservice/boardservicetest"
 )
 
 // connect builds an in-memory MCP client session against an aeman MCP server

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/aenix-org/aeman/pkg/apiserver"
-	"github.com/aenix-org/aeman/pkg/board"
-	"github.com/aenix-org/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
 )
 
 // boardRef is embedded in every tool input to select the target board.


### PR DESCRIPTION
The repository moved from the private aenix-org organization to the public aenix-io one.

- Module path and all imports: `github.com/aenix-io/aeman`.
- Docs (deploy, embedding, README paths) point at the new home; the container image is `ghcr.io/aenix-io/aeman`.
- Board-owner examples and test fixtures no longer name the old organization (generic `acme` instead).

Build, tests, and lint pass; the web bundle builds.