### PR TITLE
feat(board): weekly and monthly recurrence cycles

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -387,16 +387,18 @@ func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
 // cardPatch is the PATCH /cards/{uid} body: only present fields are applied,
 // so absent and empty are different things (empty clears).
 type cardPatch struct {
-	Title       *string     `json:"title"`
-	Description *string     `json:"description"`
-	Team        *string     `json:"team"`
-	Zone        *string     `json:"zone"`
-	Assignees   *[]string   `json:"assignees"`
-	Progress    *int        `json:"progress"`
-	Stage       *string     `json:"stage"`
-	Dates       *datesPatch `json:"dates"`
-	Plan        *planPatch  `json:"plan"`
-	ReviewOf    *string     `json:"reviewOf"`
+	Title       *string   `json:"title"`
+	Description *string   `json:"description"`
+	Team        *string   `json:"team"`
+	Zone        *string   `json:"zone"`
+	Assignees   *[]string `json:"assignees"`
+	Progress    *int      `json:"progress"`
+	Stage       *string   `json:"stage"`
+	// Recurrence is a recurrent card's reseed cycle ("", "week", "month").
+	Recurrence *string     `json:"recurrence"`
+	Dates      *datesPatch `json:"dates"`
+	Plan       *planPatch  `json:"plan"`
+	ReviewOf   *string     `json:"reviewOf"`
 	// Parent groups the card as a subtask under another card ("" ungroups).
 	Parent *string `json:"parent"`
 }
@@ -472,6 +474,12 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := svc.SetStage(ctx, owner, project, uid, stage); err != nil {
+			s.apiError(w, err)
+			return
+		}
+	}
+	if p.Recurrence != nil {
+		if err := svc.SetRecurrence(ctx, owner, project, uid, *p.Recurrence); err != nil {
 			s.apiError(w, err)
 			return
 		}

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -1211,6 +1211,15 @@ func (b *storeBackend) SetTeam(ctx context.Context, bd board.Board, card board.C
 	return nil
 }
 
+func (b *storeBackend) SetRecurrence(ctx context.Context, bd board.Board, card board.Card, cycle string) error {
+	b.mutateCard(ctx, bd, card.ItemID, "recurrence", "set the recurrence of "+cardRef(card), func(c *board.Card) {
+		c.Recurrence = cycle
+	}, func(ctx context.Context) error {
+		return b.inner.SetRecurrence(ctx, bd, card, cycle)
+	})
+	return nil
+}
+
 func (b *storeBackend) SetAssignee(ctx context.Context, bd board.Board, card board.Card, login string) error {
 	b.mutateCard(ctx, bd, card.ItemID, "assignee", "reassign "+cardRef(card), func(c *board.Card) {
 		if login == "" {

--- a/pkg/apiserver/types.go
+++ b/pkg/apiserver/types.go
@@ -69,16 +69,19 @@ type CardPlan struct {
 
 // CardSpec is the user's intent — everything an edit can change.
 type CardSpec struct {
-	Title       string    `json:"title"`
-	Description string    `json:"description,omitempty"`
-	Team        string    `json:"team,omitempty"`
-	Zone        string    `json:"zone,omitempty"`
-	Assignees   []string  `json:"assignees"`
-	Progress    int       `json:"progress"`
-	Stage       string    `json:"stage,omitempty"`
-	Dates       CardDates `json:"dates"`
-	Plan        *CardPlan `json:"plan,omitempty"`
-	ReviewOf    string    `json:"reviewOf,omitempty"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Team        string   `json:"team,omitempty"`
+	Zone        string   `json:"zone,omitempty"`
+	Assignees   []string `json:"assignees"`
+	Progress    int      `json:"progress"`
+	Stage       string   `json:"stage,omitempty"`
+	// Recurrence, on a recurrent card, is its reseed cycle: "" = every
+	// sprint, "week" / "month" = once the interval has elapsed.
+	Recurrence string    `json:"recurrence,omitempty"`
+	Dates      CardDates `json:"dates"`
+	Plan       *CardPlan `json:"plan,omitempty"`
+	ReviewOf   string    `json:"reviewOf,omitempty"`
 	// Parent, on a subtask, is the uid of the card it is grouped under.
 	Parent string `json:"parent,omitempty"`
 }
@@ -179,6 +182,7 @@ func CardResource(b board.Board, c board.Card) Card {
 		Assignees:   append([]string{}, c.Assignees...),
 		Progress:    c.Progress,
 		Stage:       string(c.Stage),
+		Recurrence:  c.Recurrence,
 		Dates:       CardDates{Start: c.StartDate, End: c.Day, Sprint: c.SprintStart},
 		ReviewOf:    c.ReviewOf,
 		Parent:      c.Parent,

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -116,6 +116,10 @@ type Card struct {
 	// top-level card). Subtasks are one level deep: a parent cannot itself be
 	// a subtask, and a card with subtasks cannot become one.
 	Parent string `json:"parent,omitempty"`
+	// Recurrence is a recurrent card's reseed cycle: "" = every sprint (the
+	// default), "week" / "month" = only once that interval has elapsed since
+	// the sprint the card is bound to (see RecurrenceDue).
+	Recurrence string `json:"recurrence,omitempty"`
 	// ReviewRound counts a review card's review rounds. A card sent back for
 	// another review after already passing starts round 2, 3, … The first
 	// review is implicit and left at 0 (round 1 is not shown).

--- a/pkg/board/events.go
+++ b/pkg/board/events.go
@@ -48,6 +48,7 @@ const (
 	EventReviewRound     = "review-round"
 	EventParent          = "parent"
 	EventSubtask         = "subtask"
+	EventRecurrence      = "recurrence"
 )
 
 // DateRange renders a start..end pair for a dates event value ("" parts kept

--- a/pkg/board/recurrence.go
+++ b/pkg/board/recurrence.go
@@ -1,0 +1,46 @@
+package board
+
+import "time"
+
+// Recurrence cycles: how often a finished recurrent card reseeds a fresh copy
+// at carry-over. The empty default keeps the original behaviour — every sprint.
+const (
+	RecurrenceSprint = ""      // every sprint (default)
+	RecurrenceWeek   = "week"  // reseed when the new sprint is ≥1 week past the card's sprint
+	RecurrenceMonth  = "month" // reseed when the new sprint is ≥1 calendar month past
+)
+
+// ValidRecurrence reports whether cycle is a storable recurrence value.
+func ValidRecurrence(cycle string) bool {
+	switch cycle {
+	case RecurrenceSprint, RecurrenceWeek, RecurrenceMonth:
+		return true
+	}
+	return false
+}
+
+// RecurrenceDue reports whether a recurrent card's next iteration is due on
+// day (the sprint being started): always for the per-sprint default, and once
+// the interval has elapsed since the sprint the card is bound to otherwise.
+// A cycle card without a sprint anchor is never due — there is nothing to
+// count the interval from.
+func RecurrenceDue(c Card, day string) bool {
+	switch c.Recurrence {
+	case RecurrenceWeek:
+		return c.SprintStart != "" && AddDays(c.SprintStart, 7) <= day
+	case RecurrenceMonth:
+		return c.SprintStart != "" && addMonths(c.SprintStart, 1) <= day
+	default:
+		return true
+	}
+}
+
+// addMonths shifts an ISO date by whole calendar months (Go-normalised: Jan 31
+// +1 month = Mar 2/3). A malformed date comes back unchanged.
+func addMonths(iso string, months int) string {
+	t, err := time.Parse(isoLayout, iso)
+	if err != nil {
+		return iso
+	}
+	return t.AddDate(0, months, 0).Format(isoLayout)
+}

--- a/pkg/boardservice/backend.go
+++ b/pkg/boardservice/backend.go
@@ -57,6 +57,8 @@ type Backend interface {
 	SetPlan(ctx context.Context, b board.Board, card board.Card, plan board.PlanBand) error
 	SetWeek(ctx context.Context, b board.Board, card board.Card, week string) error
 	SetTeam(ctx context.Context, b board.Board, card board.Card, team string) error
+	// SetRecurrence sets a recurrent card's reseed cycle ("" = every sprint).
+	SetRecurrence(ctx context.Context, b board.Board, card board.Card, cycle string) error
 	SetAssignee(ctx context.Context, b board.Board, card board.Card, login string) error
 	// SetParent sets or clears ("") the parent link making a card a subtask.
 	SetParent(ctx context.Context, b board.Board, card board.Card, parent string) error

--- a/pkg/boardservice/boardservicetest/fake.go
+++ b/pkg/boardservice/boardservicetest/fake.go
@@ -297,6 +297,15 @@ func (f *Backend) SetTeam(_ context.Context, _ board.Board, card board.Card, tea
 	return nil
 }
 
+// SetRecurrence sets a recurrent card's reseed cycle.
+func (f *Backend) SetRecurrence(_ context.Context, _ board.Board, card board.Card, cycle string) error {
+	f.rec("SetRecurrence %s %s", card.ItemID, cycle)
+	if c := f.Card(card.ItemID); c != nil {
+		c.Recurrence = cycle
+	}
+	return nil
+}
+
 // SetAssignee replaces a card's assignee.
 func (f *Backend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
 	f.rec("SetAssignee %s %s", card.ItemID, login)

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -327,28 +327,15 @@ type CarryReport struct {
 	Reseeded int `json:"reseeded"`
 }
 
-// CarryOver advances a team's sprint to today (the old current becomes previous)
-// and pulls its unfinished cards forward. It mirrors startSprint in TeamBoard.tsx:
-// idempotent (a no-op when the sprint is already today's), and it always advances
-// even with nothing to carry. team = "" is the no-team group. With dryRun the
-// would-be counts are reported and nothing is written.
-func (s *Service) CarryOver(ctx context.Context, owner string, project int, team string, dryRun bool) (CarryReport, error) {
-	b, err := s.backend.LoadBoard(ctx, owner, project)
-	if err != nil {
-		return CarryReport{}, err
-	}
-	old := board.CurrentSprint(b, team)
-	today := board.TodayIso()
-	if old == today {
-		// Already on today's sprint: re-advancing would overwrite previous.
-		return CarryReport{}, nil
-	}
+// selectCarry partitions a team's cards for a carry-over closing sprint old
+// and opening today: cards to carry forward, finished recurrent cards to
+// reseed, and completed review cards to pin back to the closing sprint.
+func selectCarry(b board.Board, team, old, today string) (carry, reseed, relocate []board.Card) {
 	// Carry only the unfinished cards of the sprint being closed (sprintStart ==
 	// the old current pointer). A card that is NOT on today's sprint — demoted
 	// back to an earlier one, or simply old — stays where it is, so removing a
 	// card from the current sprint is final and it never boomerangs back. A
 	// finished recurrent card stays behind and reseeds a fresh copy instead.
-	var carry, reseed, relocate []board.Card
 	for _, c := range b.Cards {
 		// A subtask is never carried on its own - it rides with its parent
 		// (below), whatever team either of them belongs to.
@@ -370,11 +357,26 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 			carry = append(carry, c)
 			continue
 		}
+		// A weekly/monthly recurrent card RESTS outside the current cycle: a
+		// finished (or deliberately backdated) one sits in a past sprint until
+		// the interval elapses, then the carry-over that reaches its due day
+		// reseeds it. A newer copy (same team+title, later sprint) means it
+		// was already reseeded — skip, so reruns never duplicate.
+		if c.Recurrence != "" && c.Stage == board.StageRecurrent && c.SprintStart != old {
+			if board.RecurrenceDue(c, today) && !hasNewerRecurrent(b, c) {
+				reseed = append(reseed, c)
+			}
+			continue
+		}
 		if old == "" || c.SprintStart != old {
 			continue
 		}
 		if c.Stage == board.StageRecurrent && c.Progress >= 100 {
-			reseed = append(reseed, c)
+			// A cycle card finished in the closing sprint reseeds only when
+			// its week/month has elapsed; until then it stays behind, resting.
+			if board.RecurrenceDue(c, today) {
+				reseed = append(reseed, c)
+			}
 			continue
 		}
 		if board.Complete(c.Stage, c.Progress) {
@@ -397,6 +399,26 @@ func (s *Service) CarryOver(ctx context.Context, owner string, project int, team
 		}
 		carry = append(carry, c)
 	}
+	return carry, reseed, relocate
+}
+
+// CarryOver advances a team's sprint to today (the old current becomes previous)
+// and pulls its unfinished cards forward. It mirrors startSprint in TeamBoard.tsx:
+// idempotent (a no-op when the sprint is already today's), and it always advances
+// even with nothing to carry. team = "" is the no-team group. With dryRun the
+// would-be counts are reported and nothing is written.
+func (s *Service) CarryOver(ctx context.Context, owner string, project int, team string, dryRun bool) (CarryReport, error) {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return CarryReport{}, err
+	}
+	old := board.CurrentSprint(b, team)
+	today := board.TodayIso()
+	if old == today {
+		// Already on today's sprint: re-advancing would overwrite previous.
+		return CarryReport{}, nil
+	}
+	carry, reseed, relocate := selectCarry(b, team, old, today)
 	// Subtasks ride with their carried parent - even completed ones, and
 	// whatever team they belong to; the parent's team drives the sprint.
 	followers := carryFollowers(b, carry)
@@ -485,10 +507,57 @@ func (s *Service) reseedRecurrent(ctx context.Context, b board.Board, c board.Ca
 	if err := s.backend.SetStage(ctx, b, created, board.StageRecurrent); err != nil {
 		return err
 	}
+	if c.Recurrence != "" {
+		if err := s.backend.SetRecurrence(ctx, b, created, c.Recurrence); err != nil {
+			return err
+		}
+	}
 	if desc := board.StripEventLines(c.Description); desc != "" {
 		return s.backend.SetDescription(ctx, b, created, desc)
 	}
 	return nil
+}
+
+// SetRecurrence sets a recurrent card's reseed cycle: "" (every sprint, the
+// default), "week" or "month". Only cards on the recurrent stage carry a
+// cycle — the stage menu is the only path here, and applyStage sheds the
+// cycle when the stage changes.
+func (s *Service) SetRecurrence(ctx context.Context, owner string, project int, itemID, cycle string) error {
+	if !board.ValidRecurrence(cycle) {
+		return fmt.Errorf("%w: unknown recurrence %q (\"\" | week | month)", ErrInvalidStage, cycle)
+	}
+	b, c, err := s.loadCard(ctx, owner, project, itemID)
+	if err != nil {
+		return err
+	}
+	if c.Recurrence == cycle {
+		return nil
+	}
+	if cycle != "" && c.Stage != board.StageRecurrent {
+		return fmt.Errorf("%w: a recurrence cycle needs the recurrent stage", ErrInvalidStage)
+	}
+	if err := s.backend.SetRecurrence(ctx, b, c, cycle); err != nil {
+		return err
+	}
+	s.logEvent(ctx, b, c, board.EventRecurrence, c.Recurrence, cycle)
+	return nil
+}
+
+// hasNewerRecurrent reports whether the board holds a fresher copy of a
+// resting weekly/monthly recurrent card: same team and title, still on the
+// recurrent stage, bound to a later sprint. Its presence means a past
+// carry-over already reseeded this card — the old one is history.
+func hasNewerRecurrent(b board.Board, c board.Card) bool {
+	for _, o := range b.Cards {
+		if o.ItemID == c.ItemID {
+			continue
+		}
+		if o.Team == c.Team && o.Title == c.Title &&
+			o.Stage == board.StageRecurrent && o.SprintStart > c.SprintStart {
+			return true
+		}
+	}
+	return false
 }
 
 // setSprintStartRetry sets a card's Sprint Start, retrying a few times with
@@ -990,6 +1059,15 @@ func (s *Service) applyStage(ctx context.Context, b board.Board, card board.Card
 	newStage, newProgress := board.ApplyStage(stage, card.Progress)
 	if err := s.backend.SetStage(ctx, b, card, newStage); err != nil {
 		return err
+	}
+	// Leaving the recurrent stage sheds the cycle: a stale hidden "monthly"
+	// marker on a now-ordinary card would resurrect it at some future
+	// carry-over.
+	if newStage != board.StageRecurrent && card.Recurrence != "" {
+		if err := s.backend.SetRecurrence(ctx, b, card, ""); err != nil {
+			return err
+		}
+		s.logEvent(ctx, b, card, board.EventRecurrence, card.Recurrence, "")
 	}
 	if newProgress != card.Progress {
 		if err := s.backend.SetProgress(ctx, b, card, newProgress); err != nil {

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -240,6 +240,14 @@ func (f *fakeBackend) SetTeam(_ context.Context, _ board.Board, card board.Card,
 	return nil
 }
 
+func (f *fakeBackend) SetRecurrence(_ context.Context, _ board.Board, card board.Card, cycle string) error {
+	f.rec("SetRecurrence %s %s", card.ItemID, cycle)
+	if c := f.get(card.ItemID); c != nil {
+		c.Recurrence = cycle
+	}
+	return nil
+}
+
 func (f *fakeBackend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
 	f.rec("SetAssignee %s %s", card.ItemID, login)
 	if c := f.get(card.ItemID); c != nil {
@@ -2139,5 +2147,138 @@ func TestNoteLengthLimit(t *testing.T) {
 	}
 	if err := svc.AddNote(ctx, "acme", 1, "c1", strings.Repeat("x", MaxNoteLen)); err != nil {
 		t.Fatalf("at the limit must pass: %v", err)
+	}
+}
+
+// A weekly recurrent card finished in the closing sprint does NOT reseed the
+// next morning — it rests until a carry-over reaches its due day.
+func TestCarryOverWeeklyRecurrenceRests(t *testing.T) {
+	today := board.TodayIso()
+	old := board.AddDays(today, -1) // closing sprint = yesterday
+	f := newFake([]board.Card{
+		{ItemID: "w1", Team: "alpha", SprintStart: old, Stage: board.StageRecurrent,
+			Progress: 100, Recurrence: board.RecurrenceWeek, Title: "weekly report"},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Reseeded != 0 || len(f.creates) != 0 {
+		t.Fatalf("not-due weekly card must rest; rep=%+v creates=%v", rep, f.creates)
+	}
+	if f.get("w1").SprintStart != old {
+		t.Fatalf("resting card must stay put: %+v", f.get("w1"))
+	}
+}
+
+// Once the interval has elapsed, a resting weekly/monthly card is reseeded even
+// though its sprint is long past the one being closed — and the fresh copy
+// carries the cycle.
+func TestCarryOverWeeklyRecurrenceReseedsWhenDue(t *testing.T) {
+	today := board.TodayIso()
+	anchor := board.AddDays(today, -7) // bound a week ago -> due today
+	old := board.AddDays(today, -1)
+	f := newFake([]board.Card{
+		{ItemID: "w1", Team: "alpha", SprintStart: anchor, Stage: board.StageRecurrent,
+			Progress: 100, Recurrence: board.RecurrenceWeek, Title: "weekly report"},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Reseeded != 1 || len(f.creates) != 1 {
+		t.Fatalf("due weekly card must reseed; rep=%+v creates=%v log=%v", rep, f.creates, f.log)
+	}
+	in := f.creates[0]
+	if in.Title != "weekly report" || in.SprintStart != today {
+		t.Fatalf("reseed input = %+v", in)
+	}
+	carried := false
+	for _, l := range f.log {
+		if strings.HasPrefix(l, "SetRecurrence new") && strings.HasSuffix(l, " week") {
+			carried = true
+		}
+	}
+	if !carried {
+		t.Fatalf("the copy must carry the cycle; log=%v", f.log)
+	}
+}
+
+// A backdated, still-unfinished monthly card (the "recurs on the 1st" calendar
+// flow) also reseeds when due — completion is not required for cycle cards
+// that already fell off the board.
+func TestCarryOverMonthlyRecurrenceBackdated(t *testing.T) {
+	today := board.TodayIso()
+	anchor := board.AddDays(today, -31) // over a calendar month ago
+	old := board.AddDays(today, -1)
+	f := newFake([]board.Card{
+		{ItemID: "m1", Team: "alpha", SprintStart: anchor, Stage: board.StageRecurrent,
+			Progress: 0, Recurrence: board.RecurrenceMonth, Title: "monthly invoice"},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Reseeded != 1 || len(f.creates) != 1 {
+		t.Fatalf("due monthly card must reseed; rep=%+v log=%v", rep, f.log)
+	}
+}
+
+// A due resting card with a FRESHER copy on the board (same team+title, later
+// sprint) was already reseeded by a past carry-over: reruns must not duplicate.
+func TestCarryOverRecurrenceNoDuplicateReseed(t *testing.T) {
+	today := board.TodayIso()
+	anchor := board.AddDays(today, -14)
+	newer := board.AddDays(today, -7)
+	old := board.AddDays(today, -1)
+	f := newFake([]board.Card{
+		{ItemID: "w1", Team: "alpha", SprintStart: anchor, Stage: board.StageRecurrent,
+			Progress: 100, Recurrence: board.RecurrenceWeek, Title: "weekly report"},
+		{ItemID: "w2", Team: "alpha", SprintStart: newer, Stage: board.StageRecurrent,
+			Progress: 100, Recurrence: board.RecurrenceWeek, Title: "weekly report"},
+	}, map[string]board.SprintState{"alpha": {Current: old}})
+	rep, err := f2svc(f).CarryOver(ctx, "acme", 1, "alpha", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only w2 (the newest) is a legitimate reseed source; w1 is history.
+	if rep.Reseeded != 1 || len(f.creates) != 1 {
+		t.Fatalf("exactly one reseed expected; rep=%+v creates=%v", rep, f.creates)
+	}
+}
+
+// Leaving the recurrent stage sheds the cycle, so a stale hidden marker can
+// never resurrect the card at some future carry-over.
+func TestStageChangeShedsRecurrence(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "c1", Team: "alpha", Stage: board.StageRecurrent,
+			Recurrence: board.RecurrenceMonth, Progress: 40},
+	}, nil)
+	if err := f2svc(f).SetStage(ctx, "acme", 1, "c1", board.StageLocked); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("SetRecurrence c1 ") {
+		t.Fatalf("cycle must be cleared on leaving recurrent; log=%v", f.log)
+	}
+}
+
+// SetRecurrence validates the cycle and requires the recurrent stage.
+func TestSetRecurrenceValidation(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "c1", Team: "alpha", Stage: board.StageRecurrent},
+		{ItemID: "c2", Team: "alpha"},
+	}, nil)
+	svc := f2svc(f)
+	if err := svc.SetRecurrence(ctx, "acme", 1, "c1", "week"); err != nil {
+		t.Fatal(err)
+	}
+	if f.get("c1").Recurrence != "week" {
+		t.Fatalf("cycle not stored: %+v", f.get("c1"))
+	}
+	if err := svc.SetRecurrence(ctx, "acme", 1, "c1", "yearly"); err == nil {
+		t.Fatal("unknown cycle must be rejected")
+	}
+	if err := svc.SetRecurrence(ctx, "acme", 1, "c2", "week"); err == nil {
+		t.Fatal("cycle on a non-recurrent card must be rejected")
 	}
 }

--- a/pkg/ghprojects/load.go
+++ b/pkg/ghprojects/load.go
@@ -315,6 +315,8 @@ func applyDomainRole(card *board.Card, v *rawFieldValue, roles domainFieldRoles)
 		card.Parent = v.Text
 	case roles.ReviewRound != nil && id == roles.ReviewRound.ID && v.Number != nil:
 		card.ReviewRound = int(*v.Number)
+	case roles.Recurrence != nil && id == roles.Recurrence.ID && v.Text != "":
+		card.Recurrence = v.Text
 	}
 }
 
@@ -336,6 +338,7 @@ type domainFieldRoles struct {
 	ReviewOf    *board.ProjectField
 	Parent      *board.ProjectField
 	ReviewRound *board.ProjectField
+	Recurrence  *board.ProjectField
 }
 
 // domainRoleAliases maps each role to the field names (case-insensitive) that
@@ -356,6 +359,7 @@ var domainRoleAliases = map[string][]string{
 	"reviewOf":    {"review of", "reviewof"},
 	"parent":      {"parent"},
 	"reviewRound": {"review round", "reviewround"},
+	"recurrence":  {"recurrence", "recur"},
 }
 
 // domainRoles maps the board's fields onto the typed roles by name.
@@ -393,6 +397,8 @@ func domainRoles(fields []board.ProjectField) domainFieldRoles {
 			r.Parent = f
 		case r.ReviewRound == nil && domainMatchesAlias("reviewRound", name):
 			r.ReviewRound = f
+		case r.Recurrence == nil && domainMatchesAlias("recurrence", name):
+			r.Recurrence = f
 		}
 	}
 	return r
@@ -429,6 +435,8 @@ func (r domainFieldRoles) get(role string) *board.ProjectField {
 		return r.Parent
 	case "reviewRound":
 		return r.ReviewRound
+	case "recurrence":
+		return r.Recurrence
 	default:
 		return nil
 	}

--- a/pkg/ghprojects/setters.go
+++ b/pkg/ghprojects/setters.go
@@ -67,6 +67,7 @@ var domainFieldSpecs = map[string]domainFieldSpec{
 	"day":         {name: "Day", dataType: "DATE"},
 	"start":       {name: "Start", dataType: "DATE"},
 	"sprintStart": {name: "Sprint Start", dataType: "DATE"},
+	"recurrence":  {name: "Recurrence", dataType: "TEXT"},
 	"plan": {name: "Plan", options: []domainSelectOption{
 		{"Wed", "BLUE", "By Wednesday"},
 		{"Fri", "PURPLE", "By Friday"},
@@ -430,6 +431,11 @@ func (c *Client) setDomainDate(ctx context.Context, b board.Board, card board.Ca
 // SetTeam sets (or clears) the card's team label.
 func (c *Client) SetTeam(ctx context.Context, b board.Board, card board.Card, team string) error {
 	return c.setDomainText(ctx, b, card, "team", team)
+}
+
+// SetRecurrence sets (or clears) a recurrent card's reseed cycle.
+func (c *Client) SetRecurrence(ctx context.Context, b board.Board, card board.Card, cycle string) error {
+	return c.setDomainText(ctx, b, card, "recurrence", cycle)
 }
 
 // SetReviewOf sets (or clears) the review-of link on a review card.

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -218,6 +218,7 @@ type updateCardInput struct {
 	Assignee    *string `json:"assignee,omitempty" jsonschema:"GitHub login; empty unassigns"`
 	Progress    *int    `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
 	Stage       *string `json:"stage,omitempty" jsonschema:"locked, review, recurrent or done; empty clears it"`
+	Recurrence  *string `json:"recurrence,omitempty" jsonschema:"reseed cycle of a recurrent card: empty = every sprint (default), week or month = reseeded by carry-over only once that interval has elapsed since the card's sprint"`
 	Start       *string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd, calendar semantics: the card rejoins the sprint active on it; empty clears the dates"`
 	End         *string `json:"end,omitempty" jsonschema:"end/due day as yyyy-mm-dd; empty clears it"`
 	Sprint      *string `json:"sprint,omitempty" jsonschema:"sprint start day the card belongs to; empty clears it"`
@@ -282,6 +283,11 @@ func (h *server) applyCardPatch(ctx context.Context, svc *boardservice.Service, 
 	}
 	if in.Stage != nil {
 		if err := svc.SetStage(ctx, owner, project, in.UID, board.StageKey(*in.Stage)); err != nil {
+			return err
+		}
+	}
+	if in.Recurrence != nil {
+		if err := svc.SetRecurrence(ctx, owner, project, in.UID, *in.Recurrence); err != nil {
 			return err
 		}
 	}

--- a/web/src/api/resources.ts
+++ b/web/src/api/resources.ts
@@ -61,6 +61,7 @@ export interface CardResource {
     assignees?: string[];
     progress?: number;
     stage?: string;
+    recurrence?: string;
     dates?: { start?: string; end?: string; sprint?: string };
     plan?: { band?: string; week?: string };
     reviewOf?: string;
@@ -167,6 +168,7 @@ export function resourceToCard(res: CardResource): Card {
     reviewOf: spec.reviewOf || undefined,
     parent: spec.parent || undefined,
     reviewRound: res.status?.reviewRound,
+    recurrence: spec.recurrence || undefined,
     day: dates.end || undefined,
     startDate: dates.start || undefined,
     sprintStart: dates.sprint || undefined,

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -23,7 +23,11 @@ interface CardProps {
   onSelect: (card: CardModel) => void;
   onProgress: (card: CardModel, value: number) => void;
   onDelete: (card: CardModel) => void;
-  onStage: (card: CardModel, stage: StageKey | null) => void;
+  onStage: (
+    card: CardModel,
+    stage: StageKey | null,
+    recurrence?: "" | "week" | "month",
+  ) => void;
   /** Pick the implicit "In Progress" status: clears the stage and clamps the
    *  card's progress into [10, 90]. */
   onInProgress: (card: CardModel) => void;
@@ -139,6 +143,10 @@ export function Card({
   const ref = ticket(card);
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [recOpen, setRecOpen] = useState(false);
+  // The cycle submenu opens to the right; near the viewport edge it flips
+  // left so it never clips off-screen.
+  const [recLeft, setRecLeft] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(card.title);
   const [dragValue, setDragValue] = useState<number | null>(null);
@@ -242,7 +250,21 @@ export function Card({
   const pickStage = (e: React.MouseEvent<HTMLButtonElement>, stage: StageKey | null) => {
     e.stopPropagation();
     setMenuOpen(false);
+    setRecOpen(false);
     onStage(card, stage);
+  };
+
+  // The recurrent cycle picker: Recurrent expands a submenu on the right —
+  // every sprint (the default), weekly or monthly. Picking a cycle sets the
+  // stage and the cycle together.
+  const pickRecurrence = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    cycle: "" | "week" | "month",
+  ) => {
+    e.stopPropagation();
+    setMenuOpen(false);
+    setRecOpen(false);
+    onStage(card, "recurrent", cycle);
   };
 
   const pickInProgress = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -359,7 +381,11 @@ export function Card({
           card.stage === "review"
             ? "On review"
             : card.stage === "recurrent"
-              ? "Recurrent"
+              ? card.recurrence === "week"
+                ? "Recurrent (weekly)"
+                : card.recurrence === "month"
+                  ? "Recurrent (monthly)"
+                  : "Recurrent"
               : card.stage === "locked"
                 ? "Locked"
                 : "Status"
@@ -435,7 +461,65 @@ export function Card({
           // A review card is auxiliary: it cannot be put on the "review" stage
           // itself, nor made "recurrent" (a repeating task makes no sense for a
           // one-off review).
-          (stage === "review" || stage === "recurrent") && card.reviewOf ? null : (
+          (stage === "review" || stage === "recurrent") && card.reviewOf ? null : stage ===
+            "recurrent" ? (
+            // Recurrent expands a cycle submenu on the right: every sprint
+            // (the default, plain click), weekly or monthly.
+            <div
+              key={stage}
+              className="card-stage-rec"
+              onMouseEnter={(e) => {
+                setRecLeft(
+                  e.currentTarget.getBoundingClientRect().right + 130 >
+                    window.innerWidth,
+                );
+                setRecOpen(true);
+              }}
+              onMouseLeave={() => setRecOpen(false)}
+            >
+              <button
+                type="button"
+                className={`card-stage-item${card.stage === "recurrent" ? " card-stage-item-active" : ""}`}
+                onClick={(e) => pickRecurrence(e, "")}
+              >
+                <span
+                  className="card-stage-dot"
+                  style={{ background: STAGES[stage].color }}
+                />
+                {STAGES[stage].label}
+                <span className="card-stage-sub-arrow" aria-hidden="true">
+                  ▸
+                </span>
+              </button>
+              {recOpen && (
+                <div
+                  className={`card-stage-submenu${recLeft ? " card-stage-submenu-left" : ""}`}
+                >
+                  {(
+                    [
+                      ["", "Every sprint"],
+                      ["week", "Weekly"],
+                      ["month", "Monthly"],
+                    ] as const
+                  ).map(([cycle, label]) => (
+                    <button
+                      key={cycle || "sprint"}
+                      type="button"
+                      className={`card-stage-item${
+                        card.stage === "recurrent" &&
+                        (card.recurrence ?? "") === cycle
+                          ? " card-stage-item-active"
+                          : ""
+                      }`}
+                      onClick={(e) => pickRecurrence(e, cycle)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
             <button
               key={stage}
               type="button"

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -743,10 +743,15 @@ export function MeBoard({
   // knocks a full review/locked card to 90, and cancels the linked review card
   // when the original leaves review. The optimistic patch mirrors the local
   // effects; the re-list converges the linked-card cascade.
-  const handleStage = (card: CardModel, stage: StageKey | null) => {
+  const handleStage = (
+    card: CardModel,
+    stage: StageKey | null,
+    recurrence?: "" | "week" | "month",
+  ) => {
     const prev: Partial<CardModel> = {
       stage: card.stage,
       progress: card.progress,
+      recurrence: card.recurrence,
     };
     // Done on a recurrent card completes the iteration but keeps the
     // recurrence (mirrors the server): only the progress fills.
@@ -758,6 +763,13 @@ export function MeBoard({
             : undefined
           : stage ?? undefined,
     };
+    // The recurrent picker carries the cycle; any other stage sheds it
+    // (mirrors the server's applyStage).
+    if (stage === "recurrent") {
+      patch.recurrence = recurrence ?? "";
+    } else if (stage !== "done" && card.recurrence) {
+      patch.recurrence = "";
+    }
     if (stage === "done") {
       patch.progress = 100;
     }
@@ -773,7 +785,10 @@ export function MeBoard({
     const enteringReview = stage === "review" && card.stage !== "review";
     const hasLinkedReview = board.cards.some((c) => c.reviewOf === card.itemId);
     void provider
-      .patchCard(board, card.itemId, { stage: stage ?? "" })
+      .patchCard(board, card.itemId, {
+        stage: stage ?? "",
+        ...(stage === "recurrent" ? { recurrence: recurrence ?? "" } : {}),
+      })
       .then((updated) => {
         addCard(updated);
         refreshLog(card.itemId);

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1365,10 +1365,15 @@ export function TeamBoard({
   // knocks a full review/locked card to 90, and cancels the linked review card
   // when the original leaves review. The optimistic patch mirrors the local
   // effects; the re-list converges the linked-card cascade.
-  const handleStage = (card: CardModel, stage: StageKey | null) => {
+  const handleStage = (
+    card: CardModel,
+    stage: StageKey | null,
+    recurrence?: "" | "week" | "month",
+  ) => {
     const prev: Partial<CardModel> = {
       stage: card.stage,
       progress: card.progress,
+      recurrence: card.recurrence,
     };
     // Done on a recurrent card completes the iteration but keeps the
     // recurrence (mirrors the server): only the progress fills.
@@ -1380,6 +1385,13 @@ export function TeamBoard({
             : undefined
           : stage ?? undefined,
     };
+    // The recurrent picker carries the cycle; any other stage sheds it
+    // (mirrors the server's applyStage).
+    if (stage === "recurrent") {
+      patch.recurrence = recurrence ?? "";
+    } else if (stage !== "done" && card.recurrence) {
+      patch.recurrence = "";
+    }
     if (stage === "done") {
       patch.progress = 100;
     }
@@ -1395,7 +1407,10 @@ export function TeamBoard({
     const enteringReview = stage === "review" && card.stage !== "review";
     const hasLinkedReview = board.cards.some((c) => c.reviewOf === card.itemId);
     void provider
-      .patchCard(board, card.itemId, { stage: stage ?? "" })
+      .patchCard(board, card.itemId, {
+        stage: stage ?? "",
+        ...(stage === "recurrent" ? { recurrence: recurrence ?? "" } : {}),
+      })
       .then((updated) => {
         addCard(updated);
         if (

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -113,6 +113,9 @@ function patchBody(patch: CardPatch): Record<string, unknown> {
   if (patch.progress !== undefined) {
     body.progress = patch.progress;
   }
+  if (patch.recurrence !== undefined) {
+    body.recurrence = patch.recurrence;
+  }
   if (patch.stage !== undefined) {
     body.stage = patch.stage;
   }

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -60,6 +60,8 @@ export interface Card {
   parent?: string;
   /** On a review card, its review-round counter (>=2 shown; round 1 implicit). */
   reviewRound?: number;
+  /** A recurrent card's reseed cycle: "" = every sprint, "week" | "month". */
+  recurrence?: string;
   /** ISO date (yyyy-mm-dd) the card is planned to finish/be due on. */
   day?: string;
   /** ISO date (yyyy-mm-dd) the card starts on (set at creation). */
@@ -147,6 +149,8 @@ export interface CardPatch {
   parent?: string;
   /** On a review card, its review-round counter (>=2 shown; round 1 implicit). */
   reviewRound?: number;
+  /** Recurrent card's reseed cycle: "" = every sprint, "week" | "month". */
+  recurrence?: string;
 }
 
 /** CarryReport is what a carry-over / carry-week pass did — or would do on a

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3056,3 +3056,37 @@ button.card-age {
   outline: 2px dashed var(--accent);
   outline-offset: -2px;
 }
+
+/* The Recurrent item's cycle submenu: expands to the right of the stage menu
+   (every sprint / weekly / monthly). The wrapper keeps hover alive across the
+   gap between the row and the flyout. */
+.card-stage-rec {
+  position: relative;
+}
+
+.card-stage-sub-arrow {
+  margin-left: auto;
+  padding-left: 10px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.card-stage-submenu {
+  position: absolute;
+  left: 100%;
+  top: -4px;
+  min-width: 110px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 4px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-stage-submenu-left {
+  left: auto;
+  right: 100%;
+}


### PR DESCRIPTION
## What

A recurrent card can now repeat on a longer cycle than every sprint. The Recurrent item in the card's stage menu expands a submenu on the right — **Every sprint** (default), **Weekly**, **Monthly** — and the picked cycle is stored in a `Recurrence` TEXT field, provisioned lazily like every other aeman field.

## Behaviour

- **Carry-over gate**: a finished weekly/monthly card is reseeded only when the sprint being started is at least a week / a calendar month past the sprint the card is bound to. Until then it rests in its past sprint.
- **Resting scan**: due cycle cards are found board-wide (not only in the closing sprint), so a card completed many sprints ago still reseeds on its day. A fresher copy (same team + title, later sprint) suppresses the reseed, which keeps reruns idempotent without extra writes.
- **Calendar anchoring**: set-dates already re-anchors the cycle — moving the card's start to the 1st re-binds its sprint, and a backdated, even unfinished cycle card reseeds when its interval elapses (the "created mid-month, repeats on the 1st" flow).
- **Cycle hygiene**: leaving the recurrent stage sheds the cycle (a stale hidden marker could otherwise resurrect the card months later); a cycle on a non-recurrent card and unknown cycle values are rejected with 422.
- The reseeded copy carries the cycle; the stage-icon tooltip shows it ("Recurrent (monthly)"); the submenu flips to open leftwards near the viewport edge.
- Exposed on the REST API (`spec.recurrence`, PATCH) and the MCP `update_card` tool.

## Testing

- Unit tests: rest-until-due, reseed-when-due (copy carries the cycle), backdated unfinished reseed, duplicate-reseed suppression, stage-change shedding, validation.
- Manually on a dev board: submenu render/flip, cycle round-trip through the write-behind queue, lazy `Recurrence` field provisioning on GitHub, live carry-over with a not-due cycle card (carried, not reseeded).
- Full Go + web suites and golangci-lint pass.