### PR TITLE
docs(mcp): explain that a future start parks a card off the board

### DIFF
--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -2451,3 +2451,52 @@ func TestDeleteTeamGuardsAndDeletes(t *testing.T) {
 		t.Fatalf("pointer-less team must be a no-op success, got %v", err)
 	}
 }
+
+// Scheduling a card into the future parks it off the board until that day.
+// No sprint exists for a future day yet — sprints are daily and created as
+// they start — so the card keeps the team's current sprint in its dates and a
+// carry-over adopts it when the day arrives. Reported as issue #82: the
+// dates look wrong, but the card must simply be absent from the current
+// sprint's board until its day.
+func TestSetDatesFutureDayKeepsCurrentSprintAndLeavesTheBoard(t *testing.T) {
+	today := board.TodayIso()
+	current := board.AddDays(today, -2) // the sprint in progress, opened earlier
+	future := board.AddDays(today, 26)
+	fake := newFake([]board.Card{
+		{ItemID: "c1", Team: "alpha", StartDate: today, Day: today, SprintStart: current, Assignees: []string{"ann"}},
+	}, map[string]board.SprintState{"alpha": {Current: current, ItemID: "s1"}})
+	svc := New(fake)
+
+	if err := svc.SetDates(context.Background(), "acme", 1, "c1", future, future); err != nil {
+		t.Fatal(err)
+	}
+	got := fake.get("c1")
+	if got.StartDate != future {
+		t.Fatalf("start = %q, want %q", got.StartDate, future)
+	}
+	if got.SprintStart != current {
+		t.Fatalf("sprint = %q, want the team's current sprint %q: no future sprint exists yet",
+			got.SprintStart, current)
+	}
+
+	// The point of the dates: the card is gone from the sprint in progress —
+	// on its own day and on today — and returns on the day it was scheduled for.
+	b, err := svc.Board(context.Background(), "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, day := range []string{current, today} {
+		if got := board.TeamGrid(b, "alpha", day); len(got) != 0 {
+			t.Fatalf("a future-dated card must leave the board on %s, got %+v", day, got)
+		}
+		if got := board.MeView(b, "ann", day); len(got) != 0 {
+			t.Fatalf("a future-dated card must leave the Me board on %s, got %+v", day, got)
+		}
+	}
+	if got := board.TeamGrid(b, "alpha", future); len(got) != 1 {
+		t.Fatalf("the card must show on its scheduled day, got %+v", got)
+	}
+	if got := board.MeView(b, "ann", future); len(got) != 1 {
+		t.Fatalf("the card must show on its scheduled day in Me, got %+v", got)
+	}
+}

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -167,7 +167,7 @@ type createCardInput struct {
 	Team     string `json:"team,omitempty" jsonschema:"team the card joins; empty is the no-team group. MUST be one of the board's EXISTING team keys — read them from get_board metadata.teams and map the user's wording onto an existing key, across languages and case ('маркетинг', 'the marketing team' -> existing 'marketing'). A value not in that list silently CREATES a new team with its own sprint pointer — a heavyweight, unusual action: only pass a new key when the user explicitly asks to create a new team"`
 	Zone     string `json:"zone,omitempty" jsonschema:"semantic zone: urgent, unplanned, planned or niceToHave"`
 	Assignee string `json:"assignee,omitempty" jsonschema:"GitHub login to assign"`
-	Start    string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd; defaults to end, else today"`
+	Start    string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd; defaults to end, else today. A FUTURE day parks the card off the board until that day arrives — it is not shown in the current sprint meanwhile. Sprints are daily and created as they start, so no sprint exists for a future day yet: the card keeps the team's current sprint in its dates until a carry-over adopts it on the day. That is the intended way to schedule work ahead; do not try to correct the sprint field"`
 	End      string `json:"end,omitempty" jsonschema:"end/due day as yyyy-mm-dd; defaults to start, else today"`
 	Sprint   string `json:"sprint,omitempty" jsonschema:"sprint start day the card joins; defaults to the team's current sprint"`
 	Plan     string `json:"plan,omitempty" jsonschema:"weekly-plan band, wed or fri: creates a plan card with no dates instead of a day card"`
@@ -219,7 +219,7 @@ type updateCardInput struct {
 	Progress    *int    `json:"progress,omitempty" jsonschema:"readiness percentage 0..100"`
 	Stage       *string `json:"stage,omitempty" jsonschema:"locked, review, recurrent or done; empty clears it"`
 	Recurrence  *string `json:"recurrence,omitempty" jsonschema:"reseed cycle of a recurrent card: empty = every sprint (default), week or month = reseeded by carry-over only once that interval has elapsed since the card's sprint"`
-	Start       *string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd, calendar semantics: the card rejoins the sprint active on it; empty clears the dates"`
+	Start       *string `json:"start,omitempty" jsonschema:"scheduled day as yyyy-mm-dd: the card joins the sprint active on that day. A FUTURE day parks it off the board until that day arrives (this is how you schedule work ahead, and how the +1 day / +1 week buttons work). Sprints are daily and created as they start, so no sprint exists for a future day yet: the card keeps the team's current sprint in its dates until a carry-over adopts it on the day — expected, not a mis-scheduled card, and setting sprint by hand would only drag it back onto the board. Empty clears the dates"`
 	End         *string `json:"end,omitempty" jsonschema:"end/due day as yyyy-mm-dd; empty clears it"`
 	Sprint      *string `json:"sprint,omitempty" jsonschema:"sprint start day the card belongs to; empty clears it"`
 	PlanBand    *string `json:"planBand,omitempty" jsonschema:"weekly-plan band, wed or fri; empty clears it"`


### PR DESCRIPTION
## Problem

Reported in #82: an agent scheduling work weeks ahead saw the card keep the team's current sprint in its `dates` and read that as a failed reschedule.

It is not. Sprints are daily and created as they start, so no sprint exists for a future day yet — `ActiveSprint("2026-09-01")` returns the current sprint because it is the only one covering that day. The card leaves the board until its day and a carry-over adopts it then, which is exactly what the +1 day / +1 week buttons do.

The old wording — *"the card rejoins the sprint active on it"* — was technically accurate and practically misleading. Worse, the natural next step it invites (setting `sprint` by hand to "correct" it) would drag the card back onto today's board and defeat the schedule.

## Change

`create_card` and `update_card` now describe what the caller actually gets: a future `start` parks the card off the board until that day, the sprint field legitimately stays on the team's current sprint until a carry-over adopts it, and setting `sprint` by hand is called out as counterproductive.

Docs only — no behaviour change. The rendering symptom also reported in #82 (a future-dated card showing on the team's current-sprint day) was a separate bug, fixed in #80 and released in v0.11.2.

## Testing

`TestSetDatesFutureDayKeepsCurrentSprintAndLeavesTheBoard` pins the behaviour the docs now promise: the dates land as described **and** the card is absent from both the team grid and the Me board until its scheduled day. Full suites pass under `-race`; golangci-lint clean.