### PR TITLE
fix(card): make the progress handle easier to grab

### DIFF
--- a/web/src/components/Card.tsx
+++ b/web/src/components/Card.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import type { Card as CardModel, StageKey } from "../providers/types";
 import { STAGES, STAGE_ORDER, DEFAULT_BAR_COLOR, isInProgress } from "../stages";
+import { snapProgress } from "../progress";
 import { teamColor, teamInitial } from "../avatar";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { addDays, daysSince, localDateIso, todayIso, mondayOf } from "../date";
@@ -195,7 +196,22 @@ export function Card({
         : Math.min(90, Math.max(10, Math.round(shown / 10) * 10));
   const filled = dispPct / 10;
 
-  // Progress is changed only by dragging the handle, which snaps to 10% steps.
+  // Where a pointer at clientX lands on the 10% grid. review/locked cards are
+  // clamped to 10–90%; other cards span 0–100% (0% clears).
+  const valueAt = (clientX: number): number => {
+    const rect = barRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) {
+      return value;
+    }
+    return snapProgress(
+      (clientX - rect.left) / rect.width,
+      card.stage === "review" || card.stage === "locked",
+    );
+  };
+
+  // Progress moves only by dragging the handle. The bar itself stays inert on
+  // purpose: it runs the full width of the card, and a stray press while
+  // dragging cards around would silently rewrite someone's progress.
   const onHandleDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.stopPropagation();
     e.preventDefault();
@@ -204,16 +220,10 @@ export function Card({
   };
 
   const onHandleMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (dragValue === null || !barRef.current) {
+    if (dragValue === null) {
       return;
     }
-    const rect = barRef.current.getBoundingClientRect();
-    const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0;
-    // review/locked are clamped to 10–90%; other cards span 0–100% (0% clears).
-    const locked = card.stage === "review" || card.stage === "locked";
-    const min = locked ? 10 : 0;
-    const max = locked ? 90 : 100;
-    const snapped = Math.min(max, Math.max(min, Math.round(frac * 10) * 10));
+    const snapped = valueAt(e.clientX);
     if (snapped !== dragValue) {
       setDragValue(snapped);
     }
@@ -1054,6 +1064,7 @@ export function Card({
           onPointerDown={onHandleDown}
           onPointerMove={onHandleMove}
           onPointerUp={onHandleUp}
+          onPointerCancel={onHandleUp}
         />
       </div>
     </div>

--- a/web/src/progress.test.ts
+++ b/web/src/progress.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { snapProgress } from "./progress";
+
+describe("snapProgress", () => {
+  it("snaps to the 10% grid", () => {
+    expect(snapProgress(0, false)).toBe(0);
+    expect(snapProgress(0.04, false)).toBe(0);
+    expect(snapProgress(0.06, false)).toBe(10);
+    expect(snapProgress(0.63, false)).toBe(60);
+    expect(snapProgress(1, false)).toBe(100);
+  });
+
+  it("clamps a pointer dragged past either end", () => {
+    expect(snapProgress(-0.4, false)).toBe(0);
+    expect(snapProgress(1.7, false)).toBe(100);
+  });
+
+  it("keeps a review/locked card inside 10–90", () => {
+    expect(snapProgress(0, true)).toBe(10);
+    expect(snapProgress(1, true)).toBe(90);
+    expect(snapProgress(0.5, true)).toBe(50);
+  });
+});

--- a/web/src/progress.ts
+++ b/web/src/progress.ts
@@ -1,0 +1,10 @@
+/** Progress-bar geometry shared by the card slider and its tests. */
+
+/** Snap a fraction of the bar's width (0..1, may fall outside when the pointer
+ *  runs past either end) to the 10% grid the slider works in. A review/locked
+ *  card is clamped to 10–90 so it never reads as empty or complete. */
+export function snapProgress(fraction: number, locked: boolean): number {
+  const min = locked ? 10 : 0;
+  const max = locked ? 90 : 100;
+  return Math.min(max, Math.max(min, Math.round(fraction * 10) * 10));
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1660,6 +1660,17 @@ button.card-age {
   touch-action: none;
 }
 
+/* The 11px dot is what people kept missing, so its press target grows well
+   past it — mostly sideways, the axis a pointer misses along, and down to the
+   card's edge (the dot already sits on it). Upward it stays shallow: the
+   actions row is just above, and .card-actions is raised over the handle so a
+   press there still reaches the buttons rather than starting a drag. */
+.card-bar-handle::before {
+  content: "";
+  position: absolute;
+  inset: -4px -11px 0;
+}
+
 .card:hover .card-bar-handle,
 .card-bar-handle-dragging {
   opacity: 1;
@@ -1689,6 +1700,11 @@ button.card-age {
   align-items: center;
   gap: 1px;
   flex: none;
+  /* Above the progress handle: at high percentages the handle sits right
+     under these buttons, and its enlarged press target must never swallow a
+     click meant for one of them. */
+  position: relative;
+  z-index: 4;
 }
 
 .card-action {


### PR DESCRIPTION
## Problem

People report missing the progress handle with the pointer. It is an 11px dot on a 3px line, invisible until the card is hovered, and only the dot itself accepts a press — the bar around it is inert.

## Change

The handle's press target now reaches well past the drawn dot, growing where there is room:

- **sideways, 11px each side** (33px total) — the axis a pointer misses along, since the handle slides horizontally;
- **down to the card's edge**, which the dot already sits on, so nothing reaches into the gap between cards;
- **shallow upward (4px)** — the actions row starts right there.

Where the two do meet — at high percentages the handle slides under the buttons on the right — `.card-actions` is now raised above the handle, so a press there reaches the button instead of starting a drag.

Nothing drawn moves by a pixel.

**Deliberately not done:** making the whole bar draggable. It would be the bigger win for aim, and it was tried, but the bar spans the card: a stray press while dragging cards around would silently rewrite someone's progress. Not a trade a board of PMs should pay.

## Testing

The snapping arithmetic moves into `web/src/progress.ts` with tests: the 10% grid, the 10–90 clamp for review/locked cards, and a pointer dragged past either end. Type-checked, built, 45 web tests pass.
