### PR TITLE
feat(card): copy the card id from the card row

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -31,7 +31,6 @@ interface CardProps {
   /** Pick the implicit "In Progress" status: clears the stage and clamps the
    *  card's progress into [10, 90]. */
   onInProgress: (card: CardModel) => void;
-  onRename: (card: CardModel, title: string) => void;
   onOpen: (card: CardModel) => void;
   /** Reassign the card's team / person from the avatar menu (when provided). */
   teams?: string[];
@@ -104,7 +103,6 @@ export function Card({
   onDelete,
   onStage,
   onInProgress,
-  onRename,
   onOpen,
   teams,
   people,
@@ -147,8 +145,7 @@ export function Card({
   // The cycle submenu opens to the right; near the viewport edge it flips
   // left so it never clips off-screen.
   const [recLeft, setRecLeft] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(card.title);
+  const [copied, setCopied] = useState(false);
   const [dragValue, setDragValue] = useState<number | null>(null);
   const [assignOpen, setAssignOpen] = useState(false);
   const [personInput, setPersonInput] = useState("");
@@ -323,18 +320,19 @@ export function Card({
     onSetWeek?.(card, startVal || null);
   };
 
-  const startEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
+  // The card's uid is what an agent needs to act on it (every MCP card tool
+  // takes it), so copying it is the one thing worth a click on the card
+  // itself — pasting it into a chat beats hunting for it in the API.
+  const copyId = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    setDraft(card.title);
-    setEditing(true);
-  };
-
-  const commitEdit = () => {
-    const next = draft.trim();
-    if (next && next !== card.title) {
-      onRename(card, next);
+    const p = navigator.clipboard?.writeText(card.itemId);
+    if (!p) {
+      return;
     }
-    setEditing(false);
+    void p.then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    });
   };
 
   // A plan card not yet taken into work hasn't started aging: show 0d. Once it
@@ -586,43 +584,25 @@ export function Card({
           </svg>
         </button>
       )}
-      {editing ? (
-        <input
-          type="text"
-          className="card-title-input"
-          autoFocus
-          value={draft}
-          onClick={(e) => e.stopPropagation()}
-          onDoubleClick={(e) => e.stopPropagation()}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-            if (e.key === "Enter") {
-              commitEdit();
-            } else if (e.key === "Escape") {
-              setEditing(false);
-            }
-          }}
-          onBlur={() => setEditing(false)}
-        />
-      ) : (
-        <span className="card-title" title={card.title}>
-          {card.title}
-        </span>
-      )}
+      <span className="card-title" title={card.title}>
+        {card.title}
+      </span>
 
       {ref && <span className="card-ticket">{ref}</span>}
 
       <span className="card-actions" aria-hidden={false}>
-        <button
-          type="button"
-          className="card-action card-hoveronly"
-          onClick={startEdit}
-          aria-label="Rename card"
-          title="Rename"
-        >
-          ✎
-        </button>
+        {!card.itemId.startsWith("tmp-") && (
+          <button
+            type="button"
+            className="card-action card-hoveronly"
+            onClick={copyId}
+            onDoubleClick={(e) => e.stopPropagation()}
+            aria-label="Copy card id"
+            title={copied ? "Copied" : "Copy card id"}
+          >
+            {copied ? "✓" : "⧉"}
+          </button>
+        )}
         <button
           type="button"
           className="card-action card-hoveronly card-action-delete"

--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -594,13 +594,13 @@ export function Card({
         {!card.itemId.startsWith("tmp-") && (
           <button
             type="button"
-            className="card-action card-hoveronly"
+            className="card-action card-action-id card-hoveronly"
             onClick={copyId}
             onDoubleClick={(e) => e.stopPropagation()}
             aria-label="Copy card id"
             title={copied ? "Copied" : "Copy card id"}
           >
-            {copied ? "✓" : "⧉"}
+            {copied ? "✓" : "ID"}
           </button>
         )}
         <button

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -862,18 +862,6 @@ export function MeBoard({
       });
   };
 
-  const handleRename = (card: CardModel, title: string) => {
-    const prev = card.title;
-    patchCard(card.itemId, { title });
-    void provider
-      .patchCard(board, card.itemId, { title })
-      .then(addCard)
-      .catch((err: unknown) => {
-        patchCard(card.itemId, { title: prev });
-        onError(errMessage(err));
-      });
-  };
-
   const handleDelete = (card: CardModel) => {
     // A just-created optimistic card has no server twin yet: drop it locally
     // (deleting it via the API would 404 and resurrect a phantom copy).
@@ -1345,7 +1333,6 @@ export function MeBoard({
       onDelete={handleDelete}
       onStage={handleStage}
       onInProgress={handleInProgress}
-      onRename={handleRename}
       onOpen={onOpen}
       teams={teams}
       people={people}
@@ -1557,7 +1544,6 @@ export function MeBoard({
                   onDelete={() => {}}
                   onStage={() => {}}
                   onInProgress={() => {}}
-                  onRename={() => {}}
                   onOpen={() => {}}
                 />
               )}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1193,7 +1193,6 @@ export function TeamBoard({
       onDelete={handleGridDelete}
       onStage={handleStage}
       onInProgress={handleInProgress}
-      onRename={handleRename}
       onOpen={onOpen}
       teams={roster}
       people={people}
@@ -1463,18 +1462,6 @@ export function TeamBoard({
         if (card.parent) {
           reload(); // the parent's optimistic derived bar needs the truth back
         }
-        onError(errMessage(err));
-      });
-  };
-
-  const handleRename = (card: CardModel, title: string) => {
-    const prev = card.title;
-    patchCard(card.itemId, { title });
-    void provider
-      .patchCard(board, card.itemId, { title })
-      .then(addCard)
-      .catch((err: unknown) => {
-        patchCard(card.itemId, { title: prev });
         onError(errMessage(err));
       });
   };
@@ -2242,7 +2229,6 @@ export function TeamBoard({
               onDelete={card.parent ? handleGridDelete : removeFromPlan}
               onStage={handleStage}
               onInProgress={handleInProgress}
-              onRename={handleRename}
               onOpen={onOpen}
               teams={roster}
               people={people}
@@ -2283,7 +2269,6 @@ export function TeamBoard({
               onDelete={() => {}}
               onStage={() => {}}
               onInProgress={() => {}}
-              onRename={() => {}}
               onOpen={() => {}}
             />
           )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1721,7 +1721,7 @@ button.card-age {
   margin-right: -3px;
 }
 
-/* Rename, delete, and the status flag (only on cards without a review/locked
+/* Copy-id, delete, and the status flag (only on cards without a review/locked
    state) appear on hover. Touch devices have no hover, so they stay hidden there
    and such cards are managed from the popup. The review/locked indicators carry
    no .card-hoveronly, so they always show. */
@@ -1793,17 +1793,6 @@ button.card-age {
   height: 9px;
   border-radius: 50%;
   flex: none;
-}
-
-.card-title-input {
-  flex: 1;
-  min-width: 0;
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 500;
-  padding: 1px 5px;
-  border: 1px solid var(--accent);
-  border-radius: 4px;
 }
 
 /* ---- add card ---- */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1707,6 +1707,14 @@ button.card-age {
   justify-content: center;
 }
 
+/* The copy-id action is a word, not a glyph: smaller and bolder than the
+   symbol buttons beside it so it reads as a label at 18px. */
+.card-action-id {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+}
+
 .card-action:hover {
   background: var(--hover-overlay);
   color: var(--fg);


### PR DESCRIPTION
## Why

Agents act on a card by its uid — every MCP card tool takes it — so the useful thing to grab off a card row is that id. Until now it was not exposed anywhere in the UI: you had to go find it through the API.

The slot it takes is the hover pencil, which the card no longer needs: double-clicking a card opens the detail pane, and that already renames the card and edits its description.

## What

An **ID** button on card hover copies the card's uid to the clipboard, showing a check for a moment on success. It is a word rather than a glyph on purpose — a bare copy symbol says "copy" without saying copy *what*, and a two-sheet icon carrying "ID" falls apart at 18px. It is set smaller and bolder than the symbol buttons beside it so it reads as a label in the same row.

Optimistic cards, whose id is still a local `tmp-` placeholder, show no button — there is nothing worth copying yet.

Removing the pencil left the inline title editor unreachable, so it goes too, along with its state, handlers, the `onRename` prop threaded through both boards, and its orphaned style. Net −60 lines.

## Testing

Type-checked, built, full Go + web suites pass under `-race`, golangci-lint clean. Checked by hand on a dev board across the icon iterations before settling on the label.