### PR TITLE
perf(cache): probe-based cache admission and an off-request board warmer

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -185,7 +185,16 @@ func (s *Server) defaultService(r *http.Request) (*boardservice.Service, error) 
 	if err != nil {
 		return nil, err
 	}
-	return boardservice.New(&storeBackend{inner: client, store: s.store, multiUser: s.auth != nil}), nil
+	be := &storeBackend{inner: client, store: s.store, multiUser: s.auth != nil}
+	if s.auth != nil {
+		// Bind the request's token to its session, so a warmer that later
+		// rides this client stops once the session ends (logout or TTL).
+		if sid := s.auth.sessionID(r); sid != "" {
+			auth := s.auth
+			be.warmAlive = func() bool { return auth.sessionAlive(sid) }
+		}
+	}
+	return boardservice.New(be), nil
 }
 
 // service resolves the board reference and builds the per-request board service.

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -342,6 +342,30 @@ func (a *authManager) session(r *http.Request) (oauthSession, bool) {
 	return s, true
 }
 
+// sessionID returns the caller's session cookie value ("" when absent). It
+// does not validate the session — pair it with sessionAlive.
+func (a *authManager) sessionID(r *http.Request) string {
+	c, err := r.Cookie(sessionCookie)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// sessionAlive reports whether sid still maps to a live, unexpired session.
+// The board warmer polls it each tick so a captured token stops being used
+// once its owner's session ends (logout or TTL) — not merely when GitHub
+// finally rejects the token.
+func (a *authManager) sessionAlive(sid string) bool {
+	if sid == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.sessions[sid]
+	return ok && time.Since(s.created) <= sessionTTL
+}
+
 func (a *authManager) setCookie(w http.ResponseWriter, name, value string, maxAge int) {
 	// Secure is driven by the public scheme: true behind the HTTPS proxy
 	// (Cloudflare), false only for plain-HTTP local testing.

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -128,6 +128,14 @@ type boardEntry struct {
 	// recentMove is when a local reorder last touched this board: within
 	// recentGrace the cached order outweighs a fresh (possibly stale) read.
 	recentMove time.Time
+	// warming marks the background cache warmer as running for this entry, so
+	// repeated loads do not stack a second one.
+	warming bool
+	// lastRead is when a request last read this board (cache hit or load).
+	// The warmer keeps refreshing a watcher-less board for warmIdleFor past
+	// it, so the first open of the morning finds the cache warm even though
+	// every laptop — and its watch connection — slept through the night.
+	lastRead time.Time
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -270,11 +278,15 @@ func sortCardsByRank(cards []board.Card, rank map[string]int) {
 
 // cacheState grades a cache lookup: a fresh hit is served to anyone allowed,
 // a stale one only to read paths that revalidate in the background, a miss
-// always loads.
+// always loads. cacheUnauthed is a special miss: the board itself is warm
+// enough to serve, only this login's token has not (recently enough) proven
+// it can read it — a cheap access probe can upgrade it to a hit without the
+// full multi-page load a plain miss pays.
 type cacheState int
 
 const (
 	cacheMiss cacheState = iota
+	cacheUnauthed
 	cacheStale
 	cacheFresh
 )
@@ -304,13 +316,18 @@ func (e *boardEntry) cached(login string, multiUser bool) (board.Board, cacheSta
 	}
 	authAge := time.Duration(0)
 	if multiUser || login != "" {
-		ts, ok := e.authed[login]
-		if login == "" || !ok {
+		if login == "" {
+			// No login to credit a probe to — only a full token-scoped load
+			// can serve this caller.
 			return board.Board{}, cacheMiss
+		}
+		ts, ok := e.authed[login]
+		if !ok {
+			return board.Board{}, cacheUnauthed
 		}
 		authAge = time.Since(ts)
 		if authAge >= boardStaleMax {
-			return board.Board{}, cacheMiss
+			return board.Board{}, cacheUnauthed
 		}
 	}
 	if age >= boardFreshFor || authAge >= authFreshFor {
@@ -556,10 +573,16 @@ func (e *boardEntry) removeCard(itemID string) {
 type boardStore struct {
 	mu      sync.Mutex
 	entries map[string]*boardEntry
+	// warmEvery is the background warmer's refresh cadence (see ensureWarm).
+	// It must sit well under boardStaleMax so a watched board never ages past
+	// the stale ceiling — past which every read blocks on the full multi-page
+	// GitHub load — while staying coarse enough that a large board costs only
+	// a handful of GraphQL pages per cycle. Set at construction; tests shrink it.
+	warmEvery time.Duration
 }
 
 func newBoardStore() *boardStore {
-	return &boardStore{entries: map[string]*boardEntry{}}
+	return &boardStore{entries: map[string]*boardEntry{}, warmEvery: 3 * time.Minute}
 }
 
 func storeKey(owner string, project int) string {
@@ -658,6 +681,9 @@ var _ boardservice.Backend = (*storeBackend)(nil)
 func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
 	e := b.store.entry(storeKey(owner, project))
 	login := board.ActorFrom(ctx)
+	e.mu.Lock()
+	e.lastRead = time.Now()
+	e.mu.Unlock()
 	bd, state := e.cached(login, b.multiUser)
 	if state == cacheFresh {
 		return bd, nil
@@ -667,6 +693,35 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 			b.revalidate(ctx, e, owner, project)
 			sc.served.Store(true)
 			return bd, nil
+		}
+	}
+	// The board is warm — only this login has no (recent enough) proof its
+	// token can read it. Proving that costs one tiny GraphQL probe, not the
+	// multi-page load below: without this, every engineer coming back from a
+	// >10-minute break personally re-paid the full board fetch (~2s per 100
+	// cards) just to be let into a cache their teammates kept warm.
+	if state == cacheUnauthed && login != "" {
+		if prober, ok := b.inner.(accessProber); ok {
+			if err := prober.CheckBoardAccess(ctx, owner, project); err == nil {
+				e.mu.Lock()
+				e.markAuthed(login)
+				e.mu.Unlock()
+				bd, state := e.cached(login, b.multiUser)
+				if state == cacheFresh {
+					return bd, nil
+				}
+				if state == cacheStale {
+					if sc := staleControlFrom(ctx); sc != nil {
+						b.revalidate(ctx, e, owner, project)
+						sc.served.Store(true)
+						return bd, nil
+					}
+				}
+				// A path that cannot take stale data falls through to the
+				// full load below.
+			}
+			// A failed probe falls through too: the full load surfaces the
+			// real error (no access, rate limit, network) to the caller.
 		}
 	}
 	e.loadMu.Lock()
@@ -682,7 +737,16 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 	if err != nil {
 		return board.Board{}, err
 	}
-	return b.install(e, fresh, login), nil
+	installed := b.install(e, fresh, login)
+	b.ensureWarm(e, owner, project)
+	return installed, nil
+}
+
+// accessProber is the cheap authorization check a backend may offer: can this
+// client's token read the board at all, without loading it. *ghprojects.Client
+// implements it with a single project-id query.
+type accessProber interface {
+	CheckBoardAccess(ctx context.Context, owner string, project int) error
 }
 
 // revalidate refreshes a stale cache in the background with the requesting
@@ -707,6 +771,66 @@ func (b *storeBackend) revalidate(ctx context.Context, e *boardEntry, owner stri
 			return
 		}
 		b.install(e, fresh, login)
+		b.ensureWarm(e, owner, project)
+	}()
+}
+
+// warmIdleFor is how long past the last interactive read the warmer keeps a
+// watcher-less board fresh. Long enough to carry the cache through a night of
+// sleeping laptops (whose watch connections die with them) into the next
+// morning; short enough that a board nobody opens stops costing GitHub
+// traffic within a day.
+const warmIdleFor = 16 * time.Hour
+
+// ensureWarm keeps a board's cache from ever crossing boardStaleMax while
+// anyone plausibly needs it: while the entry has watchers (every open tab
+// holds a watch connection) and for warmIdleFor past the last read, a
+// background loop refreshes the cache on the token of the request that
+// started it. Without this the first person to open aeman after a quiet
+// stretch — every morning, after every lunch — ate a 20-30s cold load; with
+// it that load happens off-request. It also REPLACES the per-tab revalidation
+// the watch ping used to kick every 30s: one 3-minute server-side loop per
+// board instead of a near-continuous full reload per open tab.
+//
+// The loop stops when neither condition holds or a refresh fails (an expired
+// or revoked token must not keep polling GitHub); the next user-driven load
+// restarts it on a current token. Single-flight per entry via e.warming.
+func (b *storeBackend) ensureWarm(e *boardEntry, owner string, project int) {
+	e.mu.Lock()
+	if e.warming {
+		e.mu.Unlock()
+		return
+	}
+	e.warming = true
+	e.mu.Unlock()
+	inner := b.inner
+	every := b.store.warmEvery
+	go func() {
+		defer func() {
+			e.mu.Lock()
+			e.warming = false
+			e.mu.Unlock()
+		}()
+		for {
+			time.Sleep(every)
+			e.mu.Lock()
+			wanted := len(e.watchers) > 0 || time.Since(e.lastRead) < warmIdleFor
+			e.mu.Unlock()
+			if !wanted {
+				return
+			}
+			e.loadMu.Lock()
+			fresh, err := inner.LoadBoard(context.Background(), owner, project)
+			if err == nil {
+				// No login: a warm refresh keeps the board current but must
+				// not vouch for anyone's access.
+				b.install(e, fresh, "")
+			}
+			e.loadMu.Unlock()
+			if err != nil {
+				return
+			}
+		}
 	}()
 }
 

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"sort"
 	"strconv"
@@ -15,6 +17,7 @@ import (
 	"github.com/aenix-io/aeman/pkg/apiserver"
 	"github.com/aenix-io/aeman/pkg/board"
 	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 )
 
 // watchFrame is one event on the watch stream: a typed change to a Card,
@@ -71,9 +74,14 @@ func clientIDFrom(ctx context.Context) string {
 	return id
 }
 
-// boardFreshFor bounds how long a cached board is served before a read reloads
-// it from the backend, so edits made outside aeman eventually surface.
-const boardFreshFor = 30 * time.Second
+// boardFreshFor bounds how long a cached board is served before a read
+// questions it. It matches the background warmer's watched cadence
+// (boardStore.warmEvery): the warmer refreshes the cache from GitHub on that
+// rhythm, so in the steady state interactive reads AND mutations land on a
+// fresh cache instead of re-paying the multi-page load themselves — the
+// pre-warmer value of 30s made every mutation outside a narrow window block
+// on a full reload. Edits made outside aeman surface within one warmer tick.
+const boardFreshFor = 3 * time.Minute
 
 // boardStaleMax bounds how old a snapshot a read-only request may still be
 // served while the store revalidates in the background. Past it (the first
@@ -131,11 +139,32 @@ type boardEntry struct {
 	// warming marks the background cache warmer as running for this entry, so
 	// repeated loads do not stack a second one.
 	warming bool
-	// lastRead is when a request last read this board (cache hit or load).
-	// The warmer keeps refreshing a watcher-less board for warmIdleFor past
-	// it, so the first open of the morning finds the cache warm even though
-	// every laptop — and its watch connection — slept through the night.
+	// warmSrc is what the warmer refreshes the board with: the client (and
+	// session-liveness check) of the most recent request whose own full load
+	// succeeded. Rotated on every such load, so the warmer migrates to the
+	// freshest token instead of riding whoever happened to start it.
+	warmSrc *warmSource
+	// lastRead is when a request was last SERVED this board (cache hit or
+	// load) — stamped only on success, so an unauthorized caller cannot
+	// extend the warm window of a board it may not read. The warmer keeps
+	// refreshing a watcher-less board for warmIdleFor past it, so the first
+	// open of the morning finds the cache warm even though every laptop —
+	// and its watch connection — slept through the night.
 	lastRead time.Time
+	// reproving guards the async access re-proof so a burst of reads (one
+	// card panel fires several GETs) probes GitHub once per login, not once
+	// per request.
+	reproving map[string]bool
+}
+
+// warmSource is the identity the background warmer loads with: a per-request
+// backend client (carrying that user's token), an optional liveness check
+// bound to the owning session (nil = always alive, the local single-user
+// mode), and the login for logging.
+type warmSource struct {
+	inner boardservice.Backend
+	alive func() bool
+	login string
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -291,66 +320,74 @@ const (
 	cacheFresh
 )
 
-// cached returns the board and how usable it is for this caller. cacheFresh
-// needs both the board within boardFreshFor and, for a named login (OAuth
-// multi-user mode; an empty login is the single local user, always allowed),
-// token-scoped access proven within authFreshFor. Past either TTL — but with
-// the board loaded and the login's proof both within boardStaleMax — the hit
-// degrades to cacheStale: read paths may serve it while a background reload
-// with the caller's own token refreshes the board AND re-proves their access,
-// so a revoked token stops refreshing its proof and hard-fails within
-// boardStaleMax. A login that never proved access always misses — the shared
-// cache is keyed only by owner/project, and this gate is what keeps one
-// user's warm board from leaking to another. multiUser forces the login check
-// even if a login somehow arrives empty, so an OAuth deployment never serves
-// the cache without a per-user authorization.
-func (e *boardEntry) cached(login string, multiUser bool) (board.Board, cacheState) {
+// cached returns the board, how usable it is for this caller, and whether
+// the caller's access proof wants a background re-proof. The board dimension
+// alone grades the hit: within boardFreshFor it is cacheFresh, past that (up
+// to boardStaleMax) cacheStale — read paths may serve a stale hit while a
+// background reload revalidates it. The login dimension gates independently:
+// for a named login (OAuth multi-user mode; an empty login is the single
+// local user, always allowed), token-scoped access must have been proven
+// within boardStaleMax — never proven, or proven too long ago, is
+// cacheUnauthed with NO board: the shared cache is keyed only by
+// owner/project, and this gate is what keeps one user's warm board from
+// leaking to another. A proof merely older than authFreshFor does not block
+// the hit — it sets reproof, and the caller re-proves the token with a cheap
+// background probe (a failed probe drops the proof; the boardStaleMax ceiling
+// bounds how long a revoked token can ride the cache either way, exactly as
+// it always did). multiUser forces the login check even if a login somehow
+// arrives empty, so an OAuth deployment never serves the cache without a
+// per-user authorization.
+func (e *boardEntry) cached(login string, multiUser bool) (board.Board, cacheState, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if !e.loaded {
-		return board.Board{}, cacheMiss
+		return board.Board{}, cacheMiss, false
 	}
 	age := time.Since(e.loadedAt)
 	if age >= boardStaleMax {
-		return board.Board{}, cacheMiss
+		return board.Board{}, cacheMiss, false
 	}
-	authAge := time.Duration(0)
+	reproof := false
 	if multiUser || login != "" {
 		if login == "" {
 			// No login to credit a probe to — only a full token-scoped load
 			// can serve this caller.
-			return board.Board{}, cacheMiss
+			return board.Board{}, cacheMiss, false
 		}
 		ts, ok := e.authed[login]
 		if !ok {
-			return board.Board{}, cacheUnauthed
+			return board.Board{}, cacheUnauthed, false
 		}
-		authAge = time.Since(ts)
+		authAge := time.Since(ts)
 		if authAge >= boardStaleMax {
-			return board.Board{}, cacheUnauthed
+			return board.Board{}, cacheUnauthed, false
 		}
+		reproof = authAge >= authFreshFor
 	}
-	if age >= boardFreshFor || authAge >= authFreshFor {
-		return e.board, cacheStale
+	if age >= boardFreshFor {
+		return e.board, cacheStale, reproof
 	}
-	return e.board, cacheFresh
+	return e.board, cacheFresh, reproof
 }
 
 // markAuthed records that a login's own token just proved read access, and
 // sweeps entries too old to back even a stale hit so the map tracks only
 // currently-active users. The caller holds e.mu.
 func (e *boardEntry) markAuthed(login string) {
-	if login == "" {
-		return
-	}
-	if e.authed == nil {
-		e.authed = map[string]time.Time{}
-	}
+	// Sweep before the empty-login return: the warmer's installs (login "")
+	// are the most frequent caller, and without this the sweep would only run
+	// on the rarer user-driven full loads.
 	now := time.Now()
 	for l, ts := range e.authed {
 		if now.Sub(ts) >= boardStaleMax {
 			delete(e.authed, l)
 		}
+	}
+	if login == "" {
+		return
+	}
+	if e.authed == nil {
+		e.authed = map[string]time.Time{}
 	}
 	e.authed[login] = now
 }
@@ -573,16 +610,35 @@ func (e *boardEntry) removeCard(itemID string) {
 type boardStore struct {
 	mu      sync.Mutex
 	entries map[string]*boardEntry
-	// warmEvery is the background warmer's refresh cadence (see ensureWarm).
-	// It must sit well under boardStaleMax so a watched board never ages past
-	// the stale ceiling — past which every read blocks on the full multi-page
-	// GitHub load — while staying coarse enough that a large board costs only
-	// a handful of GraphQL pages per cycle. Set at construction; tests shrink it.
-	warmEvery time.Duration
+	// warmEvery is the warmer's cadence while the board has watchers (open
+	// tabs): it equals boardFreshFor, so an actively watched board is always
+	// fresh and neither reads nor mutations ever block on the full multi-page
+	// GitHub load. warmIdleEvery is the watcher-less cadence (the overnight
+	// window): slower to spare the captured token, but still under
+	// boardStaleMax so the morning's first read gets an instantly served
+	// stale hit instead of a cold load. Set at construction; tests shrink them.
+	warmEvery     time.Duration
+	warmIdleEvery time.Duration
+	// log receives warmer lifecycle events (start/stop and on whose token it
+	// runs). Nil-safe via logger().
+	log *slog.Logger
+}
+
+// logger returns the store's logger, or a discard logger when none was wired
+// (tests).
+func (s *boardStore) logger() *slog.Logger {
+	if s.log != nil {
+		return s.log
+	}
+	return slog.New(slog.DiscardHandler)
 }
 
 func newBoardStore() *boardStore {
-	return &boardStore{entries: map[string]*boardEntry{}, warmEvery: 3 * time.Minute}
+	return &boardStore{
+		entries:       map[string]*boardEntry{},
+		warmEvery:     boardFreshFor,
+		warmIdleEvery: 8 * time.Minute,
+	}
 }
 
 func storeKey(owner string, project int) string {
@@ -668,6 +724,11 @@ type storeBackend struct {
 	// user's token: a cache hit is then gated on that login having proven
 	// token-scoped access. Off in local-proxy mode (a single gh identity).
 	multiUser bool
+	// warmAlive reports whether the session behind this request's token is
+	// still live; the warmer polls it so a captured token stops being used
+	// once its owner logs out or the session expires. Nil in local-proxy mode
+	// (the gh identity has no session to outlive).
+	warmAlive func() bool
 }
 
 var _ boardservice.Backend = (*storeBackend)(nil)
@@ -681,54 +742,70 @@ var _ boardservice.Backend = (*storeBackend)(nil)
 func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
 	e := b.store.entry(storeKey(owner, project))
 	login := board.ActorFrom(ctx)
-	e.mu.Lock()
-	e.lastRead = time.Now()
-	e.mu.Unlock()
-	bd, state := e.cached(login, b.multiUser)
+	bd, state, reproof := e.cached(login, b.multiUser)
 	if state == cacheFresh {
+		if reproof {
+			b.reproveAsync(ctx, e, owner, project, login)
+		}
+		b.markRead(e)
 		return bd, nil
 	}
 	if state == cacheStale {
 		if sc := staleControlFrom(ctx); sc != nil {
+			// The background revalidation re-proves the caller's token too
+			// (install records the login), so no separate probe is needed.
 			b.revalidate(ctx, e, owner, project)
 			sc.served.Store(true)
+			b.markRead(e)
 			return bd, nil
 		}
 	}
 	// The board is warm — only this login has no (recent enough) proof its
 	// token can read it. Proving that costs one tiny GraphQL probe, not the
 	// multi-page load below: without this, every engineer coming back from a
-	// >10-minute break personally re-paid the full board fetch (~2s per 100
-	// cards) just to be let into a cache their teammates kept warm.
+	// break personally re-paid the full board fetch (~2s per 100 cards) just
+	// to be let into a cache their teammates kept warm.
+	probeFailed := false
 	if state == cacheUnauthed && login != "" {
-		if prober, ok := b.inner.(accessProber); ok {
-			if err := prober.CheckBoardAccess(ctx, owner, project); err == nil {
-				e.mu.Lock()
-				e.markAuthed(login)
-				e.mu.Unlock()
-				bd, state := e.cached(login, b.multiUser)
-				if state == cacheFresh {
+		bd, st, ok := b.admitByProbe(ctx, e, owner, project, login)
+		probeFailed = !ok
+		if ok {
+			if st == cacheFresh {
+				b.markRead(e)
+				return bd, nil
+			}
+			if st == cacheStale {
+				if sc := staleControlFrom(ctx); sc != nil {
+					b.revalidate(ctx, e, owner, project)
+					sc.served.Store(true)
+					b.markRead(e)
 					return bd, nil
 				}
-				if state == cacheStale {
-					if sc := staleControlFrom(ctx); sc != nil {
-						b.revalidate(ctx, e, owner, project)
-						sc.served.Store(true)
-						return bd, nil
-					}
-				}
-				// A path that cannot take stale data falls through to the
-				// full load below.
 			}
-			// A failed probe falls through too: the full load surfaces the
-			// real error (no access, rate limit, network) to the caller.
+			// A path that cannot take stale data falls through to the full
+			// load below.
 		}
+		// A failed probe falls through too: the full load surfaces the real
+		// error (no access, rate limit, network) to the caller.
 	}
 	e.loadMu.Lock()
 	defer e.loadMu.Unlock()
-	// A concurrent loader may have refreshed the cache while we waited.
-	if bd, state := e.cached(login, b.multiUser); state == cacheFresh {
+	// A concurrent loader — the warmer included — may have refreshed the
+	// cache while we waited on loadMu; a mutation that queued behind the
+	// warmer's reload must ride that result (proving its own access by probe
+	// when needed — but not re-asking after a probe that just failed) instead
+	// of re-paying the full load.
+	if bd, st, rp := e.cached(login, b.multiUser); st == cacheFresh {
+		if rp {
+			b.reproveAsync(ctx, e, owner, project, login)
+		}
+		b.markRead(e)
 		return bd, nil
+	} else if st == cacheUnauthed && login != "" && !probeFailed {
+		if bd, st2, ok := b.admitByProbe(ctx, e, owner, project, login); ok && st2 == cacheFresh {
+			b.markRead(e)
+			return bd, nil
+		}
 	}
 	// The token-scoped backend load is the authorization check: GitHub rejects a
 	// token that can't read this board, so reaching a cached result requires
@@ -738,7 +815,9 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		return board.Board{}, err
 	}
 	installed := b.install(e, fresh, login)
+	b.setWarmSrc(e, login)
 	b.ensureWarm(e, owner, project)
+	b.markRead(e)
 	return installed, nil
 }
 
@@ -747,6 +826,73 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 // implements it with a single project-id query.
 type accessProber interface {
 	CheckBoardAccess(ctx context.Context, owner string, project int) error
+}
+
+// markRead stamps the entry as served. Only successful serves count: an
+// unauthorized caller must not be able to extend the warm window.
+func (b *storeBackend) markRead(e *boardEntry) {
+	e.mu.Lock()
+	e.lastRead = time.Now()
+	e.mu.Unlock()
+}
+
+// admitByProbe re-proves login's access with the cheap probe and, on success,
+// records it and returns the resulting cache state. ok=false means the probe
+// was unavailable or failed — the caller falls back to the full load.
+func (b *storeBackend) admitByProbe(ctx context.Context, e *boardEntry, owner string, project int, login string) (board.Board, cacheState, bool) {
+	prober, hasProbe := b.inner.(accessProber)
+	if !hasProbe || login == "" {
+		return board.Board{}, cacheMiss, false
+	}
+	if err := prober.CheckBoardAccess(ctx, owner, project); err != nil {
+		return board.Board{}, cacheMiss, false
+	}
+	e.mu.Lock()
+	e.markAuthed(login)
+	e.mu.Unlock()
+	bd, state, _ := e.cached(login, b.multiUser)
+	return bd, state, true
+}
+
+// reproveAsync refreshes an aging access proof in the background: the read was
+// already served (the proof is inside boardStaleMax), so the caller must not
+// wait on GitHub. A probe that positively reports no access drops the proof —
+// the next read gates hard on cacheUnauthed; a transient failure leaves the
+// proof aging toward the boardStaleMax ceiling, exactly as the old
+// revalidation-based re-proof did. Deduplicated per login so a burst of GETs
+// probes once.
+func (b *storeBackend) reproveAsync(ctx context.Context, e *boardEntry, owner string, project int, login string) {
+	prober, ok := b.inner.(accessProber)
+	if !ok || login == "" {
+		return
+	}
+	e.mu.Lock()
+	if e.reproving == nil {
+		e.reproving = map[string]bool{}
+	}
+	if e.reproving[login] {
+		e.mu.Unlock()
+		return
+	}
+	e.reproving[login] = true
+	e.mu.Unlock()
+	bg := context.WithoutCancel(ctx)
+	go func() {
+		ctx, cancel := context.WithTimeout(bg, 30*time.Second)
+		defer cancel()
+		err := prober.CheckBoardAccess(ctx, owner, project)
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		delete(e.reproving, login)
+		switch {
+		case err == nil:
+			e.markAuthed(login)
+		case errors.Is(err, ghprojects.ErrBoardNotFound):
+			// Access is positively gone (revoked, or the board vanished):
+			// drop the proof so the next read gates on cacheUnauthed.
+			delete(e.authed, login)
+		}
+	}()
 }
 
 // revalidate refreshes a stale cache in the background with the requesting
@@ -771,6 +917,7 @@ func (b *storeBackend) revalidate(ctx context.Context, e *boardEntry, owner stri
 			return
 		}
 		b.install(e, fresh, login)
+		b.setWarmSrc(e, login)
 		b.ensureWarm(e, owner, project)
 	}()
 }
@@ -782,53 +929,134 @@ func (b *storeBackend) revalidate(ctx context.Context, e *boardEntry, owner stri
 // traffic within a day.
 const warmIdleFor = 16 * time.Hour
 
-// ensureWarm keeps a board's cache from ever crossing boardStaleMax while
+// warmLoadTimeout bounds one warm refresh: a dozen-page board at GitHub's
+// worst is minutes, and the warmer holds loadMu for the duration.
+const warmLoadTimeout = 5 * time.Minute
+
+// warmMaxFails is how many consecutive failed refreshes the warmer tolerates
+// before giving up. Transient upstream errors (a 502 at 02:00) just skip a
+// tick — the cadence itself is the backoff — but a persistently failing
+// source (a revoked token answering 401 forever) must not poll GitHub all
+// night.
+const warmMaxFails = 5
+
+// setWarmSrc rotates the warmer's identity to the calling request: its
+// backend client (token), its session-liveness check, and its login. Called
+// on every successful user-driven full load, so the warmer always rides the
+// freshest token instead of whoever happened to start it.
+func (b *storeBackend) setWarmSrc(e *boardEntry, login string) {
+	// In multi-user mode only a session-bound client may power the warmer: a
+	// token with no liveness check (an MCP request's, or a stray empty login)
+	// would keep being used with nothing to ever stop it.
+	if b.multiUser && (b.warmAlive == nil || login == "") {
+		return
+	}
+	e.mu.Lock()
+	e.warmSrc = &warmSource{inner: b.inner, alive: b.warmAlive, login: login}
+	e.mu.Unlock()
+}
+
+// ensureWarm keeps a board's cache from ever crossing boardFreshFor while
 // anyone plausibly needs it: while the entry has watchers (every open tab
-// holds a watch connection) and for warmIdleFor past the last read, a
-// background loop refreshes the cache on the token of the request that
-// started it. Without this the first person to open aeman after a quiet
-// stretch — every morning, after every lunch — ate a 20-30s cold load; with
-// it that load happens off-request. It also REPLACES the per-tab revalidation
-// the watch ping used to kick every 30s: one 3-minute server-side loop per
-// board instead of a near-continuous full reload per open tab.
+// holds a watch connection) it refreshes every warmEvery (= boardFreshFor, so
+// watched boards are always fresh and mutations never block on a full load),
+// and for warmIdleFor past the last read it keeps a watcher-less board under
+// boardStaleMax at the slower warmIdleEvery — carrying the cache through the
+// night so the first open of the morning is served instantly. It REPLACES the
+// per-tab revalidation the watch ping used to kick every 30s: one server-side
+// loop per board instead of a near-continuous full reload per open tab.
 //
-// The loop stops when neither condition holds or a refresh fails (an expired
-// or revoked token must not keep polling GitHub); the next user-driven load
-// restarts it on a current token. Single-flight per entry via e.warming.
+// Each tick re-reads e.warmSrc, so the loop migrates to the most recent
+// loader's token and stops when that source's session is gone (logout, TTL) —
+// a captured token must not outlive its owner's session. Transient refresh
+// failures skip a tick (broadcasting a Sync so stale-read holds release, as
+// revalidate does); warmMaxFails consecutive failures, or a positive
+// access-gone answer, end the loop. The next user-driven load restarts it.
+// Single-flight per entry via e.warming.
 func (b *storeBackend) ensureWarm(e *boardEntry, owner string, project int) {
 	e.mu.Lock()
-	if e.warming {
+	if e.warming || e.warmSrc == nil {
 		e.mu.Unlock()
 		return
 	}
 	e.warming = true
 	e.mu.Unlock()
-	inner := b.inner
-	every := b.store.warmEvery
+	store := b.store
+	key := storeKey(owner, project)
 	go func() {
+		// Safety net for panics only: regular exits clear the flag inside the
+		// same critical section as their decision and set cleared, so this
+		// defer cannot race a successor loop that took the flag in between.
+		cleared := false
 		defer func() {
+			if cleared {
+				return
+			}
 			e.mu.Lock()
 			e.warming = false
 			e.mu.Unlock()
 		}()
+		fails := 0
 		for {
+			e.mu.Lock()
+			watched := len(e.watchers) > 0
+			e.mu.Unlock()
+			every := store.warmEvery
+			if !watched {
+				every = store.warmIdleEvery
+			}
 			time.Sleep(every)
+
 			e.mu.Lock()
 			wanted := len(e.watchers) > 0 || time.Since(e.lastRead) < warmIdleFor
-			e.mu.Unlock()
-			if !wanted {
+			src := e.warmSrc
+			alive := src != nil && (src.alive == nil || src.alive())
+			if !wanted || !alive {
+				e.warming = false
+				e.mu.Unlock()
+				cleared = true
+				if !alive && wanted {
+					login := ""
+					if src != nil {
+						login = src.login
+					}
+					store.logger().Info("board warmer stopped: source session ended",
+						"board", key, "login", login)
+				}
 				return
 			}
+			e.mu.Unlock()
+
 			e.loadMu.Lock()
-			fresh, err := inner.LoadBoard(context.Background(), owner, project)
+			lctx, cancel := context.WithTimeout(context.Background(), warmLoadTimeout)
+			fresh, err := src.inner.LoadBoard(lctx, owner, project)
+			cancel()
 			if err == nil {
 				// No login: a warm refresh keeps the board current but must
 				// not vouch for anyone's access.
 				b.install(e, fresh, "")
+				fails = 0
 			}
 			e.loadMu.Unlock()
 			if err != nil {
-				return
+				fails++
+				e.mu.Lock()
+				// Same contract as a failed revalidation: clients holding a
+				// stale-read revalidation hold get their Sync.
+				e.syncBroadcast()
+				gone := errors.Is(err, ghprojects.ErrBoardNotFound)
+				if gone || fails >= warmMaxFails {
+					e.warming = false
+					e.mu.Unlock()
+					cleared = true
+					store.logger().Warn("board warmer stopped",
+						"board", key, "login", src.login, "err", err,
+						"consecutiveFails", fails, "accessGone", gone)
+					return
+				}
+				e.mu.Unlock()
+				store.logger().Warn("board warm refresh failed; retrying next tick",
+					"board", key, "login", src.login, "err", err, "consecutiveFails", fails)
 			}
 		}
 	}()

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -538,40 +538,42 @@ func TestStaleHeaderOnAPIRead(t *testing.T) {
 // single-user mode (empty login, multiUser=false) skips the login gate.
 func TestCachedAuthz(t *testing.T) {
 	e := &boardEntry{loaded: true, loadedAt: time.Now()}
-	if _, state := e.cached("", false); state != cacheFresh {
+	if _, state, _ := e.cached("", false); state != cacheFresh {
 		t.Fatal("local single-user mode should serve the fresh cache")
 	}
-	if bd, state := e.cached("alice", true); state != cacheUnauthed || bd.ID != "" || len(bd.Cards) != 0 {
+	if bd, state, _ := e.cached("alice", true); state != cacheUnauthed || bd.ID != "" || len(bd.Cards) != 0 {
 		t.Fatal("multi-user: unauthorized login must get cacheUnauthed and NO board")
 	}
 	e.markAuthed("alice")
-	if _, state := e.cached("alice", true); state != cacheFresh {
-		t.Fatal("multi-user: authorized login must hit the fresh cache")
+	if _, state, reproof := e.cached("alice", true); state != cacheFresh || reproof {
+		t.Fatal("multi-user: authorized login must hit the fresh cache, no re-proof")
 	}
-	if _, state := e.cached("", true); state != cacheMiss {
+	if _, state, _ := e.cached("", true); state != cacheMiss {
 		t.Fatal("multi-user: an empty login must never hit the cache")
 	}
 	e.loadedAt = time.Now().Add(-2 * boardFreshFor)
-	if _, state := e.cached("alice", true); state != cacheStale {
+	if _, state, _ := e.cached("alice", true); state != cacheStale {
 		t.Fatal("past the fresh TTL an authorized login must get a stale hit")
 	}
-	if bd, state := e.cached("mallory", true); state != cacheUnauthed || bd.ID != "" {
+	if bd, state, _ := e.cached("mallory", true); state != cacheUnauthed || bd.ID != "" {
 		t.Fatal("a stale hit must still require per-login authorization")
 	}
-	// A fresh board with an aging proof degrades the same way: the background
-	// reload re-checks the token instead of blocking the read on it.
+	// A fresh board with an aging proof is still served fresh — blocking (or
+	// degrading) the read on the token re-check was what forced a full reload
+	// per user per minute — but the reproof flag tells the caller to re-prove
+	// the token with a background probe.
 	e.loadedAt = time.Now()
 	e.authed["alice"] = time.Now().Add(-2 * authFreshFor)
-	if _, state := e.cached("alice", true); state != cacheStale {
-		t.Fatal("an aged authorization must degrade a fresh board to a stale hit")
+	if _, state, reproof := e.cached("alice", true); state != cacheFresh || !reproof {
+		t.Fatal("an aged authorization must serve fresh WITH the reproof flag")
 	}
 	e.authed["alice"] = time.Now().Add(-boardStaleMax - time.Second)
-	if _, state := e.cached("alice", true); state != cacheUnauthed {
+	if _, state, _ := e.cached("alice", true); state != cacheUnauthed {
 		t.Fatal("an authorization older than boardStaleMax must re-prove (cacheUnauthed)")
 	}
 	e.markAuthed("alice")
 	e.loadedAt = time.Now().Add(-boardStaleMax - time.Second)
-	if _, state := e.cached("alice", true); state != cacheMiss {
+	if _, state, _ := e.cached("alice", true); state != cacheMiss {
 		t.Fatal("past boardStaleMax the cache must miss regardless of authorization")
 	}
 }
@@ -738,6 +740,7 @@ func (w *warmBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board
 func TestBoardCacheWarmerFollowsWatchers(t *testing.T) {
 	store := newBoardStore()
 	store.warmEvery = 10 * time.Millisecond
+	store.warmIdleEvery = 10 * time.Millisecond
 	inner := &warmBackend{}
 	be := &storeBackend{inner: inner, store: store}
 

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -531,16 +531,18 @@ func TestStaleHeaderOnAPIRead(t *testing.T) {
 
 // cached gates a hit on load freshness AND, in multi-user mode, the caller's
 // proven access: a fresh hit needs both within their fresh TTLs, an older
-// board or proof (each up to boardStaleMax) degrades to a stale hit, and a
-// login that never proved access — or nothing within boardStaleMax — misses.
-// Local single-user mode (empty login, multiUser=false) skips the login gate.
+// board or proof (each up to boardStaleMax) degrades to a stale hit. A login
+// that never proved access — or whose proof aged past boardStaleMax — gets
+// cacheUnauthed: no board (nothing may be served before proof), but the
+// caller knows a cheap access probe can admit it without a full load. Local
+// single-user mode (empty login, multiUser=false) skips the login gate.
 func TestCachedAuthz(t *testing.T) {
 	e := &boardEntry{loaded: true, loadedAt: time.Now()}
 	if _, state := e.cached("", false); state != cacheFresh {
 		t.Fatal("local single-user mode should serve the fresh cache")
 	}
-	if _, state := e.cached("alice", true); state != cacheMiss {
-		t.Fatal("multi-user: unauthorized login must miss the cache")
+	if bd, state := e.cached("alice", true); state != cacheUnauthed || bd.ID != "" || len(bd.Cards) != 0 {
+		t.Fatal("multi-user: unauthorized login must get cacheUnauthed and NO board")
 	}
 	e.markAuthed("alice")
 	if _, state := e.cached("alice", true); state != cacheFresh {
@@ -553,7 +555,7 @@ func TestCachedAuthz(t *testing.T) {
 	if _, state := e.cached("alice", true); state != cacheStale {
 		t.Fatal("past the fresh TTL an authorized login must get a stale hit")
 	}
-	if _, state := e.cached("mallory", true); state != cacheMiss {
+	if bd, state := e.cached("mallory", true); state != cacheUnauthed || bd.ID != "" {
 		t.Fatal("a stale hit must still require per-login authorization")
 	}
 	// A fresh board with an aging proof degrades the same way: the background
@@ -564,8 +566,8 @@ func TestCachedAuthz(t *testing.T) {
 		t.Fatal("an aged authorization must degrade a fresh board to a stale hit")
 	}
 	e.authed["alice"] = time.Now().Add(-boardStaleMax - time.Second)
-	if _, state := e.cached("alice", true); state != cacheMiss {
-		t.Fatal("an authorization older than boardStaleMax must miss")
+	if _, state := e.cached("alice", true); state != cacheUnauthed {
+		t.Fatal("an authorization older than boardStaleMax must re-prove (cacheUnauthed)")
 	}
 	e.markAuthed("alice")
 	e.loadedAt = time.Now().Add(-boardStaleMax - time.Second)
@@ -635,5 +637,156 @@ func TestUnattributedWorkIsNotEchoSuppressed(t *testing.T) {
 	}
 	if got := clientIDFrom(board.Unattributed(withClient)); got != "" {
 		t.Fatalf("unattributed work must carry no origin, got %q", got)
+	}
+}
+
+// probedBackend is an authzBackend that also offers the cheap access probe,
+// with its own counter and verdict so tests can tell the two apart.
+type probedBackend struct {
+	authzBackend
+	probes    int
+	probeDeny bool
+}
+
+func (p *probedBackend) CheckBoardAccess(_ context.Context, _ string, _ int) error {
+	p.probes++
+	if p.probeDeny {
+		return errors.New("github: not authorized")
+	}
+	return nil
+}
+
+// A second authorized user reaching a warm cache pays one cheap access probe,
+// not the full multi-page board load — that full reload on every >10-minute
+// break is exactly the 20-30s first-open hang this path removes.
+func TestBoardCacheProbeAdmitsSecondUser(t *testing.T) {
+	store := newBoardStore()
+
+	alice := &probedBackend{}
+	aliceBE := &storeBackend{inner: alice, store: store, multiUser: true}
+	bob := &probedBackend{}
+	bobBE := &storeBackend{inner: bob, store: store, multiUser: true}
+
+	aliceCtx := board.WithActor(context.Background(), "alice")
+	bobCtx := board.WithActor(context.Background(), "bob")
+
+	// Alice's first read pays the full load and warms the cache.
+	if _, err := aliceBE.LoadBoard(aliceCtx, "acme", 1); err != nil {
+		t.Fatalf("alice load: %v", err)
+	}
+	// Bob arrives at the warm cache without any proof of access: one probe,
+	// zero full loads, and he is served.
+	if _, err := bobBE.LoadBoard(bobCtx, "acme", 1); err != nil {
+		t.Fatalf("bob load: %v", err)
+	}
+	if bob.probes != 1 {
+		t.Fatalf("bob probes = %d, want 1", bob.probes)
+	}
+	if bob.loads != 0 {
+		t.Fatalf("bob full loads = %d, want 0 (the probe must admit him)", bob.loads)
+	}
+	// Bob again right away: his proof is recorded, not even a probe now.
+	if _, err := bobBE.LoadBoard(bobCtx, "acme", 1); err != nil {
+		t.Fatalf("bob second load: %v", err)
+	}
+	if bob.probes != 1 || bob.loads != 0 {
+		t.Fatalf("bob after markAuthed: probes=%d loads=%d, want 1/0", bob.probes, bob.loads)
+	}
+}
+
+// A denied user's probe failure must NOT admit them: the request falls through
+// to their own token-scoped load, which surfaces the real authorization error.
+func TestBoardCacheProbeDeniedFallsThrough(t *testing.T) {
+	store := newBoardStore()
+
+	alice := &probedBackend{}
+	aliceBE := &storeBackend{inner: alice, store: store, multiUser: true}
+	mallory := &probedBackend{probeDeny: true}
+	mallory.deny = true
+	malloryBE := &storeBackend{inner: mallory, store: store, multiUser: true}
+
+	if _, err := aliceBE.LoadBoard(board.WithActor(context.Background(), "alice"), "acme", 1); err != nil {
+		t.Fatalf("alice load: %v", err)
+	}
+	if _, err := malloryBE.LoadBoard(board.WithActor(context.Background(), "mallory"), "acme", 1); err == nil {
+		t.Fatal("mallory read a board she cannot access (probe admitted her)")
+	}
+	if mallory.probes != 1 {
+		t.Fatalf("mallory probes = %d, want 1", mallory.probes)
+	}
+	if mallory.loads != 1 {
+		t.Fatalf("mallory full loads = %d, want 1 (the denied probe must not short-circuit the real check)", mallory.loads)
+	}
+}
+
+// warmBackend counts loads atomically: the warmer hits it from a background
+// goroutine while the test polls the counter.
+type warmBackend struct {
+	boardservice.Backend // nil: only LoadBoard is exercised
+	loads                atomic.Int64
+}
+
+func (w *warmBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	w.loads.Add(1)
+	return board.Board{Owner: "acme", Number: 1}, nil
+}
+
+// The background warmer keeps a board's cache refreshed on its own while the
+// board has watchers (open tabs) or was read within warmIdleFor — so no
+// interactive read ever pays the full cold load — and stops polling GitHub
+// once neither holds.
+func TestBoardCacheWarmerFollowsWatchers(t *testing.T) {
+	store := newBoardStore()
+	store.warmEvery = 10 * time.Millisecond
+	inner := &warmBackend{}
+	be := &storeBackend{inner: inner, store: store}
+
+	_, unsubscribe := store.subscribe(storeKey("acme", 1), "tab-1", nil, map[string]bool{"cards": true})
+
+	if _, err := be.LoadBoard(context.Background(), "acme", 1); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	base := inner.loads.Load()
+
+	// The warmer must refresh on its own, with no further requests.
+	deadline := time.Now().Add(2 * time.Second)
+	for inner.loads.Load() < base+2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := inner.loads.Load(); got < base+2 {
+		t.Fatalf("warmer never refreshed: loads = %d, want >= %d", got, base+2)
+	}
+
+	// Watchers gone but the board was just read: the warmer keeps going —
+	// this is the overnight window that makes the next morning's open warm.
+	unsubscribe()
+	base = inner.loads.Load()
+	deadline = time.Now().Add(2 * time.Second)
+	for inner.loads.Load() < base+2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := inner.loads.Load(); got < base+2 {
+		t.Fatalf("warmer must outlive the watchers within warmIdleFor: loads = %d, want >= %d", got, base+2)
+	}
+
+	// No watchers AND the last read has aged out: the warmer must wind down.
+	e := store.entry(storeKey("acme", 1))
+	e.mu.Lock()
+	e.lastRead = time.Now().Add(-warmIdleFor - time.Minute)
+	e.mu.Unlock()
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		warming := e.warming
+		e.mu.Unlock()
+		if !warming {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	settled := inner.loads.Load()
+	time.Sleep(60 * time.Millisecond)
+	if got := inner.loads.Load(); got != settled {
+		t.Fatalf("warmer kept polling an idle, watcher-less board: %d -> %d", settled, got)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,7 @@ func New(opts Options) (*Server, error) {
 	s.apiTokens = s.tokenForRequest
 	s.newService = s.defaultService
 	s.store = newBoardStore()
+	s.store.log = s.log
 	if opts.Auth != nil {
 		s.auth = newAuthManager(*opts.Auth, opts.Logger)
 	}

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -111,11 +111,10 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return
 			}
-			// Keep the shared cache warm while anyone is watching: a stale
-			// cache revalidates in the background (single-flight, stale-
-			// allowed), so user fetches land fresh — no progress bar — and
-			// external GitHub edits keep arriving as ordinary diff events.
-			go func() { _, _ = svc.Board(warmCtx, owner, project) }()
+			// Cache freshness is the store's warmer's job now (ensureWarm):
+			// one server-side reload loop per board, instead of every open
+			// tab kicking a stale revalidation — a near-continuous full
+			// GitHub reload on a multi-page board — from its ping ticker.
 		}
 	}
 }

--- a/pkg/boardservice/boardservicetest/fake.go
+++ b/pkg/boardservice/boardservicetest/fake.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/aenix-io/aeman/pkg/board"
 	"github.com/aenix-io/aeman/pkg/boardservice"
@@ -15,6 +16,10 @@ import (
 // Backend is an in-memory boardservice.Backend. It logs every call and mutates
 // its board so the service's views reflect the result of an action.
 type Backend struct {
+	// mu guards every field: the service resolves link titles on a background
+	// goroutine (resolveTitleAsync), so the fake is hit concurrently with the
+	// test's own requests and assertions.
+	mu      sync.Mutex
 	refs    map[string]board.Link
 	board   board.Board
 	log     []string
@@ -25,10 +30,16 @@ type Backend struct {
 // New builds a Backend seeded with cards and per-team sprint states.
 // Refs configures ResolveIssueRef answers, keyed by link URL (ignoring any
 // fragment). URLs absent from the map fail to resolve.
-func (f *Backend) SetRefs(refs map[string]board.Link) { f.refs = refs }
+func (f *Backend) SetRefs(refs map[string]board.Link) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refs = refs
+}
 
 // ResolveIssueRef satisfies boardservice.LinkResolver from the seeded refs.
 func (f *Backend) ResolveIssueRef(_ context.Context, link board.Link) (board.Link, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("ResolveIssueRef %s", link.URL)
 	resolved, ok := f.refs[link.URL]
 	if !ok {
@@ -44,10 +55,13 @@ func New(cards []board.Card, states map[string]board.SprintState) *Backend {
 	return &Backend{board: board.Board{ID: "B1", Number: 1, Owner: "acme", Cards: cards, SprintStates: states}}
 }
 
+// rec appends to the call log. Callers hold f.mu.
 func (f *Backend) rec(format string, a ...any) { f.log = append(f.log, fmt.Sprintf(format, a...)) }
 
 // Saw reports whether the call log contains an exact entry.
 func (f *Backend) Saw(s string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	for _, e := range f.log {
 		if e == s {
 			return true
@@ -58,6 +72,8 @@ func (f *Backend) Saw(s string) bool {
 
 // Count returns how many logged calls start with prefix.
 func (f *Backend) Count(prefix string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	n := 0
 	for _, e := range f.log {
 		if strings.HasPrefix(e, prefix) {
@@ -68,7 +84,16 @@ func (f *Backend) Count(prefix string) int {
 }
 
 // Card returns a pointer to the seeded card with the given item id, or nil.
+// Card returns a pointer INTO the fake's board: safe for assertions after the
+// exercised call settles, not for concurrent use while async work runs.
 func (f *Backend) Card(itemID string) *board.Card {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.card(itemID)
+}
+
+// card is the lock-free lookup the mutating methods use. Callers hold f.mu.
+func (f *Backend) card(itemID string) *board.Card {
 	for i := range f.board.Cards {
 		if f.board.Cards[i].ItemID == itemID {
 			return &f.board.Cards[i]
@@ -78,10 +103,16 @@ func (f *Backend) Card(itemID string) *board.Card {
 }
 
 // Creates returns the create inputs the service issued, in order.
-func (f *Backend) Creates() []board.CreateInput { return f.creates }
+func (f *Backend) Creates() []board.CreateInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]board.CreateInput(nil), f.creates...)
+}
 
 // LoadBoard returns a copy of the seeded board snapshot.
 func (f *Backend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("LoadBoard")
 	cards := make([]board.Card, len(f.board.Cards))
 	copy(cards, f.board.Cards)
@@ -94,6 +125,8 @@ func (f *Backend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, er
 
 // LoadCards returns the seeded cards matching ids, mirroring a partial reload.
 func (f *Backend) LoadCards(_ context.Context, _ board.Board, ids []string) ([]board.Card, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("LoadCards")
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
@@ -110,6 +143,8 @@ func (f *Backend) LoadCards(_ context.Context, _ board.Board, ids []string) ([]b
 
 // CreateCard appends a new card and records the create input.
 func (f *Backend) CreateCard(_ context.Context, _ board.Board, in board.CreateInput) (board.Card, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.nextID++
 	card := board.Card{
 		ItemID: fmt.Sprintf("new%d", f.nextID), Title: in.Title, IsDraft: true,
@@ -128,6 +163,8 @@ func (f *Backend) CreateCard(_ context.Context, _ board.Board, in board.CreateIn
 
 // DeleteCard removes a card from the board.
 func (f *Backend) DeleteCard(_ context.Context, _ board.Board, card board.Card) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("DeleteCard %s", card.ItemID)
 	out := f.board.Cards[:0]
 	for _, c := range f.board.Cards {
@@ -141,14 +178,18 @@ func (f *Backend) DeleteCard(_ context.Context, _ board.Board, card board.Card) 
 
 // MoveCard records a reorder (the in-memory order is left unchanged).
 func (f *Backend) MoveCard(_ context.Context, _ board.Board, card board.Card, afterID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("MoveCard %s after=%s", card.ItemID, afterID)
 	return nil
 }
 
 // AddNote records a note on a card.
 func (f *Backend) AppendEvent(_ context.Context, _ board.Board, card board.Card, e board.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("AppendEvent %s %s %s->%s", card.ItemID, e.Kind, e.From, e.To)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		f.nextID++
 		e.ID = fmt.Sprintf("ev%d", f.nextID)
 		c.Events = append(c.Events, e)
@@ -157,8 +198,10 @@ func (f *Backend) AppendEvent(_ context.Context, _ board.Board, card board.Card,
 }
 
 func (f *Backend) AddNote(ctx context.Context, _ board.Board, card board.Card, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("AddNote %s %s", card.ItemID, text)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		f.nextID++
 		c.Notes = append(c.Notes, board.Note{
 			ID:     fmt.Sprintf("note%d", f.nextID),
@@ -172,8 +215,10 @@ func (f *Backend) AddNote(ctx context.Context, _ board.Board, card board.Card, t
 
 // EditNote rewrites the note's body on the seeded card.
 func (f *Backend) EditNote(_ context.Context, _ board.Board, card board.Card, note board.Note, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("EditNote %s %s %s", card.ItemID, note.ID, text)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		for i := range c.Notes {
 			if c.Notes[i].ID == note.ID {
 				c.Notes[i].Body = text
@@ -185,8 +230,10 @@ func (f *Backend) EditNote(_ context.Context, _ board.Board, card board.Card, no
 
 // DeleteNote drops the note from the seeded card.
 func (f *Backend) DeleteNote(_ context.Context, _ board.Board, card board.Card, note board.Note) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("DeleteNote %s %s", card.ItemID, note.ID)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		out := c.Notes[:0]
 		for _, n := range c.Notes {
 			if n.ID != note.ID {
@@ -200,8 +247,10 @@ func (f *Backend) DeleteNote(_ context.Context, _ board.Board, card board.Card, 
 
 // SetDescription replaces the seeded card's description.
 func (f *Backend) SetDescription(_ context.Context, _ board.Board, card board.Card, description string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetDescription %s %s", card.ItemID, description)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Description = description
 	}
 	return nil
@@ -209,8 +258,10 @@ func (f *Backend) SetDescription(_ context.Context, _ board.Board, card board.Ca
 
 // RenameCard changes a card's title.
 func (f *Backend) RenameCard(_ context.Context, _ board.Board, card board.Card, title string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("RenameCard %s", card.ItemID)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Title = title
 	}
 	return nil
@@ -218,8 +269,10 @@ func (f *Backend) RenameCard(_ context.Context, _ board.Board, card board.Card, 
 
 // SetStage sets a card's stage.
 func (f *Backend) SetStage(_ context.Context, _ board.Board, card board.Card, stage board.StageKey) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetStage %s %s", card.ItemID, stage)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Stage = stage
 	}
 	return nil
@@ -227,8 +280,10 @@ func (f *Backend) SetStage(_ context.Context, _ board.Board, card board.Card, st
 
 // SetProgress sets a card's progress.
 func (f *Backend) SetProgress(_ context.Context, _ board.Board, card board.Card, progress int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetProgress %s %d", card.ItemID, progress)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Progress = progress
 	}
 	return nil
@@ -236,8 +291,10 @@ func (f *Backend) SetProgress(_ context.Context, _ board.Board, card board.Card,
 
 // SetZone sets a card's zone.
 func (f *Backend) SetZone(_ context.Context, _ board.Board, card board.Card, zone board.ZoneKey) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetZone %s %s", card.ItemID, zone)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Zone = zone
 	}
 	return nil
@@ -245,8 +302,10 @@ func (f *Backend) SetZone(_ context.Context, _ board.Board, card board.Card, zon
 
 // SetDay records a day change.
 func (f *Backend) SetDay(_ context.Context, _ board.Board, card board.Card, day string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetDay %s %s", card.ItemID, day)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Day = day
 	}
 	return nil
@@ -254,8 +313,10 @@ func (f *Backend) SetDay(_ context.Context, _ board.Board, card board.Card, day 
 
 // SetStart sets a card's start date.
 func (f *Backend) SetStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetStart %s %s", card.ItemID, date)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.StartDate = date
 	}
 	return nil
@@ -263,8 +324,10 @@ func (f *Backend) SetStart(_ context.Context, _ board.Board, card board.Card, da
 
 // SetSprintStart sets a card's sprint-start date.
 func (f *Backend) SetSprintStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetSprintStart %s %s", card.ItemID, date)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.SprintStart = date
 	}
 	return nil
@@ -272,8 +335,10 @@ func (f *Backend) SetSprintStart(_ context.Context, _ board.Board, card board.Ca
 
 // SetPlan sets a card's weekly-plan band.
 func (f *Backend) SetPlan(_ context.Context, _ board.Board, card board.Card, plan board.PlanBand) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetPlan %s %s", card.ItemID, plan)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Plan = plan
 	}
 	return nil
@@ -281,8 +346,10 @@ func (f *Backend) SetPlan(_ context.Context, _ board.Board, card board.Card, pla
 
 // SetWeek sets a card's plan week.
 func (f *Backend) SetWeek(_ context.Context, _ board.Board, card board.Card, week string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetWeek %s %s", card.ItemID, week)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Week = week
 	}
 	return nil
@@ -290,8 +357,10 @@ func (f *Backend) SetWeek(_ context.Context, _ board.Board, card board.Card, wee
 
 // SetTeam sets a card's team.
 func (f *Backend) SetTeam(_ context.Context, _ board.Board, card board.Card, team string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetTeam %s %s", card.ItemID, team)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Team = team
 	}
 	return nil
@@ -299,8 +368,10 @@ func (f *Backend) SetTeam(_ context.Context, _ board.Board, card board.Card, tea
 
 // SetRecurrence sets a recurrent card's reseed cycle.
 func (f *Backend) SetRecurrence(_ context.Context, _ board.Board, card board.Card, cycle string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetRecurrence %s %s", card.ItemID, cycle)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Recurrence = cycle
 	}
 	return nil
@@ -308,8 +379,10 @@ func (f *Backend) SetRecurrence(_ context.Context, _ board.Board, card board.Car
 
 // SetAssignee replaces a card's assignee.
 func (f *Backend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetAssignee %s %s", card.ItemID, login)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		if login == "" {
 			c.Assignees = []string{}
 		} else {
@@ -321,8 +394,10 @@ func (f *Backend) SetAssignee(_ context.Context, _ board.Board, card board.Card,
 
 // SetParent sets a card's parent link.
 func (f *Backend) SetParent(_ context.Context, _ board.Board, card board.Card, parent string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetParent %s %s", card.ItemID, parent)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.Parent = parent
 	}
 	return nil
@@ -330,8 +405,10 @@ func (f *Backend) SetParent(_ context.Context, _ board.Board, card board.Card, p
 
 // SetReviewOf sets a card's review-of link.
 func (f *Backend) SetReviewOf(_ context.Context, _ board.Board, card board.Card, reviewOf string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetReviewOf %s %s", card.ItemID, reviewOf)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.ReviewOf = reviewOf
 	}
 	return nil
@@ -339,8 +416,10 @@ func (f *Backend) SetReviewOf(_ context.Context, _ board.Board, card board.Card,
 
 // SetReviewRound records a review card's round counter.
 func (f *Backend) SetReviewRound(_ context.Context, _ board.Board, card board.Card, round int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetReviewRound %s %d", card.ItemID, round)
-	if c := f.Card(card.ItemID); c != nil {
+	if c := f.card(card.ItemID); c != nil {
 		c.ReviewRound = round
 	}
 	return nil
@@ -348,6 +427,8 @@ func (f *Backend) SetReviewRound(_ context.Context, _ board.Board, card board.Ca
 
 // SetSprintState creates or updates a team's sprint pointer.
 func (f *Backend) SetSprintState(_ context.Context, _ board.Board, team, current, previous string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetSprintState %s cur=%s prev=%s", team, current, previous)
 	st := f.board.SprintStates[team]
 	st.Current = current

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +21,10 @@ var _ Backend = (*ghprojects.Client)(nil)
 // fakeBackend implements Backend over an in-memory board, logging every call and
 // mutating its board so the service's views reflect the result.
 type fakeBackend struct {
+	// mu guards every field: the service runs background goroutines (the
+	// async title resolve, carry-over sprint writes), so the fake is hit
+	// concurrently with the test's assertions.
+	mu      sync.Mutex
 	refs    map[string]board.Link
 	b       board.Board
 	log     []string
@@ -37,6 +42,8 @@ func newFake(cards []board.Card, states map[string]board.SprintState) *fakeBacke
 func (f *fakeBackend) rec(format string, a ...any) { f.log = append(f.log, fmt.Sprintf(format, a...)) }
 
 func (f *fakeBackend) saw(s string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	for _, e := range f.log {
 		if e == s {
 			return true
@@ -46,6 +53,8 @@ func (f *fakeBackend) saw(s string) bool {
 }
 
 func (f *fakeBackend) count(prefix string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	n := 0
 	for _, e := range f.log {
 		if strings.HasPrefix(e, prefix) {
@@ -65,6 +74,8 @@ func (f *fakeBackend) get(itemID string) *board.Card {
 }
 
 func (f *fakeBackend) ResolveIssueRef(_ context.Context, link board.Link) (board.Link, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("ResolveIssueRef %s", link.URL)
 	resolved, ok := f.refs[link.URL]
 	if !ok {
@@ -74,6 +85,8 @@ func (f *fakeBackend) ResolveIssueRef(_ context.Context, link board.Link) (board
 }
 
 func (f *fakeBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("LoadBoard")
 	cards := make([]board.Card, len(f.b.Cards))
 	copy(cards, f.b.Cards)
@@ -85,6 +98,8 @@ func (f *fakeBackend) LoadBoard(_ context.Context, _ string, _ int) (board.Board
 }
 
 func (f *fakeBackend) LoadCards(_ context.Context, _ board.Board, ids []string) ([]board.Card, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("LoadCards")
 	want := make(map[string]bool, len(ids))
 	for _, id := range ids {
@@ -100,6 +115,8 @@ func (f *fakeBackend) LoadCards(_ context.Context, _ board.Board, ids []string) 
 }
 
 func (f *fakeBackend) CreateCard(_ context.Context, _ board.Board, in board.CreateInput) (board.Card, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.nextID++
 	card := board.Card{
 		ItemID: fmt.Sprintf("new%d", f.nextID), Title: in.Title, IsDraft: true,
@@ -117,6 +134,8 @@ func (f *fakeBackend) CreateCard(_ context.Context, _ board.Board, in board.Crea
 }
 
 func (f *fakeBackend) DeleteCard(_ context.Context, _ board.Board, card board.Card) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("DeleteCard %s", card.ItemID)
 	out := f.b.Cards[:0]
 	for _, c := range f.b.Cards {
@@ -129,11 +148,15 @@ func (f *fakeBackend) DeleteCard(_ context.Context, _ board.Board, card board.Ca
 }
 
 func (f *fakeBackend) MoveCard(_ context.Context, _ board.Board, card board.Card, afterID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("MoveCard %s after=%s", card.ItemID, afterID)
 	return nil
 }
 
 func (f *fakeBackend) AppendEvent(_ context.Context, _ board.Board, card board.Card, e board.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("AppendEvent %s %s %s->%s", card.ItemID, e.Kind, e.From, e.To)
 	if c := f.get(card.ItemID); c != nil {
 		c.Events = append(c.Events, e)
@@ -142,26 +165,36 @@ func (f *fakeBackend) AppendEvent(_ context.Context, _ board.Board, card board.C
 }
 
 func (f *fakeBackend) AddNote(_ context.Context, _ board.Board, card board.Card, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("AddNote %s %s", card.ItemID, text)
 	return nil
 }
 
 func (f *fakeBackend) EditNote(_ context.Context, _ board.Board, card board.Card, note board.Note, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("EditNote %s %s %s", card.ItemID, note.ID, text)
 	return nil
 }
 
 func (f *fakeBackend) DeleteNote(_ context.Context, _ board.Board, card board.Card, note board.Note) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("DeleteNote %s %s", card.ItemID, note.ID)
 	return nil
 }
 
 func (f *fakeBackend) SetDescription(_ context.Context, _ board.Board, card board.Card, description string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetDescription %s %s", card.ItemID, description)
 	return nil
 }
 
 func (f *fakeBackend) RenameCard(_ context.Context, _ board.Board, card board.Card, title string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("RenameCard %s", card.ItemID)
 	if c := f.get(card.ItemID); c != nil {
 		c.Title = title
@@ -170,6 +203,8 @@ func (f *fakeBackend) RenameCard(_ context.Context, _ board.Board, card board.Ca
 }
 
 func (f *fakeBackend) SetStage(_ context.Context, _ board.Board, card board.Card, stage board.StageKey) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetStage %s %s", card.ItemID, stage)
 	if c := f.get(card.ItemID); c != nil {
 		c.Stage = stage
@@ -178,6 +213,8 @@ func (f *fakeBackend) SetStage(_ context.Context, _ board.Board, card board.Card
 }
 
 func (f *fakeBackend) SetProgress(_ context.Context, _ board.Board, card board.Card, progress int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetProgress %s %d", card.ItemID, progress)
 	if c := f.get(card.ItemID); c != nil {
 		c.Progress = progress
@@ -186,6 +223,8 @@ func (f *fakeBackend) SetProgress(_ context.Context, _ board.Board, card board.C
 }
 
 func (f *fakeBackend) SetZone(_ context.Context, _ board.Board, card board.Card, zone board.ZoneKey) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetZone %s %s", card.ItemID, zone)
 	if c := f.get(card.ItemID); c != nil {
 		c.Zone = zone
@@ -194,6 +233,8 @@ func (f *fakeBackend) SetZone(_ context.Context, _ board.Board, card board.Card,
 }
 
 func (f *fakeBackend) SetDay(_ context.Context, _ board.Board, card board.Card, day string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetDay %s %s", card.ItemID, day)
 	if c := f.get(card.ItemID); c != nil {
 		c.Day = day
@@ -202,6 +243,8 @@ func (f *fakeBackend) SetDay(_ context.Context, _ board.Board, card board.Card, 
 }
 
 func (f *fakeBackend) SetStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetStart %s %s", card.ItemID, date)
 	if c := f.get(card.ItemID); c != nil {
 		c.StartDate = date
@@ -210,6 +253,8 @@ func (f *fakeBackend) SetStart(_ context.Context, _ board.Board, card board.Card
 }
 
 func (f *fakeBackend) SetSprintStart(_ context.Context, _ board.Board, card board.Card, date string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetSprintStart %s %s", card.ItemID, date)
 	if c := f.get(card.ItemID); c != nil {
 		c.SprintStart = date
@@ -218,6 +263,8 @@ func (f *fakeBackend) SetSprintStart(_ context.Context, _ board.Board, card boar
 }
 
 func (f *fakeBackend) SetPlan(_ context.Context, _ board.Board, card board.Card, plan board.PlanBand) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetPlan %s %s", card.ItemID, plan)
 	if c := f.get(card.ItemID); c != nil {
 		c.Plan = plan
@@ -226,6 +273,8 @@ func (f *fakeBackend) SetPlan(_ context.Context, _ board.Board, card board.Card,
 }
 
 func (f *fakeBackend) SetWeek(_ context.Context, _ board.Board, card board.Card, week string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetWeek %s %s", card.ItemID, week)
 	if c := f.get(card.ItemID); c != nil {
 		c.Week = week
@@ -234,6 +283,8 @@ func (f *fakeBackend) SetWeek(_ context.Context, _ board.Board, card board.Card,
 }
 
 func (f *fakeBackend) SetTeam(_ context.Context, _ board.Board, card board.Card, team string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetTeam %s %s", card.ItemID, team)
 	if c := f.get(card.ItemID); c != nil {
 		c.Team = team
@@ -242,6 +293,8 @@ func (f *fakeBackend) SetTeam(_ context.Context, _ board.Board, card board.Card,
 }
 
 func (f *fakeBackend) SetRecurrence(_ context.Context, _ board.Board, card board.Card, cycle string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetRecurrence %s %s", card.ItemID, cycle)
 	if c := f.get(card.ItemID); c != nil {
 		c.Recurrence = cycle
@@ -250,6 +303,8 @@ func (f *fakeBackend) SetRecurrence(_ context.Context, _ board.Board, card board
 }
 
 func (f *fakeBackend) SetAssignee(_ context.Context, _ board.Board, card board.Card, login string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetAssignee %s %s", card.ItemID, login)
 	if c := f.get(card.ItemID); c != nil {
 		if login == "" {
@@ -262,6 +317,8 @@ func (f *fakeBackend) SetAssignee(_ context.Context, _ board.Board, card board.C
 }
 
 func (f *fakeBackend) SetParent(_ context.Context, _ board.Board, card board.Card, parent string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetParent %s %s", card.ItemID, parent)
 	if c := f.get(card.ItemID); c != nil {
 		c.Parent = parent
@@ -270,6 +327,8 @@ func (f *fakeBackend) SetParent(_ context.Context, _ board.Board, card board.Car
 }
 
 func (f *fakeBackend) SetReviewOf(_ context.Context, _ board.Board, card board.Card, reviewOf string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetReviewOf %s %s", card.ItemID, reviewOf)
 	if c := f.get(card.ItemID); c != nil {
 		c.ReviewOf = reviewOf
@@ -278,6 +337,8 @@ func (f *fakeBackend) SetReviewOf(_ context.Context, _ board.Board, card board.C
 }
 
 func (f *fakeBackend) SetReviewRound(_ context.Context, _ board.Board, card board.Card, round int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetReviewRound %s %d", card.ItemID, round)
 	if c := f.get(card.ItemID); c != nil {
 		c.ReviewRound = round
@@ -286,6 +347,8 @@ func (f *fakeBackend) SetReviewRound(_ context.Context, _ board.Board, card boar
 }
 
 func (f *fakeBackend) SetSprintState(_ context.Context, _ board.Board, team, current, previous string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.rec("SetSprintState %s cur=%s prev=%s", team, current, previous)
 	st := f.b.SprintStates[team]
 	st.Current = current

--- a/pkg/ghprojects/probe.go
+++ b/pkg/ghprojects/probe.go
@@ -1,0 +1,57 @@
+package ghprojects
+
+import (
+	"context"
+	"fmt"
+)
+
+// The access probe fetches nothing but the project's node id — the cheapest
+// possible question GitHub can answer about a board (~0.5s), against the ~2s
+// per 100-card page a full load pays a dozen times over. It exists for the
+// board store: proving that a signed-in user's token can read an
+// already-cached board must not cost that user a full multi-page reload.
+const orgProbeQuery = `query($owner: String!, $number: Int!) {
+  organization(login: $owner) { projectV2(number: $number) { id } }
+}`
+
+const userProbeQuery = `query($owner: String!, $number: Int!) {
+  user(login: $owner) { projectV2(number: $number) { id } }
+}`
+
+// CheckBoardAccess reports whether the client's token can read the project:
+// nil when GitHub resolves it, ErrBoardNotFound when the project does not
+// exist or the token cannot see it (GitHub does not distinguish the two), and
+// the upstream error otherwise (rate limit, network, auth), mirroring
+// loadProject's org-then-user resolution.
+func (c *Client) CheckBoardAccess(ctx context.Context, owner string, number int) error {
+	vars := map[string]any{"owner": owner, "number": number}
+
+	var orgData projectResult
+	orgErr := c.graphql(ctx, orgProbeQuery, vars, &orgData)
+	if orgData.Organization != nil {
+		if orgData.Organization.ProjectV2 != nil {
+			return nil
+		}
+		return fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
+	}
+
+	var userData projectResult
+	userErr := c.graphql(ctx, userProbeQuery, vars, &userData)
+	if userData.User != nil {
+		if userData.User.ProjectV2 != nil {
+			return nil
+		}
+		return fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
+	}
+
+	if isNotFoundErr(orgErr) || isNotFoundErr(userErr) {
+		return fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
+	}
+	if userErr != nil {
+		return userErr
+	}
+	if orgErr != nil {
+		return orgErr
+	}
+	return fmt.Errorf("%w: project #%d for %q", ErrBoardNotFound, number, owner)
+}

--- a/pkg/ghprojects/probe_test.go
+++ b/pkg/ghprojects/probe_test.go
@@ -1,0 +1,101 @@
+package ghprojects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type probeResp struct {
+	code int
+	body string
+}
+
+// verdictOf collapses an access decision to what the board store acts on:
+// admit (nil), a positive not-found/no-access, or some other upstream error.
+func verdictOf(err error) string {
+	switch {
+	case err == nil:
+		return "ADMIT"
+	case errors.Is(err, ErrBoardNotFound):
+		return "DENY(not-found)"
+	default:
+		return "DENY(err)"
+	}
+}
+
+func fixtureServer(t *testing.T, resps []probeResp) *httptest.Server {
+	t.Helper()
+	i := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		r := resps[min(i, len(resps)-1)]
+		i++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(r.code)
+		fmt.Fprint(w, r.body)
+	}))
+}
+
+// CheckBoardAccess is the cheap stand-in for the full board load in the cache
+// authorization gate, so its verdict must never be MORE permissive than the
+// load's: a token the full load would reject must be rejected by the probe on
+// the same fixtures. This table runs identical GitHub responses through both
+// paths and requires the verdicts to match — the lockstep this test pins is
+// the entire security argument for admitting users by probe.
+func TestCheckBoardAccessMatchesFullLoad(t *testing.T) {
+	cases := []struct {
+		name  string
+		resps []probeResp
+		want  string
+	}{
+		{"org resolves, project present (authorized)", []probeResp{
+			{200, `{"data":{"organization":{"projectV2":{"id":"PVT_1"}}}}`}}, "ADMIT"},
+		{"org resolves, projectV2 null + NOT_FOUND (no access or missing)", []probeResp{
+			{200, `{"data":{"organization":{"projectV2":null}},"errors":[{"type":"NOT_FOUND","message":"Could not resolve to a ProjectV2"}]}`}}, "DENY(not-found)"},
+		{"org null, user resolves with project (user-owned board)", []probeResp{
+			{200, `{"data":{"organization":null},"errors":[{"type":"NOT_FOUND","message":"no org"}]}`},
+			{200, `{"data":{"user":{"projectV2":{"id":"PVT_2"}}}}`}}, "ADMIT"},
+		{"RATE_LIMITED on both", []probeResp{
+			{200, `{"data":null,"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded"}]}`}}, "DENY(err)"},
+		{"HTTP 401 revoked token", []probeResp{
+			{401, `{"message":"Bad credentials"}`}}, "DENY(err)"},
+		{"HTTP 403 SAML or secondary rate limit", []probeResp{
+			{403, `{"message":"Resource protected by organization SAML enforcement"}`}}, "DENY(err)"},
+		{"INSUFFICIENT_SCOPES (token lacks read:project)", []probeResp{
+			{200, `{"data":{"organization":null},"errors":[{"type":"INSUFFICIENT_SCOPES","message":"requires read:project"}]}`},
+			{200, `{"data":{"user":null},"errors":[{"type":"INSUFFICIENT_SCOPES","message":"requires read:project"}]}`}}, "DENY(err)"},
+		{"partial answer: project id present, FORBIDDEN alongside", []probeResp{
+			{200, `{"data":{"organization":{"projectV2":{"id":"PVT_3"}}},"errors":[{"type":"FORBIDDEN","message":"partially forbidden"}]}`}}, "ADMIT"},
+		{"empty 200 data", []probeResp{
+			{200, `{"data":{}}`}}, "DENY(not-found)"},
+		{"HTTP 502 upstream", []probeResp{
+			{502, `bad gateway`}}, "DENY(err)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probeSrv := fixtureServer(t, tc.resps)
+			defer probeSrv.Close()
+			probeErr := New("tok", WithEndpoint(probeSrv.URL)).
+				CheckBoardAccess(context.Background(), "acme", 1)
+
+			loadSrv := fixtureServer(t, tc.resps)
+			defer loadSrv.Close()
+			_, loadErr := New("tok", WithEndpoint(loadSrv.URL)).
+				LoadProjectBoard(context.Background(), "acme", 1)
+
+			probeV, loadV := verdictOf(probeErr), verdictOf(loadErr)
+			if probeV != tc.want {
+				t.Fatalf("probe verdict = %s (%v), want %s", probeV, probeErr, tc.want)
+			}
+			if probeV != loadV {
+				t.Fatalf("probe and full load disagree: probe=%s load=%s (%v / %v)", probeV, loadV, probeErr, loadErr)
+			}
+			if probeErr == nil && loadErr != nil {
+				t.Fatalf("HOLE: probe admits where the full load denies (%v)", loadErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Opening aeman after any break longer than ten minutes hung on a 20-30s progress bar. Measured on the production-size board (~1400 cards): a full load is ~15 sequential GraphQL pages at ~2s each — sequential because GitHub's cursor pagination cannot be parallelized — so ~28s wall-clock. Two designs made that load far more frequent than it had to be:

- The shared board cache is (correctly) gated per login, but the only way a login could prove access was a **full token-scoped board load**. Every engineer coming back from a break personally re-paid ~28s to be admitted into a cache their teammates kept warm.
- Overnight, with every laptop asleep, no watch connection survived to keep the cache alive — the first open of the morning always started cold. During the day, the opposite: every open tab kicked a stale revalidation from its 30s ping ticker, a near-continuous full reload.

## Change

**Probe-based admission.** Proving that a token can read the board costs one project-id GraphQL query (~0.5s), not a full load. A login reaching a warm cache is admitted by that probe; an aging proof refreshes the same way in the background while the read is served fresh. The full load remains the authorization path wherever the probe is unavailable or fails, and a probe that positively reports access gone drops the proof. A parity test runs identical GitHub fixtures (not-found, partial errors, rate-limit, 401/403, insufficient scopes, 502) through both the probe and the full load and pins their verdicts together — the probe is exactly as strict as the load it stands in for.

**Off-request warmer.** One server-side loop per board refreshes the cache on the cadence of the fresh window while the board has watchers, and on a slower idle cadence for 16h past the last read — carrying the cache through the night, so the morning's first open is served instantly. It replaces the per-tab ping revalidation entirely. The warmer's identity rotates to the most recent successful loader and is bound to that user's web session: it stops on logout or session expiry, never runs on MCP-request tokens (nothing to bind their lifetime to), tolerates transient upstream failures by skipping a tick, and stops with a log line on persistent failure or access loss. Warm refreshes never vouch for anyone's access.

Mutations benefit directly: with the warmer keeping the cache inside the fresh window, reads and mutations land on the cached board instead of blocking on a reload.

## Review

The change went through three independent adversarial reviews (concurrency/lifecycle, cache-authorization security, perf/operations). The security review verified empirically that the probe admits no one the full load would reject, and found no bypass of the per-login cache gate. All blockers and majors they raised are addressed in the second commit; the notable ones: mutations re-paying full loads (fresh window now matches the warmer cadence), the warmer dying overnight on a single 502 (bounded retries), a captured OAuth token outliving its owner's session (session-bound, rotating source), and an unauthorized caller being able to extend the warm window (reads stamp it only when actually served).

## Numbers

On the ~1400-card board: first open after a break drops from ~28s to milliseconds (probe ~0.5s when a re-proof is needed); the only remaining cold load is the very first request after a server restart. Steady-state GitHub traffic drops from roughly one full reload per active tab per minute to one per board per 3 minutes (8 minutes when nobody is watching).

## Known trade-offs

- External GitHub edits (made outside aeman) surface within one warmer tick (~3 min worst case, was ~30-60s via per-tab revalidations) for passive viewers; active users' own reads still trigger revalidation as before.
- A user whose token can read the project but not some linked private issues gets the shared cache's fuller view (titles instead of "(untitled)" placeholders). Not new — the pre-probe flow had the same property one full load later — but worth stating: the gate proves "can read this board", not "sees exactly what their own token would fetch".
- The post-deploy cold start is not addressed here; a follow-up could warm the pinned board at boot from a persisted session token.

## Testing

- `TestBoardCacheProbeAdmitsSecondUser`, `TestBoardCacheProbeDeniedFallsThrough` — probe admits exactly one cheap check, denial falls through to the caller's own load.
- `TestCachedAuthz` — the full state matrix including the new re-proof flag.
- `TestBoardCacheWarmerFollowsWatchers` — refreshes on its own, outlives watchers within the idle window, stops when both conditions lapse.
- `TestCheckBoardAccessMatchesFullLoad` — 10-fixture probe/load parity table.
- Shared test fakes made goroutine-safe (the async title resolve and the warmer hit them from background goroutines); everything runs and passes under `-race`.
- Verified live against the production-size board: cold prime once, then instant reads across warmer ticks.