### PR TITLE
fix(board): stop sprint-pointer writes scattering across duplicates

### DIFF
--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -1355,7 +1355,19 @@ func (b *storeBackend) SetSprintState(ctx context.Context, bd board.Board, team,
 				}
 			},
 			exec: func(ctx context.Context) error {
-				return b.inner.SetSprintState(ctx, bd, team, current, previous)
+				// The queue can drain long after enqueue: resolve the team's
+				// sprint-state card AT WRITE TIME from the live cache, not
+				// from the enqueue-era snapshot — a stale snapshot pointing
+				// at a missing card is how duplicate sprint-state cards were
+				// born (and how pointer writes scattered between them).
+				ref := bd
+				e.mu.Lock()
+				ref.SprintStates = map[string]board.SprintState{}
+				if live, ok := e.board.SprintStates[team]; ok {
+					ref.SprintStates[team] = live
+				}
+				e.mu.Unlock()
+				return b.inner.SetSprintState(ctx, ref, team, current, previous)
 			},
 		})
 		return nil

--- a/internal/server/writequeue_test.go
+++ b/internal/server/writequeue_test.go
@@ -23,6 +23,7 @@ type wbBackend struct {
 	progressCalls        int
 	gate                 chan struct{} // nil = no gating
 	fail                 bool
+	sprintWrites         []string
 }
 
 func (w *wbBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
@@ -540,5 +541,56 @@ func TestTouchedSkipsDeletedCard(t *testing.T) {
 	}
 	if _, gone := e.recentGone["c1"]; !gone {
 		t.Fatal("touched stripped the card's recentGone protection")
+	}
+}
+
+func (w *wbBackend) SetSprintState(_ context.Context, b board.Board, team, current, previous string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.sprintWrites = append(w.sprintWrites, team+"@"+b.SprintStates[team].ItemID+" "+current+"/"+previous)
+	return nil
+}
+
+// A queued sprint-pointer write must resolve the sprint-state card at WRITE
+// time from the live cache — the enqueue-era snapshot may point at a card
+// that a fresher load replaced (the duplicate-scatter incident).
+func TestSprintStateWriteResolvesLive(t *testing.T) {
+	inner := &wbBackend{board: watchBoard(), gate: make(chan struct{})}
+	store := newBoardStore()
+	be := &storeBackend{inner: inner, store: store}
+	bd, err := be.LoadBoard(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry("acme/1")
+
+	// Hold the queue on a gated op so the sprint write stays queued while the
+	// cache moves under it.
+	if err := be.SetProgress(context.Background(), bd, bd.Cards[0], 40); err != nil {
+		t.Fatal(err)
+	}
+	// Enqueue the pointer roll with the CURRENT snapshot (sprint-state s1)...
+	if err := be.SetSprintState(context.Background(), bd, "alpha", "2026-01-11", "2026-01-10"); err != nil {
+		t.Fatal(err)
+	}
+	// ...then the cache learns the team's card is really s1-NEW (a fresher
+	// load replaced the duplicate) before the queue drains.
+	e.mu.Lock()
+	st := e.board.SprintStates["alpha"]
+	st.ItemID = "s1-new"
+	e.board.SprintStates["alpha"] = st
+	e.mu.Unlock()
+
+	close(inner.gate)
+	waitFor(t, "queue drain", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.unsynced() == 0
+	})
+	inner.mu.Lock()
+	writes := append([]string(nil), inner.sprintWrites...)
+	inner.mu.Unlock()
+	if len(writes) != 1 || writes[0] != "alpha@s1-new 2026-01-11/2026-01-10" {
+		t.Fatalf("sprint write = %v, want the LIVE card s1-new", writes)
 	}
 }

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -201,15 +201,17 @@ func NewBoard(fields []ProjectField, cards []Card) Board {
 		SprintStates: map[string]SprintState{},
 	}
 	seen := map[string]bool{}
+	winners := map[string]Card{}
 	for _, c := range cards {
 		if c.Title == SprintStateTitle {
-			b.SprintStates[c.Team] = SprintState{
-				Current:  c.SprintStart,
-				Previous: c.StartDate,
-				ItemID:   c.ItemID,
+			// Duplicate sprint-state cards happen (a bootstrap raced a stale
+			// snapshot); the winner must be DETERMINISTIC or the pointer
+			// flip-flops between duplicates as board positions churn — the
+			// oldest card wins, ties broken by item id.
+			if prev, ok := winners[c.Team]; !ok || olderSprintState(c, prev) {
+				winners[c.Team] = c
 			}
-			// Duplicate sprint-state cards for one team keep the first
-			// position they appeared at.
+			// Duplicates keep the first position they appeared at.
 			if !seen[c.Team] {
 				seen[c.Team] = true
 				b.TeamOrder = append(b.TeamOrder, c.Team)
@@ -218,5 +220,22 @@ func NewBoard(fields []ProjectField, cards []Card) Board {
 		}
 		b.Cards = append(b.Cards, c)
 	}
+	for team, c := range winners {
+		b.SprintStates[team] = SprintState{
+			Current:  c.SprintStart,
+			Previous: c.StartDate,
+			ItemID:   c.ItemID,
+		}
+	}
 	return b
+}
+
+// olderSprintState reports whether a is the older sprint-state card: earlier
+// CreatedAt, ties (and hand-built snapshots without timestamps) broken by the
+// smaller item id.
+func olderSprintState(a, b Card) bool {
+	if a.CreatedAt != b.CreatedAt {
+		return a.CreatedAt < b.CreatedAt
+	}
+	return a.ItemID < b.ItemID
 }

--- a/pkg/board/board_test.go
+++ b/pkg/board/board_test.go
@@ -83,3 +83,28 @@ func TestNewBoardTeamOrder(t *testing.T) {
 		t.Fatalf("TeamOrder = %v, want %v", b.TeamOrder, want)
 	}
 }
+
+// Duplicate sprint-state cards must resolve to a DETERMINISTIC winner — the
+// oldest card — whatever their board positions; the pointer must not
+// flip-flop between duplicates as positions churn.
+func TestNewBoardDuplicateSprintStateWinner(t *testing.T) {
+	dup := Card{ItemID: "s-new", Title: SprintStateTitle, Team: "alpha",
+		SprintStart: "2026-07-23", StartDate: "2026-07-22", CreatedAt: "2026-07-21T14:25:44Z"}
+	orig := Card{ItemID: "s-old", Title: SprintStateTitle, Team: "alpha",
+		SprintStart: "2026-07-21", StartDate: "2026-07-20", CreatedAt: "2026-06-29T09:49:52Z"}
+
+	// Whichever order the board lists them in, the older card wins.
+	for name, cards := range map[string][]Card{
+		"orig first": {orig, dup},
+		"dup first":  {dup, orig},
+	} {
+		b := NewBoard(nil, cards)
+		st := b.SprintStates["alpha"]
+		if st.ItemID != "s-old" || st.Current != "2026-07-21" {
+			t.Fatalf("%s: winner = %+v, want the oldest card s-old", name, st)
+		}
+		if len(b.TeamOrder) != 1 || b.TeamOrder[0] != "alpha" {
+			t.Fatalf("%s: TeamOrder = %v", name, b.TeamOrder)
+		}
+	}
+}

--- a/pkg/ghprojects/setters.go
+++ b/pkg/ghprojects/setters.go
@@ -636,6 +636,17 @@ func (c *Client) CreateCard(ctx context.Context, b board.Board, in board.CreateI
 func (c *Client) SetSprintState(ctx context.Context, b board.Board, team, current, previous string) error {
 	itemID := b.SprintStates[team].ItemID
 	if itemID == "" {
+		// Never create off a snapshot's absence alone: a stale or partial
+		// snapshot missing the team's pointer is how duplicate sprint-state
+		// cards are born. Re-read the live project and only create when the
+		// card is confirmed missing there too.
+		if b.Owner != "" && b.Number > 0 {
+			if fresh, err := c.LoadBoard(ctx, b.Owner, b.Number); err == nil {
+				itemID = fresh.SprintStates[team].ItemID
+			}
+		}
+	}
+	if itemID == "" {
 		var created struct {
 			AddProjectV2DraftIssue struct {
 				ProjectItem struct {


### PR DESCRIPTION
## Incident

Cozystack ran Carry over and most cards did not move. Root cause chain:

1. A **duplicate `aeman:sprint-state` card** for the team was born on Jul 21 (a bootstrap raced a snapshot that lacked the team's pointer).
2. `NewBoard` resolved duplicates by "last in board order wins" — board positions churn, so daily pointer writes landed in **different cards on different days**.
3. The write-behind cache masked the scatter until a server restart rebuilt the cache from GitHub, resurrecting a days-old pointer. The next carry-over closed the wrong sprint and skipped every card of the newer one ("not in the closing sprint — never boomerangs").

Board data was repaired by hand (duplicate deleted, pointer restored, carry re-run: 60 cards moved, none left behind).

## Fix — three layers

- **Deterministic winner**: `NewBoard` resolves duplicate sprint-state cards to the OLDEST card (ties by item id), whatever their positions — the pointer cannot flip-flop again.
- **Write-time resolution**: a queued pointer write resolves the team's sprint-state card from the live cache at drain time, not from the enqueue-era snapshot.
- **Creation guard**: before minting a new sprint-state card, the backend re-reads the live project and creates only on a confirmed absence — duplicates stop being born.

## Testing

- `TestNewBoardDuplicateSprintStateWinner`: the oldest card wins in either board order, TeamOrder keeps one slot.
- `TestSprintStateWriteResolvesLive`: a pointer write enqueued against an older snapshot drains against the card the cache knows NOW.
- Full Go + web suites and golangci-lint pass.