### PR TITLE
perf(api): answer carry ops from the cached snapshot

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -913,7 +913,13 @@ func (s *Server) handleCarryOver(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	rep, err := svc.CarryOver(r.Context(), owner, project, in.Team, in.DryRun)
+	// The carry ops read the board through the SAME snapshot every other
+	// mutation already trusts: with write-behind the cache (queue replayed on
+	// top) IS the live truth, while a blocking GitHub reload here only adds
+	// seconds of latency and a chance to read a lagging replica. Stale-window
+	// semantics apply; a cold cache still loads.
+	ctx, _ := withStaleAllowed(r.Context())
+	rep, err := svc.CarryOver(ctx, owner, project, in.Team, in.DryRun)
 	if err != nil {
 		s.apiError(w, err)
 		return
@@ -934,7 +940,9 @@ func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	rep, err := svc.CarryWeek(r.Context(), owner, project, in.Team, in.Week, in.DryRun)
+	// Same cached-snapshot read as carry-over (see handleCarryOver).
+	ctx, _ := withStaleAllowed(r.Context())
+	rep, err := svc.CarryWeek(ctx, owner, project, in.Team, in.Week, in.DryRun)
 	if err != nil {
 		s.apiError(w, err)
 		return

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -7,8 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"strings"
 
 	"github.com/aenix-io/aeman/pkg/apiserver"
 	"github.com/aenix-io/aeman/pkg/board"
@@ -568,5 +571,55 @@ func TestCachedAuthz(t *testing.T) {
 	e.loadedAt = time.Now().Add(-boardStaleMax - time.Second)
 	if _, state := e.cached("alice", true); state != cacheMiss {
 		t.Fatal("past boardStaleMax the cache must miss regardless of authorization")
+	}
+}
+
+// failAfterFirstLoad serves one upstream board load, then hard-fails: a test
+// double for "GitHub is slow/unreachable right now".
+type failAfterFirstLoad struct {
+	*swrBackend
+	calls atomic.Int32
+}
+
+func (f *failAfterFirstLoad) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
+	if f.calls.Add(1) > 1 {
+		return board.Board{}, errors.New("upstream unavailable")
+	}
+	return f.swrBackend.LoadBoard(ctx, owner, project)
+}
+
+// Carry over must answer from the cached snapshot inside the stale window —
+// its blocking full-board reload was the whole wait behind the button. The
+// upstream here fails after the seeding load, so a 200 proves the handler
+// never blocked on a fresh read.
+func TestCarryOverServedFromSnapshot(t *testing.T) {
+	srv := newTestServer(t)
+	inner := &failAfterFirstLoad{swrBackend: &swrBackend{board: watchBoard()}}
+	srv.newService = func(*http.Request) (*boardservice.Service, error) {
+		return boardservice.New(&storeBackend{inner: inner, store: srv.store}), nil
+	}
+
+	// Seed the cache (the one allowed upstream load), then age it past the
+	// fresh TTL into the stale window.
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/cards?owner=acme&project=1&view=all", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed read: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	e := srv.store.entry("acme/1")
+	e.mu.Lock()
+	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
+	e.mu.Unlock()
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sprints/actions/carry-over?owner=acme&project=1",
+		strings.NewReader(`{"team":"alpha","dryRun":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	srv.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("carry-over dry run blocked on the upstream: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "carried") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Problem

Pressing Carry over showed a long progress bar before anything moved. The wait was not the carry itself: the dry run (which only feeds the confirm-dialog counts) and the real pass each begin with a board read, and mutation-path reads always blocked for a FRESH board — a full paginated GitHub reload whenever the cache was over 30 seconds old, seconds each on a real board. The mutations that follow are write-behind and effectively instant.

## Fix

The carry-over and carry-week handlers opt into the stale window the way reads do: they are answered from the cached snapshot (with the write-behind queue replayed on top — the server's live truth) while a background revalidation refreshes the cache. A cold cache still loads in full, and every other mutation keeps the fresh-read path.

The original "mutations must read fresh" rule predates write-behind; today a blocking GitHub read adds latency and a chance of reading a lagging replica, not correctness.

## Testing

- New HTTP-level test: with the cache aged into the stale window and the upstream hard-failing, the carry-over dry run still answers 200 from the snapshot — proving the handler never blocks on a fresh read.
- Existing guard test (`TestMutationReadsBlockForFresh`) still passes: other mutations keep blocking for fresh.
- Full Go + web suites and golangci-lint pass.