### PR TITLE
fix(links): keep markdown emphasis out of a link's URL

### DIFF
--- a/pkg/board/links.go
+++ b/pkg/board/links.go
@@ -41,6 +41,14 @@ func (l Link) FallbackTitle() string {
 
 var urlPattern = regexp.MustCompile(`https?://[^\s<>"'\)\]]+`)
 
+// urlTrailing is the punctuation stripped off a matched URL's tail. Beyond
+// sentence punctuation it covers markdown emphasis, because descriptions are
+// written in markdown and a bolded link — **https://…/pull/1360** — otherwise
+// keeps the asterisks and stops being recognised as a GitHub reference: it
+// degrades to a plain link with no title, no state, no dedupe against the
+// same item written as a shorthand. Matches GFM's autolink rule.
+const urlTrailing = ".,;:!?*_~`"
+
 // shorthandPattern is the GitHub cross-reference shorthand: owner/repo#123.
 // Boundaries are validated separately (shorthandBounded) — RE2 has no
 // lookbehind, and "a/b/c#1" or a URL tail must not produce a phantom ref.
@@ -59,7 +67,7 @@ func ExtractLinks(description string) []Link {
 	var matches []match
 	urlSpans := urlPattern.FindAllStringIndex(description, -1)
 	for _, sp := range urlSpans {
-		raw := strings.TrimRight(description[sp[0]:sp[1]], ".,;:!?")
+		raw := strings.TrimRight(description[sp[0]:sp[1]], urlTrailing)
 		matches = append(matches, match{sp[0], classifyLink(raw)})
 	}
 	inURL := func(i int) bool {

--- a/pkg/board/links_test.go
+++ b/pkg/board/links_test.go
@@ -109,3 +109,50 @@ func TestParseGitHubRefShorthand(t *testing.T) {
 		t.Fatal("plain text must not parse")
 	}
 }
+
+// Descriptions are markdown, so a link is often written bolded or italic.
+// The emphasis markers must not become part of the URL: a **-wrapped PR link
+// used to degrade into a plain link — no title, no state, no dedupe against
+// the same item written as a shorthand. Reported on a real card carrying
+// "- Backend: **https://github.com/acme/repo/pull/1360** (`branch`)".
+func TestExtractLinksStripsMarkdownEmphasis(t *testing.T) {
+	desc := "- Backend: **https://github.com/acme/repo/pull/1360** (`fix/x`).\n" +
+		"- UI: **https://github.com/acme/repo-ui/pull/432** done.\n" +
+		"- italic _https://github.com/acme/repo/issues/7_ and ~~https://github.com/acme/repo/pull/8~~\n"
+	got := ExtractLinks(desc)
+	want := []Link{
+		{URL: "https://github.com/acme/repo/pull/1360", Kind: "pull", Owner: "acme", Repo: "repo", Number: 1360},
+		{URL: "https://github.com/acme/repo-ui/pull/432", Kind: "pull", Owner: "acme", Repo: "repo-ui", Number: 432},
+		{URL: "https://github.com/acme/repo/issues/7", Kind: "issue", Owner: "acme", Repo: "repo", Number: 7},
+		{URL: "https://github.com/acme/repo/pull/8", Kind: "pull", Owner: "acme", Repo: "repo", Number: 8},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d links, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].URL != w.URL || got[i].Kind != w.Kind || got[i].Number != w.Number {
+			t.Fatalf("link %d = %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+// A bolded URL and the same item as a shorthand are one link, not two: the
+// dedupe key only matches once the asterisks are off the URL.
+func TestExtractLinksDedupesEmphasisedURLAgainstShorthand(t *testing.T) {
+	got := ExtractLinks("**https://github.com/acme/repo/pull/12** — see acme/repo#12")
+	if len(got) != 1 {
+		t.Fatalf("got %d links, want 1: %+v", len(got), got)
+	}
+	if got[0].URL != "https://github.com/acme/repo/pull/12" || got[0].Kind != "pull" {
+		t.Fatalf("link = %+v", got[0])
+	}
+}
+
+// Trailing characters that are legitimately part of a path stay put — only a
+// URL's tail is trimmed, and only of emphasis/sentence punctuation.
+func TestExtractLinksKeepsInnerPunctuation(t *testing.T) {
+	got := ExtractLinks("https://example.com/a_b/c~d/e*f?q=1&x=2")
+	if len(got) != 1 || got[0].URL != "https://example.com/a_b/c~d/e*f?q=1&x=2" {
+		t.Fatalf("inner punctuation must survive, got %+v", got)
+	}
+}

--- a/web/src/links.test.ts
+++ b/web/src/links.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { optimisticTitle } from "./links";
+import { extractLinks, optimisticTitle } from "./links";
 
 // The card must never sit on screen showing a raw URL: a bare GitHub
 // reference reads as the same "Pull: owner/repo#N" label the server falls
@@ -32,5 +32,31 @@ describe("optimisticTitle", () => {
     ]) {
       expect(optimisticTitle(title)).toBe(title);
     }
+  });
+});
+
+// The client mirrors the server's extraction (pkg/board/links.go): markdown
+// emphasis around a link must not end up inside the URL, or the links menu
+// shows a bare unresolved link instead of the PR.
+describe("extractLinks trailing markdown", () => {
+  it("strips ** around a PR link", () => {
+    const got = extractLinks("- Backend: **https://github.com/acme/repo/pull/1360** (`fix/x`).");
+    expect(got).toHaveLength(1);
+    expect(got[0].url).toBe("https://github.com/acme/repo/pull/1360");
+    expect(got[0].kind).toBe("pull");
+    expect(got[0].number).toBe(1360);
+  });
+
+  it("strips _ and ~ emphasis too", () => {
+    const got = extractLinks("_https://github.com/acme/repo/issues/7_ ~~https://github.com/acme/repo/pull/8~~");
+    expect(got.map((l) => l.url)).toEqual([
+      "https://github.com/acme/repo/issues/7",
+      "https://github.com/acme/repo/pull/8",
+    ]);
+  });
+
+  it("keeps punctuation that is part of the path", () => {
+    const got = extractLinks("https://example.com/a_b/c~d/e*f?q=1");
+    expect(got[0].url).toBe("https://example.com/a_b/c~d/e*f?q=1");
   });
 });

--- a/web/src/links.ts
+++ b/web/src/links.ts
@@ -18,6 +18,13 @@ export interface CardLink {
 
 const URL_PATTERN = /https?:\/\/[^\s<>"'\)\]]+/g;
 
+/** Punctuation stripped off a matched URL's tail. Beyond sentence
+ *  punctuation it covers markdown emphasis: descriptions are markdown, and a
+ *  bolded link — **https://…/pull/1360** — would otherwise keep the asterisks
+ *  and stop being recognised as a GitHub reference. Mirrors urlTrailing in
+ *  pkg/board/links.go (GFM's autolink rule). */
+const URL_TRAILING = /[.,;:!?*_~`]+$/;
+
 /** extractLinks finds every URL in a description, classifies GitHub issue/PR
  * links, dedupes, and orders GitHub references first, plain links after. */
 export function extractLinks(description: string): CardLink[] {
@@ -25,7 +32,7 @@ export function extractLinks(description: string): CardLink[] {
   const plain: CardLink[] = [];
   const seen = new Set<string>();
   for (const raw of description.match(URL_PATTERN) ?? []) {
-    const url = raw.replace(/[.,;:!?]+$/, "");
+    const url = raw.replace(URL_TRAILING, "");
     if (seen.has(url)) {
       continue;
     }


### PR DESCRIPTION
## Problem

Card descriptions are markdown, and links in them are routinely written bolded:

```
- Backend: **https://github.com/acme/repo/pull/1360** (`fix/account-incomplete-status`)
- UI: **https://github.com/acme/repo-ui/pull/432** (`fix/verification-queue-exclude-drafts`)
```

The trailing `**` ended up inside the URL, so `.../pull/1360**` no longer looked like a GitHub reference. Those links degraded to plain links — no title, no state, no dedupe against the same item written as an `owner/repo#N` shorthand — while an unadorned link right below them on the same card resolved fine.

Only sentence punctuation (`.,;:!?`) was being trimmed off a matched URL's tail.

## Change

Trim markdown emphasis as well (`*_~` and backticks), matching GFM's autolink rule, in the server extractor and its client mirror so both agree. Punctuation inside a path is untouched — only the tail is trimmed.

## Testing

- Go: emphasis stripped for `**`, `_`, `~~`; a bolded URL dedupes against the same item as a shorthand; inner punctuation (`/a_b/c~d/e*f?q=1`) survives.
- Web: the same three cases against the client mirror.
- Verified against the real card that surfaced this: both PR links now resolve to their titles and states instead of showing as bare links.

Full suites pass under `-race`; golangci-lint clean.