### PR TITLE
fix(board): a deferred card leaves the sprint in progress at once

### DIFF
--- a/pkg/board/filters.go
+++ b/pkg/board/filters.go
@@ -26,10 +26,15 @@ func TeamGrid(b Board, team, day string) []Card {
 		inRange := c.StartDate != "" && c.Day != "" && c.Day >= c.StartDate &&
 			day >= c.StartDate && day <= c.Day
 		// A deferred / future-scheduled card (startDate past today) lives on its
-		// own day (or range), and its past sprint day keeps it as history; it is
-		// hidden everywhere else until that day arrives.
+		// own day (or range), and a CLOSED sprint's day keeps it as history; it
+		// is hidden everywhere else until that day arrives. The team's CURRENT
+		// sprint is never history: deferring a card is precisely the act of
+		// taking it out of the sprint in progress, so it must leave that day at
+		// once — even when the sprint opened days ago (no carry-over since).
 		if c.StartDate != "" && c.StartDate > today {
-			if day == c.StartDate || inRange || (c.SprintStart != "" && day == c.SprintStart && c.SprintStart < today) {
+			pastSprintDay := c.SprintStart != "" && day == c.SprintStart &&
+				c.SprintStart < today && c.SprintStart != CurrentSprint(b, c.Team)
+			if day == c.StartDate || inRange || pastSprintDay {
 				out = append(out, c)
 			}
 			continue

--- a/pkg/board/filters_test.go
+++ b/pkg/board/filters_test.go
@@ -159,3 +159,46 @@ func TestWeeklyPlan(t *testing.T) {
 		})
 	}
 }
+
+// Deferring a card takes it out of the sprint in progress at once — even when
+// that sprint opened days ago (no carry-over since), so its start day is in
+// the past. A genuinely CLOSED sprint's day still keeps the card as history.
+func TestTeamGridDeferredLeavesCurrentSprint(t *testing.T) {
+	today := TodayIso()
+	current := AddDays(today, -3) // sprint opened three days ago, still current
+	previous := AddDays(today, -6)
+	deferred := Card{
+		ItemID: "c1", Team: "alpha",
+		StartDate:   AddDays(today, 7), // deferred a week out
+		Day:         current,           // stale end date, as Defer leaves it
+		SprintStart: current,
+	}
+	b := Board{
+		Cards: []Card{deferred},
+		SprintStates: map[string]SprintState{
+			"alpha": {Current: current, Previous: previous},
+		},
+	}
+	if got := TeamGrid(b, "alpha", current); len(got) != 0 {
+		t.Fatalf("deferred card must leave the current sprint day, got %+v", got)
+	}
+	if got := TeamGrid(b, "alpha", today); len(got) != 0 {
+		t.Fatalf("deferred card must not show on today, got %+v", got)
+	}
+	if got := TeamGrid(b, "alpha", deferred.StartDate); len(got) != 1 {
+		t.Fatalf("deferred card must show on its own future day, got %+v", got)
+	}
+
+	// The same card bound to a CLOSED sprint keeps that day as history.
+	past := deferred
+	past.SprintStart = previous
+	hist := Board{
+		Cards: []Card{past},
+		SprintStates: map[string]SprintState{
+			"alpha": {Current: current, Previous: previous},
+		},
+	}
+	if got := TeamGrid(hist, "alpha", previous); len(got) != 1 {
+		t.Fatalf("a closed sprint's day must keep the card as history, got %+v", got)
+	}
+}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -238,17 +238,19 @@ export function TeamBoard({
           c.day >= c.startDate &&
           selectedDate >= c.startDate &&
           selectedDate <= c.day;
-        // A deferred / future-scheduled card (startDate past today) lives on its
-        // own day (or range), and its past sprint day keeps it as history; it is
-        // hidden everywhere else until that day arrives.
+        // A deferred / future-scheduled card (startDate past today) lives on
+        // its own day (or range), and a CLOSED sprint's day keeps it as
+        // history; it is hidden everywhere else until that day arrives. The
+        // team's CURRENT sprint is never history: deferring is precisely the
+        // act of taking the card out of the sprint in progress, so it must
+        // leave that day at once (mirrors board.TeamGrid).
         if (c.startDate && c.startDate > today) {
-          return (
-            selectedDate === c.startDate ||
-            inRange ||
-            (!!c.sprintStart &&
-              selectedDate === c.sprintStart &&
-              c.sprintStart < today)
-          );
+          const pastSprintDay =
+            !!c.sprintStart &&
+            selectedDate === c.sprintStart &&
+            c.sprintStart < today &&
+            c.sprintStart !== currentSprint(board, c.team ?? null);
+          return selectedDate === c.startDate || inRange || pastSprintDay;
         }
         if (c.sprintStart === selectedDate) {
           return true;


### PR DESCRIPTION
## Problem

Deferring an old card (+1 day / +1 week) left it sitting on the Team grid, in the very sprint it was pushed out of. Reported as: «если отправить старую карточку на неделю вперед, то она не исчезает из текущего спринта».

The rule that keeps a deferred card on its sprint-start day *as history* only asked whether that day was before today. Whenever a team's current sprint had opened on an earlier day — normal whenever no carry-over has run since — the sprint still being worked satisfied that test and counted as history, so the card stayed put.

## Fix

The history exception now applies to **closed** sprints only, never to the team's current pointer: deferring is precisely the act of taking a card out of the sprint in progress, so it leaves that day immediately. A genuinely past sprint's day still keeps the card as history, and its own future day is unaffected.

Mirrored on both sides — `pkg/board/filters.go` (TeamGrid) and `TeamBoard.tsx` — so the API and the UI cannot disagree.

## Testing

- `TestTeamGridDeferredLeavesCurrentSprint` covers all four days: current sprint (gone), today (gone), its own future day (shown), a closed sprint's day (still history).
- Reproduced live on a dev board before the fix and verified after: a card deferred a week out disappears from the current-sprint day and reappears only on its target day.
- Full Go + web suites and golangci-lint pass.