### PR TITLE
feat(teams): server-side team order and deletion

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -77,6 +77,8 @@ func (s *Server) registerAPI(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/sprints", s.handlePatchSprint)
 	mux.HandleFunc("POST /api/v1/sprints/actions/carry-over", s.handleCarryOver)
 	mux.HandleFunc("POST /api/v1/sprints/actions/carry-week", s.handleCarryWeek)
+	mux.HandleFunc("POST /api/v1/sprints/actions/reorder-teams", s.handleReorderTeams)
+	mux.HandleFunc("POST /api/v1/sprints/actions/delete-team", s.handleDeleteTeam)
 	mux.HandleFunc("GET /api/v1/ordering", s.handleGetOrdering)
 	mux.HandleFunc("POST /api/v1/presence", s.handleSetPresence)
 	mux.HandleFunc("GET /api/v1/watch", s.handleWatch)
@@ -129,6 +131,8 @@ func (s *Server) handleAPIIndex(w http.ResponseWriter, _ *http.Request) {
 			{"GET", "/api/v1/sprints", "Per-team sprint pointers"},
 			{"PATCH", "/api/v1/sprints", "Set a team's sprint pointer directly ({team, current, previous})"},
 			{"POST", "/api/v1/sprints/actions/carry-over", "Advance a team's sprint to today, carry unfinished ({team, dryRun})"},
+			{"POST", "/api/v1/sprints/actions/reorder-teams", "Apply a shared team order (moves the hidden sprint-state cards; body {teams:[...]})"},
+			{"POST", "/api/v1/sprints/actions/delete-team", "Delete a team's sprint pointer; refused while cards still use the team (body {team})"},
 			{"POST", "/api/v1/sprints/actions/carry-week", "Pull unfinished plan cards into the week ({team, week, dryRun})"},
 			{"GET", "/api/v1/ordering", "The board-level manual card order"},
 			{"POST", "/api/v1/presence", "Share the caller's live card selection ({login, card}; empty card clears)"},
@@ -950,6 +954,49 @@ func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, rep)
 }
 
+// handleReorderTeams applies a shared team order: the hidden sprint-state
+// cards are moved into the given sequence, so every client reads the same
+// order back from the board metadata.
+func (s *Server) handleReorderTeams(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Teams []string `json:"teams"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	// Same cached-snapshot read as carry-over (see handleCarryOver).
+	ctx, _ := withStaleAllowed(r.Context())
+	if err := svc.ReorderTeams(ctx, owner, project, in.Teams); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// handleDeleteTeam deletes a team's hidden sprint-state card. A team that
+// still has cards is protected server-side (422).
+func (s *Server) handleDeleteTeam(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Team string `json:"team"`
+	}
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+	svc, owner, project, ok := s.service(w, r)
+	if !ok {
+		return
+	}
+	if err := svc.DeleteTeam(r.Context(), owner, project, in.Team); err != nil {
+		s.apiError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
 // --- Shared helpers ----------------------------------------------------------------
 
 // handleSetPresence records the caller's live Me-view selection — ephemeral
@@ -1051,7 +1098,8 @@ func (s *Server) apiError(w http.ResponseWriter, err error) {
 		errors.Is(err, boardservice.ErrNoteTooLong),
 		errors.Is(err, boardservice.ErrSubtaskDepth),
 		errors.Is(err, boardservice.ErrParentNotFound),
-		errors.Is(err, boardservice.ErrOpenSubtasks):
+		errors.Is(err, boardservice.ErrOpenSubtasks),
+		errors.Is(err, boardservice.ErrTeamInUse):
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 	default:
 		writeJSONError(w, http.StatusBadGateway, err.Error())

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -869,9 +869,61 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 	e.mu.Lock()
 	e.removeCard(card.ItemID)
 	e.markGone(card.ItemID)
+	// A deleted sprint-state card takes its team with it: drop the cached
+	// pointer and the team's order slot so /board reads and watchers see the
+	// team gone immediately, not after the next revalidation.
+	for team, st := range e.board.SprintStates {
+		if st.ItemID != card.ItemID {
+			continue
+		}
+		delete(e.board.SprintStates, team)
+		e.board.TeamOrder = removeString(e.board.TeamOrder, team)
+		e.sprintChanged(clientIDFrom(ctx), team)
+		break
+	}
 	e.cardChanged(clientIDFrom(ctx), card, "DELETED")
 	e.mu.Unlock()
 	return nil
+}
+
+// removeString drops the first occurrence of v from list, in place.
+func removeString(list []string, v string) []string {
+	for i, s := range list {
+		if s == v {
+			return append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
+}
+
+// teamOfSprintState finds the team whose sprint-state card has the item id.
+func teamOfSprintState(states map[string]board.SprintState, itemID string) (string, bool) {
+	for team, st := range states {
+		if st.ItemID == itemID {
+			return team, true
+		}
+	}
+	return "", false
+}
+
+// moveTeamAfter re-slots team in the order list after the team owning the
+// afterID sprint-state card ("" or unknown = to the front).
+func moveTeamAfter(order []string, states map[string]board.SprintState, team, afterID string) []string {
+	order = removeString(append([]string(nil), order...), team)
+	at := 0
+	if afterTeam, ok := teamOfSprintState(states, afterID); ok {
+		for i, t := range order {
+			if t == afterTeam {
+				at = i + 1
+				break
+			}
+		}
+	}
+	out := make([]string, 0, len(order)+1)
+	out = append(out, order[:at]...)
+	out = append(out, team)
+	out = append(out, order[at:]...)
+	return out
 }
 
 // MoveCard applies the new position to the cached order (so lists keep the
@@ -881,6 +933,11 @@ func (b *storeBackend) MoveCard(ctx context.Context, bd board.Board, card board.
 	e := b.store.entry(storeKey(bd.Owner, bd.Number))
 	e.mu.Lock()
 	e.board.Cards = moveCardAfter(e.board.Cards, card.ItemID, afterID)
+	// Moving a sprint-state card is a TEAM reorder: mirror it onto the cached
+	// TeamOrder so /board reads agree with the new order immediately.
+	if team, ok := teamOfSprintState(e.board.SprintStates, card.ItemID); ok {
+		e.board.TeamOrder = moveTeamAfter(e.board.TeamOrder, e.board.SprintStates, team, afterID)
+	}
 	e.recentMove = time.Now()
 	e.orderingChanged(clientIDFrom(ctx))
 	e.mu.Unlock()

--- a/pkg/apiserver/types.go
+++ b/pkg/apiserver/types.go
@@ -269,11 +269,25 @@ func OrderingResource(b board.Board) Ordering {
 
 // BoardResource is the read-only board identity resource.
 func BoardResource(b board.Board) BoardInfo {
+	// Teams come out in BOARD order (the sprint-state cards' positions — the
+	// shared, server-side team order); stragglers the order does not know
+	// (defensive: map entries without an order slot) append sorted.
 	teams := make([]string, 0, len(b.SprintStates))
-	for t := range b.SprintStates {
-		teams = append(teams, t)
+	inOrder := map[string]bool{}
+	for _, t := range b.TeamOrder {
+		if _, ok := b.SprintStates[t]; ok && !inOrder[t] {
+			inOrder[t] = true
+			teams = append(teams, t)
+		}
 	}
-	sortStrings(teams)
+	rest := make([]string, 0)
+	for t := range b.SprintStates {
+		if !inOrder[t] {
+			rest = append(rest, t)
+		}
+	}
+	sortStrings(rest)
+	teams = append(teams, rest...)
 	seen := map[string]bool{}
 	members := []string{}
 	for _, c := range b.Cards {

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -183,6 +183,10 @@ type Board struct {
 	Cards  []Card         `json:"cards"`
 	// SprintStates maps each team key ("" = the no-team group) to its pointer.
 	SprintStates map[string]SprintState `json:"sprintStates"`
+	// TeamOrder lists the SprintStates keys in board order — the position of
+	// each team's hidden sprint-state card on the project. That position IS
+	// the team order every client shares (reordering teams moves the card).
+	TeamOrder []string `json:"teamOrder,omitempty"`
 }
 
 // NewBoard builds a Board snapshot from a board's fields and full card list,
@@ -196,12 +200,19 @@ func NewBoard(fields []ProjectField, cards []Card) Board {
 		Cards:        make([]Card, 0, len(cards)),
 		SprintStates: map[string]SprintState{},
 	}
+	seen := map[string]bool{}
 	for _, c := range cards {
 		if c.Title == SprintStateTitle {
 			b.SprintStates[c.Team] = SprintState{
 				Current:  c.SprintStart,
 				Previous: c.StartDate,
 				ItemID:   c.ItemID,
+			}
+			// Duplicate sprint-state cards for one team keep the first
+			// position they appeared at.
+			if !seen[c.Team] {
+				seen[c.Team] = true
+				b.TeamOrder = append(b.TeamOrder, c.Team)
 			}
 			continue
 		}

--- a/pkg/board/board_test.go
+++ b/pkg/board/board_test.go
@@ -68,3 +68,18 @@ func mustMarshal(t *testing.T, v any) []byte {
 	}
 	return data
 }
+
+// NewBoard records the sprint-state cards' board positions as the shared team
+// order (duplicates keep their first slot).
+func TestNewBoardTeamOrder(t *testing.T) {
+	b := NewBoard(nil, []Card{
+		{ItemID: "s1", Title: SprintStateTitle, Team: "gamma", SprintStart: "2026-01-01"},
+		{ItemID: "c1", Team: "alpha"},
+		{ItemID: "s2", Title: SprintStateTitle, Team: "alpha", SprintStart: "2026-01-01"},
+		{ItemID: "s3", Title: SprintStateTitle, Team: "gamma", SprintStart: "2026-01-02"},
+	})
+	want := []string{"gamma", "alpha"}
+	if len(b.TeamOrder) != 2 || b.TeamOrder[0] != want[0] || b.TeamOrder[1] != want[1] {
+		t.Fatalf("TeamOrder = %v, want %v", b.TeamOrder, want)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -23,6 +23,10 @@ var ErrNoteNotFound = errors.New("note not found")
 // card cannot be made recurrent (a review is one-off, not a repeating task).
 var ErrInvalidStage = errors.New("invalid stage for this card")
 
+// ErrTeamInUse is returned when deleting a team that still has cards on the
+// board — the caller must reassign or delete them first.
+var ErrTeamInUse = errors.New("team still has cards")
+
 // MaxDescriptionLen caps a card description (in runes). The description shares
 // a draft card's body with the note and event logs, and GitHub caps the body
 // at ~64K — an oversized description would break log appends.
@@ -325,6 +329,58 @@ func (s *Service) withLinkDescription(ctx context.Context, b board.Board, card b
 type CarryReport struct {
 	Carried  int `json:"carried"`
 	Reseeded int `json:"reseeded"`
+}
+
+// ReorderTeams applies a shared team order by moving the hidden sprint-state
+// cards into the given sequence on the project — the board position of those
+// cards IS the team order every client reads back (Board.TeamOrder). Teams
+// without a sprint pointer are skipped; teams missing from the list keep
+// their positions after the reordered ones.
+func (s *Service) ReorderTeams(ctx context.Context, owner string, project int, teams []string) error {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return err
+	}
+	prev := ""
+	for _, team := range teams {
+		st, ok := b.SprintStates[team]
+		if !ok || st.ItemID == "" {
+			continue
+		}
+		stub := board.Card{ItemID: st.ItemID, Title: board.SprintStateTitle, Team: team}
+		if err := s.backend.MoveCard(ctx, b, stub, prev); err != nil {
+			return err
+		}
+		prev = st.ItemID
+	}
+	return nil
+}
+
+// DeleteTeam removes a team from the board by deleting its hidden sprint-state
+// card. A team still referenced by cards is protected (ErrTeamInUse): deleting
+// its pointer would orphan them silently. A team with no pointer has nothing
+// server-side to delete — that is a no-op success, the client just drops its
+// local entry.
+func (s *Service) DeleteTeam(ctx context.Context, owner string, project int, team string) error {
+	b, err := s.backend.LoadBoard(ctx, owner, project)
+	if err != nil {
+		return err
+	}
+	inUse := 0
+	for _, c := range b.Cards {
+		if c.Team == team {
+			inUse++
+		}
+	}
+	if inUse > 0 {
+		return fmt.Errorf("%w: %d card(s) still on %q — reassign or delete them first", ErrTeamInUse, inUse, team)
+	}
+	st, ok := b.SprintStates[team]
+	if !ok || st.ItemID == "" {
+		return nil
+	}
+	stub := board.Card{ItemID: st.ItemID, Title: board.SprintStateTitle, Team: team}
+	return s.backend.DeleteCard(ctx, b, stub)
 }
 
 // selectCarry partitions a team's cards for a carry-over closing sprint old

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -2280,5 +2281,56 @@ func TestSetRecurrenceValidation(t *testing.T) {
 	}
 	if err := svc.SetRecurrence(ctx, "acme", 1, "c2", "week"); err == nil {
 		t.Fatal("cycle on a non-recurrent card must be rejected")
+	}
+}
+
+// ReorderTeams moves the hidden sprint-state cards into the given sequence —
+// the shared, server-side team order.
+func TestReorderTeamsMovesSprintStates(t *testing.T) {
+	f := newFake(nil, map[string]board.SprintState{
+		"alpha": {Current: "2026-01-01", ItemID: "s-alpha"},
+		"beta":  {Current: "2026-01-01", ItemID: "s-beta"},
+		"gamma": {Current: "2026-01-01", ItemID: "s-gamma"},
+	})
+	if err := f2svc(f).ReorderTeams(ctx, "acme", 1, []string{"gamma", "alpha", "beta"}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"MoveCard s-gamma after=",
+		"MoveCard s-alpha after=s-gamma",
+		"MoveCard s-beta after=s-alpha",
+	}
+	got := []string{}
+	for _, l := range f.log {
+		if strings.HasPrefix(l, "MoveCard") {
+			got = append(got, l)
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("moves = %v, want %v", got, want)
+	}
+}
+
+// DeleteTeam removes the sprint-state card — but never while cards still use
+// the team, and quietly succeeds when there is no pointer to delete.
+func TestDeleteTeamGuardsAndDeletes(t *testing.T) {
+	f := newFake([]board.Card{
+		{ItemID: "c1", Team: "alpha"},
+	}, map[string]board.SprintState{
+		"alpha": {Current: "2026-01-01", ItemID: "s-alpha"},
+		"beta":  {Current: "2026-01-01", ItemID: "s-beta"},
+	})
+	svc := f2svc(f)
+	if err := svc.DeleteTeam(ctx, "acme", 1, "alpha"); !errors.Is(err, ErrTeamInUse) {
+		t.Fatalf("in-use team must be protected, got %v", err)
+	}
+	if err := svc.DeleteTeam(ctx, "acme", 1, "beta"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.saw("DeleteCard s-beta") {
+		t.Fatalf("sprint-state not deleted; log=%v", f.log)
+	}
+	if err := svc.DeleteTeam(ctx, "acme", 1, "ghost"); err != nil {
+		t.Fatalf("pointer-less team must be a no-op success, got %v", err)
 	}
 }

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -164,7 +164,7 @@ func (h *server) getCard(ctx context.Context, _ *mcp.CallToolRequest, in cardRef
 type createCardInput struct {
 	boardRef
 	Title    string `json:"title" jsonschema:"card title (required)"`
-	Team     string `json:"team,omitempty" jsonschema:"team the card joins; empty is the no-team group"`
+	Team     string `json:"team,omitempty" jsonschema:"team the card joins; empty is the no-team group. MUST be one of the board's EXISTING team keys — read them from get_board metadata.teams and map the user's wording onto an existing key, across languages and case ('маркетинг', 'the marketing team' -> existing 'marketing'). A value not in that list silently CREATES a new team with its own sprint pointer — a heavyweight, unusual action: only pass a new key when the user explicitly asks to create a new team"`
 	Zone     string `json:"zone,omitempty" jsonschema:"semantic zone: urgent, unplanned, planned or niceToHave"`
 	Assignee string `json:"assignee,omitempty" jsonschema:"GitHub login to assign"`
 	Start    string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd; defaults to end, else today"`
@@ -213,7 +213,7 @@ type updateCardInput struct {
 	cardRef
 	Title       *string `json:"title,omitempty" jsonschema:"new title"`
 	Description *string `json:"description,omitempty" jsonschema:"the card's shared free-form body (what the whole team sees; live-syncs onto the linked review card) — the right place for review or handoff context, and for reference links: include related open PRs and issues in free form as FULL URLs or owner/repo#123 shorthands (encouraged — links are extracted from anywhere in the text, surfaced on the card, and GitHub refs resolve to live titles/states; read them back with list_links); empty clears it"`
-	Team        *string `json:"team,omitempty" jsonschema:"team to move to (joins its current sprint); empty is the no-team group"`
+	Team        *string `json:"team,omitempty" jsonschema:"team to move to (joins its current sprint); empty is the no-team group. MUST be an EXISTING team key from get_board metadata.teams — map the user's wording onto an existing key, across languages and case; an unknown value silently CREATES a new team (heavyweight, unusual) — only on an explicit request for a brand-new team"`
 	Zone        *string `json:"zone,omitempty" jsonschema:"semantic zone: urgent, unplanned, planned or niceToHave; empty clears it"`
 	Assignee    *string `json:"assignee,omitempty" jsonschema:"GitHub login; empty unassigns"`
 	Progress    *int    `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
@@ -497,7 +497,7 @@ func (h *server) releaseFromPlan(ctx context.Context, _ *mcp.CallToolRequest, in
 // carryOverInput names a team for the sprint carry-over.
 type carryOverInput struct {
 	boardRef
-	Team   string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Team   string `json:"team,omitempty" jsonschema:"EXISTING team key from get_board metadata.teams; empty is the no-team group. Carrying an unknown team quietly bootstraps a sprint pointer for it — never invent a key here"`
 	DryRun bool   `json:"dryRun,omitempty" jsonschema:"report the would-be counts without changing anything"`
 }
 
@@ -516,7 +516,7 @@ func (h *server) carryOver(ctx context.Context, _ *mcp.CallToolRequest, in carry
 // carryWeekInput names a team and target week for the weekly carry.
 type carryWeekInput struct {
 	boardRef
-	Team   string `json:"team,omitempty" jsonschema:"team key; empty is the no-team group"`
+	Team   string `json:"team,omitempty" jsonschema:"EXISTING team key from get_board metadata.teams; empty is the no-team group. Carrying an unknown team quietly bootstraps a sprint pointer for it — never invent a key here"`
 	Week   string `json:"week,omitempty" jsonschema:"target week Monday as yyyy-mm-dd; defaults to the current week"`
 	DryRun bool   `json:"dryRun,omitempty" jsonschema:"report the would-be counts without changing anything"`
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -265,16 +265,17 @@ export function App() {
   const roster = useMemo(() => {
     const seen = new Set<string>();
     const out: string[] = [];
-    for (const t of addedTeams) {
-      if (!seen.has(t)) {
+    // The board's own teams come FIRST, in the server-side order (the
+    // sprint-state cards' positions) — shared by everyone, on every device.
+    for (const t of board?.teams ?? []) {
+      if (t && !seen.has(t)) {
         seen.add(t);
         out.push(t);
       }
     }
-    // The board's own roster (teams with a sprint pointer) is the source of
-    // truth — cards now load one view at a time, so we can't infer teams from
-    // them. Any team present on the loaded cards is folded in as a fallback.
-    for (const t of [...(board?.teams ?? []), ...(board?.cards ?? []).map((c) => c.team ?? "")]) {
+    // Hand-added drafts (no sprint pointer yet) follow in their local order,
+    // then any team present only on loaded cards as a fallback.
+    for (const t of [...addedTeams, ...(board?.cards ?? []).map((c) => c.team ?? "")]) {
       if (t && !seen.has(t)) {
         seen.add(t);
         out.push(t);
@@ -337,11 +338,31 @@ export function App() {
   );
   const watchKey = queryString(watchSel);
 
-  // Reorder the whole roster (from the manage dialog) and persist the order.
-  const reorderTeams = useCallback((ordered: string[]) => {
-    setAddedTeams(ordered);
-    writeStringList(scopedLS(LS_TEAM_ROSTER, boardKeyRef.current), ordered);
-  }, []);
+  // Reorder the whole roster (from the manage dialog). Teams the server knows
+  // (sprint pointer) get the order pushed to the board itself — their hidden
+  // sprint-state cards are moved, so the order is shared by the whole team.
+  // Hand-added drafts keep their relative order locally as before.
+  const reorderTeams = useCallback(
+    (ordered: string[]) => {
+      setAddedTeams(ordered);
+      writeStringList(scopedLS(LS_TEAM_ROSTER, boardKeyRef.current), ordered);
+      const cur = board;
+      if (!cur) {
+        return;
+      }
+      const server = ordered.filter((t) => cur.teams.includes(t));
+      if (server.length < 2) {
+        return;
+      }
+      setBoard((b) => (b ? { ...b, teams: server } : b));
+      void provider.reorderTeams(cur, server).catch((err: unknown) => {
+        // Keep the optimistic order on screen; the next reload converges it
+        // back to the server's truth if the write really failed.
+        setError(errMessage(err));
+      });
+    },
+    [board, provider],
+  );
 
   const addTeam = useCallback((team: string) => {
     const t = team.trim();
@@ -358,21 +379,52 @@ export function App() {
     });
   }, []);
 
-  const removeTeam = useCallback((team: string) => {
-    setAddedTeams((cur) => {
-      const next = cur.filter((t) => t !== team);
-      writeStringList(scopedLS(LS_TEAM_ROSTER, boardKeyRef.current), next);
-      return next;
-    });
-    // Drop the removed team from the filter (clearing it if it becomes empty).
-    setTeamFilter((cur) => {
-      if (cur === null) {
-        return cur;
+  const removeTeam = useCallback(
+    (team: string) => {
+      const dropLocal = () => {
+        setAddedTeams((cur) => {
+          const next = cur.filter((t) => t !== team);
+          writeStringList(scopedLS(LS_TEAM_ROSTER, boardKeyRef.current), next);
+          return next;
+        });
+        // Drop the removed team from the filter (clearing it if it becomes empty).
+        setTeamFilter((cur) => {
+          if (cur === null) {
+            return cur;
+          }
+          const next = cur.filter((k) => k !== team);
+          return next.length ? next : null;
+        });
+      };
+      const cur = board;
+      if (!cur || !cur.teams.includes(team)) {
+        // A hand-added draft lives only in this browser.
+        dropLocal();
+        return;
       }
-      const next = cur.filter((k) => k !== team);
-      return next.length ? next : null;
-    });
-  }, []);
+      // A board-backed team is deleted on the server (its hidden sprint-state
+      // card goes away); the server refuses while cards still use the team,
+      // and that message is the user's answer.
+      void provider
+        .deleteTeam(cur, team)
+        .then(() => {
+          dropLocal();
+          setBoard((b) =>
+            b
+              ? {
+                  ...b,
+                  teams: b.teams.filter((t) => t !== team),
+                  sprintStates: Object.fromEntries(
+                    Object.entries(b.sprintStates).filter(([k]) => k !== team),
+                  ),
+                }
+              : b,
+          );
+        })
+        .catch((err: unknown) => setError(errMessage(err)));
+    },
+    [board, provider],
+  );
 
   // Persist the filter whenever it changes (null means "all", we store
   // nothing). boardKeyRef is updated synchronously by doLoad before the

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -325,6 +325,14 @@ export const apiProvider: Provider = {
     });
   },
 
+  async reorderTeams(board: BoardAddr, teams: string[]): Promise<void> {
+    await api(board, "POST", "/sprints/actions/reorder-teams", { teams });
+  },
+
+  async deleteTeam(board: BoardAddr, team: string): Promise<void> {
+    await api(board, "POST", "/sprints/actions/delete-team", { team });
+  },
+
   async carryWeek(
     board: BoardAddr,
     team: string | null,

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -223,6 +223,10 @@ export interface Provider {
     week: string,
     dryRun?: boolean,
   ): Promise<CarryReport>;
+  /** Apply a shared team order (moves the hidden sprint-state cards). */
+  reorderTeams(board: BoardAddr, teams: string[]): Promise<void>;
+  /** Delete a team's sprint pointer; rejects while cards still use the team. */
+  deleteTeam(board: BoardAddr, team: string): Promise<void>;
   /** Set a team's sprint pointer directly (current/previous start dates). */
   setSprintState(
     board: BoardAddr,


### PR DESCRIPTION
## Problem

Two long-standing gaps in team management, plus a fresh field incident:

- **Reordering teams never persisted for anyone else**: the order lived in each browser's localStorage, so every device and every teammate saw their own (or alphabetical) order.
- **Removing a team didn't stick**: the roster is a union with the board's teams, and any team backed by a hidden sprint-state card came right back after its localStorage entry was removed.
- An MCP agent, asked in Russian to "put the card on the marketing team", silently **created a new Cyrillic-named team** instead of using the existing `marketing` — team creation is implicit and nothing warned the model it is a heavyweight action.

## Fix

The hidden `aeman:sprint-state` cards are ordinary project items with positions — the board itself now carries the team order:

- `Board.TeamOrder` is read from the sprint-state cards' placement; the board metadata lists teams in that order (stragglers sorted after), so the order is shared by every client and device.
- `POST /sprints/actions/reorder-teams` applies an order by moving the sprint-state cards; `POST /sprints/actions/delete-team` deletes a team's pointer and is refused with 422 while cards still use the team ("N card(s) still on …").
- The server cache mirrors both immediately (no 30s revalidation gap): a moved sprint-state card re-slots the cached TeamOrder, a deleted one drops the team and notifies sprint watchers.
- The manage dialog pushes reorders to the server and deletes board-backed teams through the guard; localStorage keeps only hand-added drafts that have no sprint pointer yet.
- The MCP `team` parameters (create_card, update_card, carry_over, carry_week) now direct agents to map the user's wording onto the board's EXISTING team keys — across languages and case — and warn that an unknown key silently bootstraps a new team, to be done only on an explicit request.

## Testing

- Unit: TeamOrder from card positions (dupes keep first slot), ordered board metadata, reorder move sequence, delete guard / delete / pointer-less no-op.
- Live on a dev board: reorder reflected in `metadata.teams` immediately; delete refused with 422 while a card used the team (the guard caught a real leftover card during testing), then succeeded after cleanup; full Go + web suites and golangci-lint pass.