### PR TITLE
fix(cards): give a link-titled card a readable name at once

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -442,10 +442,19 @@ func TestAPICreateCardFromGitHubURL(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
+	// The create answers instantly under the readable fallback — it must not
+	// block on GitHub — and the real title arrives from the background
+	// resolve, which reaches every watcher (see boardservice.resolveTitleAsync).
 	c := decodeCard(t, rec)
-	if c.Spec.Title != "feat: warp drive" || c.Spec.Description != "https://github.com/acme/repo/pull/7" {
+	if c.Spec.Title != "Pull: acme/repo#7" || c.Spec.Description != "https://github.com/acme/repo/pull/7" {
 		t.Fatalf("card = %+v", c.Spec)
 	}
+	uid := c.Metadata.UID
+	waitFor(t, "the background resolve to rename the card", func() bool {
+		rec := do(t, srv, http.MethodGet, "/api/v1/cards/"+uid+"?owner=acme&project=1", "")
+		return rec.Code == http.StatusOK &&
+			decodeCard(t, rec).Spec.Title == "feat: warp drive"
+	})
 }
 
 func TestAPIRecurrentOnReviewCardRejected(t *testing.T) {

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -61,6 +61,12 @@ func withClientID(ctx context.Context, id string) context.Context {
 }
 
 func clientIDFrom(ctx context.Context) string {
+	// Server-side work on nobody's behalf (a background title resolve) must
+	// reach every watcher, including the tab that triggered the create — an
+	// echo-suppressed rename would sit unseen until a reload.
+	if board.IsUnattributed(ctx) {
+		return ""
+	}
 	id, _ := ctx.Value(clientIDCtxKey{}).(string)
 	return id
 }

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -623,3 +623,17 @@ func TestCarryOverServedFromSnapshot(t *testing.T) {
 		t.Fatalf("unexpected body: %s", rec.Body.String())
 	}
 }
+
+// Server-side work on nobody's behalf — the background title resolve after a
+// create-by-URL — must reach EVERY watcher, the tab that triggered the create
+// included. Echo-suppressing it against that client is what left the raw URL
+// on screen until a reload.
+func TestUnattributedWorkIsNotEchoSuppressed(t *testing.T) {
+	withClient := withClientID(context.Background(), "tab-1")
+	if got := clientIDFrom(withClient); got != "tab-1" {
+		t.Fatalf("a client's own change keeps its origin, got %q", got)
+	}
+	if got := clientIDFrom(board.Unattributed(withClient)); got != "" {
+		t.Fatalf("unattributed work must carry no origin, got %q", got)
+	}
+}

--- a/pkg/board/events.go
+++ b/pkg/board/events.go
@@ -78,6 +78,24 @@ func ActorFrom(ctx context.Context) string {
 	return login
 }
 
+// unattributedKey marks a context whose changes belong to no single client:
+// work the server does on its own behalf (a background title resolve), which
+// every watcher — the originating tab included — must be told about.
+type unattributedKey struct{}
+
+// Unattributed marks ctx as carrying server-side work with no originating
+// client, so watch frames reach everyone instead of being echo-suppressed
+// against whoever happened to trigger it.
+func Unattributed(ctx context.Context) context.Context {
+	return context.WithValue(ctx, unattributedKey{}, true)
+}
+
+// IsUnattributed reports whether ctx was marked by Unattributed.
+func IsUnattributed(ctx context.Context) bool {
+	on, _ := ctx.Value(unattributedKey{}).(bool)
+	return on
+}
+
 // eventPrefix marks a log-line body as a machine event rather than a work
 // note. Parsers treat any log line whose body starts with it as an Event.
 const eventPrefix = ":: "

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -199,15 +199,17 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 	// "Pull: owner/repo#N": when resolution fails (no repo access on a private
 	// repo, dead link) the card stays usable — a bare URL as the title, or a
 	// content-less item that never renders, is what left cards invisible.
+	// Resolving the ref costs a GitHub round trip (seconds), and blocking the
+	// create on it left the raw URL sitting in the UI all that time. Create at
+	// once under the readable fallback and fetch the real title in the
+	// background (resolveTitleAsync), which renames the card — unless the
+	// person retitled it first.
 	var linkDescription string
+	var pendingRef *board.Link
 	if ref, ok := board.ParseGitHubRef(strings.TrimSpace(args.Title)); ok {
 		linkDescription = ref.URL
 		args.Title = ref.FallbackTitle()
-		if resolver, hasResolver := s.backend.(LinkResolver); hasResolver {
-			if resolved, err := resolver.ResolveIssueRef(ctx, ref); err == nil && resolved.Title != "" {
-				args.Title = resolved.Title
-			}
-		}
+		pendingRef = &ref
 	}
 	// A weekly-plan card lives in the plan bands, not on the day boards: it gets
 	// no dates and joins no sprint. It mirrors handleCreatePlan in TeamBoard.tsx.
@@ -227,6 +229,7 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		})
 		card, err = s.withLinkDescription(ctx, b, card, err, linkDescription)
 		if err == nil {
+			s.resolveTitleAsync(ctx, b, card, pendingRef)
 			s.logEvent(ctx, b, card, board.EventCreated, "", "")
 		}
 		return card, err
@@ -298,6 +301,7 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 	card, err = s.withLinkDescription(ctx, b, card, err, linkDescription)
 	if err == nil {
 		s.logEvent(ctx, b, card, board.EventCreated, "", "")
+		s.resolveTitleAsync(ctx, b, card, pendingRef)
 	}
 	if err == nil && args.Parent != "" {
 		if perr := s.SetParent(ctx, owner, project, card.ItemID, args.Parent); perr != nil {
@@ -309,6 +313,55 @@ func (s *Service) CreateCard(ctx context.Context, owner string, project int, arg
 		card.Parent = args.Parent
 	}
 	return card, err
+}
+
+// spawn runs background work. Tests replace it to run inline so the
+// asynchronous title resolve is deterministic.
+var spawn = func(fn func()) { go fn() }
+
+// asyncResolveTimeout bounds a background title resolve; GitHub occasionally
+// takes seconds, but a create must never leave work hanging indefinitely.
+const asyncResolveTimeout = 30 * time.Second
+
+// resolveTitleAsync fetches a create-by-URL card's real title in the
+// background and renames the card to it. The create itself already returned
+// under the readable "Issue: owner/repo#N" fallback, so nobody waits on
+// GitHub. Two guards: the rename is skipped when the person (or an agent)
+// retitled the card meanwhile — their words win over ours — and the work is
+// marked unattributed so the watch frame reaches the creating tab too,
+// instead of being echo-suppressed into invisibility.
+func (s *Service) resolveTitleAsync(ctx context.Context, b board.Board, card board.Card, ref *board.Link) {
+	if ref == nil {
+		return
+	}
+	resolver, ok := s.backend.(LinkResolver)
+	if !ok {
+		return
+	}
+	fallback := ref.FallbackTitle()
+	link := *ref
+	itemID := card.ItemID
+	// Detached from the request: the response is already on its way out, but
+	// the caller's values (token, actor) must survive.
+	bg := board.Unattributed(context.WithoutCancel(ctx))
+	spawn(func() {
+		ctx, cancel := context.WithTimeout(bg, asyncResolveTimeout)
+		defer cancel()
+		resolved, err := resolver.ResolveIssueRef(ctx, link)
+		if err != nil || resolved.Title == "" || resolved.Title == fallback {
+			return
+		}
+		fresh, cerr := s.backend.LoadBoard(ctx, b.Owner, b.Number)
+		if cerr != nil {
+			return
+		}
+		current, found := findCard(fresh, itemID)
+		// Gone, or retitled by a human while we were away: leave it alone.
+		if !found || current.Title != fallback {
+			return
+		}
+		_ = s.backend.RenameCard(ctx, fresh, current, resolved.Title)
+	})
 }
 
 // withLinkDescription moves the source URL of a create-by-URL card into its

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -1315,6 +1315,7 @@ func TestCreateCardFromGitHubURL(t *testing.T) {
 			URL: "https://github.com/acme/repo/pull/7", Kind: "pull",
 			Owner: "acme", Repo: "repo", Number: 7, Title: "feat: warp drive", State: "open"},
 	}
+	defer inlineSpawn(t)()
 	svc := New(fake)
 	card, err := svc.CreateCard(context.Background(), "acme", 1, CreateCardArgs{
 		Team: "alpha", Title: "  https://github.com/acme/repo/pull/7 ",
@@ -1322,11 +1323,64 @@ func TestCreateCardFromGitHubURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if card.Title != "feat: warp drive" {
-		t.Fatalf("title = %q", card.Title)
+	// The create answers at once under the readable fallback — it never waits
+	// on GitHub — and the background resolve renames the card afterwards.
+	if card.Title != "Pull: acme/repo#7" {
+		t.Fatalf("create should answer under the fallback, got %q", card.Title)
+	}
+	if !fake.saw("RenameCard " + card.ItemID) {
+		t.Fatalf("the background resolve must rename the card; log=%v", fake.log)
+	}
+	if got := fake.get(card.ItemID).Title; got != "feat: warp drive" {
+		t.Fatalf("resolved title = %q", got)
 	}
 	if !fake.saw("SetDescription " + card.ItemID + " https://github.com/acme/repo/pull/7") {
 		t.Fatal("description must carry the source link")
+	}
+}
+
+// inlineSpawn makes the background title resolve run inline for the duration
+// of a test, and returns the restore func.
+func inlineSpawn(t *testing.T) func() {
+	t.Helper()
+	old := spawn
+	spawn = func(fn func()) { fn() }
+	return func() { spawn = old }
+}
+
+// A person retitling the card before the resolve lands keeps their words: the
+// background rename only replaces the untouched fallback.
+func TestCreateCardFromURLKeepsUserRename(t *testing.T) {
+	fake := newFake(nil, map[string]board.SprintState{"alpha": {Current: "2026-06-20", ItemID: "s1"}})
+	fake.refs = map[string]board.Link{
+		"https://github.com/acme/repo/pull/7": {
+			URL: "https://github.com/acme/repo/pull/7", Kind: "pull",
+			Owner: "acme", Repo: "repo", Number: 7, Title: "feat: warp drive", State: "open"},
+	}
+	// Retitle the card the moment it exists, before the resolve runs.
+	old := spawn
+	spawn = func(fn func()) {
+		for i := range fake.b.Cards {
+			if fake.b.Cards[i].Title == "Pull: acme/repo#7" {
+				fake.b.Cards[i].Title = "my own words"
+			}
+		}
+		fn()
+	}
+	defer func() { spawn = old }()
+
+	svc := New(fake)
+	card, err := svc.CreateCard(context.Background(), "acme", 1, CreateCardArgs{
+		Team: "alpha", Title: "https://github.com/acme/repo/pull/7",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fake.get(card.ItemID).Title; got != "my own words" {
+		t.Fatalf("a user rename must survive the resolve, got %q", got)
+	}
+	if fake.saw("RenameCard " + card.ItemID) {
+		t.Fatalf("the resolve must not rename a retitled card; log=%v", fake.log)
 	}
 }
 

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -1,3 +1,4 @@
+import { optimisticTitle } from "../links";
 import {
   useCallback,
   useEffect,
@@ -613,7 +614,7 @@ export function MeBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     addCard({
       itemId: tempId,
-      title,
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: viewMe ? [viewMe] : [],
       zone: parent.zone ?? "gray",
@@ -1007,7 +1008,9 @@ export function MeBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
       itemId: tempId,
-      title,
+      // A bare GitHub reference reads as its readable label at once; the
+      // server's background resolve renames it to the real title shortly.
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: [reviewerLogin],
       zone,
@@ -1199,7 +1202,9 @@ export function MeBoard({
     const firstSprint = sprint === null;
     const optimistic: CardModel = {
       itemId: tempId,
-      title,
+      // A bare GitHub reference reads as its readable label at once; the
+      // server's background resolve renames it to the real title shortly.
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: viewMe ? [viewMe] : [],
       zone,

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1,3 +1,4 @@
+import { optimisticTitle } from "../links";
 import {
   Fragment,
   useEffect,
@@ -407,7 +408,9 @@ export function TeamBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
       itemId: tempId,
-      title,
+      // A bare GitHub reference reads as its readable label at once; the
+      // server's background resolve renames it to the real title shortly.
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: [],
       plan,
@@ -1119,7 +1122,7 @@ export function TeamBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     addCard({
       itemId: tempId,
-      title,
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: parent.assignees.slice(0, 1),
       zone: parent.zone ?? "gray",
@@ -1765,7 +1768,9 @@ export function TeamBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
       itemId: tempId,
-      title,
+      // A bare GitHub reference reads as its readable label at once; the
+      // server's background resolve renames it to the real title shortly.
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: [reviewerLogin],
       zone,
@@ -1897,7 +1902,9 @@ export function TeamBoard({
     const tempId = `tmp-${new Date().toISOString()}`;
     const optimistic: CardModel = {
       itemId: tempId,
-      title,
+      // A bare GitHub reference reads as its readable label at once; the
+      // server's background resolve renames it to the real title shortly.
+      title: optimisticTitle(title),
       isDraft: true,
       assignees: engineer ? [engineer] : [],
       zone,

--- a/web/src/links.test.ts
+++ b/web/src/links.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { optimisticTitle } from "./links";
+
+// The card must never sit on screen showing a raw URL: a bare GitHub
+// reference reads as the same "Pull: owner/repo#N" label the server falls
+// back to, until the background resolve renames it to the real title.
+describe("optimisticTitle", () => {
+  it("labels a bare PR URL", () => {
+    expect(optimisticTitle("https://github.com/acme/webapp/pull/7")).toBe(
+      "Pull: acme/webapp#7",
+    );
+  });
+
+  it("labels a bare issue URL, trimming whitespace", () => {
+    expect(optimisticTitle("  https://github.com/acme/webapp/issues/12 ")).toBe(
+      "Issue: acme/webapp#12",
+    );
+  });
+
+  it("labels the owner/repo#N shorthand", () => {
+    expect(optimisticTitle("cncf/foundation#1465")).toBe(
+      "Issue: cncf/foundation#1465",
+    );
+  });
+
+  it("leaves the user's own wording alone", () => {
+    for (const title of [
+      "Fix the flaky e2e test",
+      "see https://github.com/acme/webapp/pull/7 for context",
+      "https://example.com/docs",
+      "a/b/c#1",
+    ]) {
+      expect(optimisticTitle(title)).toBe(title);
+    }
+  });
+});

--- a/web/src/links.ts
+++ b/web/src/links.ts
@@ -36,6 +36,29 @@ export function extractLinks(description: string): CardLink[] {
   return [...refs, ...plain];
 }
 
+const SHORTHAND = /^([A-Za-z0-9][A-Za-z0-9-]*)\/([A-Za-z0-9_.-]+)#([0-9]+)$/;
+
+/** optimisticTitle is what a card typed as a bare GitHub reference should read
+ *  the instant it appears, before the server's background resolve renames it
+ *  to the item's real title: the same readable "Pull: owner/repo#N" label the
+ *  server falls back to (mirrors board.Link.FallbackTitle). Anything that is
+ *  not a bare reference is the user's own wording and is left untouched. */
+export function optimisticTitle(raw: string): string {
+  const text = raw.trim();
+  const short = SHORTHAND.exec(text);
+  if (short) {
+    // A shorthand carries no issue/pull distinction; the server resolves it,
+    // and until then "Issue:" is the neutral label it also starts from.
+    return `Issue: ${short[1]}/${short[2]}#${short[3]}`;
+  }
+  const link = classifyLink(text);
+  if (link.kind === "link" || !link.owner || !link.repo || !link.number) {
+    return raw;
+  }
+  const kind = link.kind === "pull" ? "Pull" : "Issue";
+  return `${kind}: ${link.owner}/${link.repo}#${link.number}`;
+}
+
 /** classifyLink recognises github.com/{owner}/{repo}/issues|pull/{n}. */
 function classifyLink(url: string): CardLink {
   const link: CardLink = { url, kind: "link" };


### PR DESCRIPTION
## Problem

Creating a card from a pasted GitHub link left the raw URL on screen, and people reloaded the page to get a readable name. Reported as: «когда пользователь копирует ссылку в название карточки она превращается в осмысленное название не сразу, а после перезагрузки страницы».

Two causes stacked up:

1. The create **blocked on a GitHub round trip** to fetch the item's title, so the optimistic card showed the URL for the whole request.
2. The client's optimistic card rendered exactly what was typed — the URL — until the response landed.

## Fix

**The create no longer waits on GitHub.** It answers immediately under the same readable `Pull: owner/repo#N` fallback the server already used for unresolvable links, and a background pass fetches the real title and renames the card (measured on a dev board: fallback at once, real title ~1s later).

Two guards keep that honest:

- **A person's words win**: the background rename re-reads the card and only replaces the untouched fallback, so a card retitled meanwhile (by a human or an agent over MCP) is left alone.
- **The creating tab actually sees it**: watch frames echo-suppress against the originating client, which would have hidden the rename from the very person who created the card — until a reload, exactly as reported. Server-side work on nobody's behalf is now marked `board.Unattributed`, and the watch layer broadcasts it to everyone.

**The client mirrors the same label** (`optimisticTitle`, the TS twin of `board.Link.FallbackTitle`) in every optimistic card — Me zones, Team grid, weekly plan and both subtask forms — so the raw URL never shows, not even for the length of the create.

The background work is detached from the request (`context.WithoutCancel` + a 30s timeout), and its launch point is a swappable `spawn` so tests run it inline.

## Testing

- `TestCreateCardFromGitHubURL` — create answers under the fallback, the background pass renames to the real title.
- `TestCreateCardFromURLKeepsUserRename` — a card retitled before the resolve lands keeps the person's wording; no rename call is made.
- `TestUnattributedWorkIsNotEchoSuppressed` — unattributed work carries no origin, so nothing is echo-suppressed.
- `TestAPICreateCardFromGitHubURL` — end-to-end over HTTP: instant fallback, then the resolved title.
- 4 new web tests for `optimisticTitle` (PR URL, issue URL, `owner/repo#N` shorthand, and leaving the user's own wording alone).
- Verified live on a dev board with both a public and a private repo link; full Go + web suites and golangci-lint pass.