### PR TITLE
style(theme): tell the done bar from the in-progress one everywhere

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -145,7 +145,7 @@
   --stage-locked: #cf222e;
   --stage-review: #b07d1a;
   --stage-recurrent: #1f6feb;
-  --stage-done: #2596b5;
+  --stage-done: #16657f;
   --bar-default: #2596b5;
 
   /* Weekly-plan deadline bands: under tritanopia violet drifts toward the
@@ -220,7 +220,9 @@
   --stage-locked: #ff7b72;
   --stage-review: #e3b341;
   --stage-recurrent: #79c0ff;
-  --stage-done: #3fb950;
+  /* Done deepens, the in-progress bar stays bright: the pair must be
+     tellable apart at a glance (enforced by theme-contrast.test.ts). */
+  --stage-done: #238636;
   --bar-default: #3fb950;
 }
 
@@ -238,7 +240,7 @@
   --stage-locked: #ff8a50;
   --stage-review: #f0b429;
   --stage-recurrent: #58a6ff;
-  --stage-done: #2ec4a6;
+  --stage-done: #0e8f77;
   --bar-default: #2ec4a6;
 
   /* Weekly-plan bands, dark variants of the light-vivid pair. */
@@ -262,7 +264,7 @@
   --stage-locked: #ff7b72;
   --stage-review: #e3b341;
   --stage-recurrent: #79c0ff;
-  --stage-done: #56b6c2;
+  --stage-done: #1d7f9c;
   --bar-default: #56b6c2;
 
   /* Weekly-plan bands, dark variants of the light-marine pair. */

--- a/web/src/theme-contrast.test.ts
+++ b/web/src/theme-contrast.test.ts
@@ -124,6 +124,22 @@ describe("white label on solid accent/danger fills", () => {
   }
 });
 
+// A finished bar must be tellable from an in-progress one in every cell: the
+// palettes separate the pair by luminance within one hue family (the channel
+// that survives every CVD axis), so hold them to a minimum contrast between
+// each other AND keep the deeper done fill visible on the card background.
+describe("done vs in-progress bar separation", () => {
+  for (const [name, sels] of Object.entries(cell)) {
+    it(`${name}: --stage-done and --bar-default stay distinct`, () => {
+      const done = resolve("--stage-done", sels);
+      const bar = resolve("--bar-default", sels);
+      expect(done).not.toBe(bar);
+      expect(contrast(done, bar)).toBeGreaterThanOrEqual(1.5);
+      expect(contrast(done, resolve("--bg", sels))).toBeGreaterThanOrEqual(3.0);
+    });
+  }
+});
+
 // The spine label is the only text that sits on a zone fill; in the CVD palettes
 // and dark mode it is painted --fg, and must stay readable on every zone.
 describe("zone spine contrast where the spine is --fg", () => {


### PR DESCRIPTION
## Problem

In the dark themes and in light Marine, a finished card's progress bar was the exact same colour as an in-progress one: four of the six theme × palette cells set `--stage-done` and `--bar-default` to identical values (dark default `#3fb950`, dark vivid `#2ec4a6`, dark marine `#56b6c2`, light marine `#2596b5`). Only light default had the intended light/deep green pair.

## Fix

Deepen the done fill within each palette's own hue family — separating the pair by luminance, the channel that survives every colour-vision axis the CVD palettes are built around:

| cell | in-progress | done |
|---|---|---|
| dark default | `#3fb950` | `#238636` |
| dark vivid | `#2ec4a6` | `#0e8f77` |
| dark marine | `#56b6c2` | `#1d7f9c` |
| light marine | `#2596b5` | `#16657f` |

The invariant is now enforced by `theme-contrast.test.ts`: in every cell the pair must differ by ≥1.5:1 contrast (the long-standing light-default pair sits at ~1.8) and the done fill must keep ≥3:1 against the background.

## Testing

- Web suite passes (32 tests, incl. the 6 new separation invariants).
- Visually verified in dark default on a dev board: a 90% bar and a 100% bar side by side are clearly distinct.