### PR TITLE
fix(auth): a token GitHub refuses ends the session that holds it

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -224,7 +224,7 @@ func (s *Server) handleCardLog(w http.ResponseWriter, r *http.Request) {
 	}
 	card, err := svc.Card(r.Context(), owner, project, r.PathValue("uid"))
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, apiserver.CardLog(card))
@@ -245,7 +245,7 @@ func (s *Server) handleGetBoard(w http.ResponseWriter, r *http.Request) {
 	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, apiserver.BoardResource(b))
@@ -276,7 +276,7 @@ func (s *Server) handleListCards(w http.ResponseWriter, r *http.Request) {
 	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, apiserver.ListCards(b, sel))
@@ -297,7 +297,7 @@ func (s *Server) handleListSprints(w http.ResponseWriter, r *http.Request) {
 	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -313,7 +313,7 @@ func (s *Server) handleGetOrdering(w http.ResponseWriter, r *http.Request) {
 	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, apiserver.OrderingResource(b))
@@ -386,12 +386,12 @@ func (s *Server) handleCreateCard(w http.ResponseWriter, r *http.Request) {
 	}
 	card, err := svc.CreateCard(r.Context(), owner, project, args)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, apiserver.CardResource(b, card))
@@ -445,19 +445,19 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 	uid := r.PathValue("uid")
 	if p.Title != nil {
 		if err := svc.Rename(ctx, owner, project, uid, *p.Title); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
 	if p.Description != nil {
 		if err := svc.SetDescription(ctx, owner, project, uid, *p.Description); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
 	if p.Team != nil {
 		if err := svc.SetTeam(ctx, owner, project, uid, *p.Team, ""); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
@@ -467,7 +467,7 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := svc.SetZone(ctx, owner, project, uid, zone); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
@@ -477,7 +477,7 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 			login = (*p.Assignees)[0]
 		}
 		if err := svc.SetAssignee(ctx, owner, project, uid, login); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
@@ -487,19 +487,19 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := svc.SetStage(ctx, owner, project, uid, stage); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
 	if p.Recurrence != nil {
 		if err := svc.SetRecurrence(ctx, owner, project, uid, *p.Recurrence); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
 	if p.Progress != nil {
 		if err := svc.SetProgress(ctx, owner, project, uid, *p.Progress); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
@@ -515,13 +515,13 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 	}
 	if p.Parent != nil {
 		if err := svc.SetParent(ctx, owner, project, uid, *p.Parent); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
 	if p.ReviewOf != nil {
 		if err := svc.SetReviewOf(ctx, owner, project, uid, *p.ReviewOf); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return
 		}
 	}
@@ -542,18 +542,18 @@ func (s *Server) applyDatesPatch(w http.ResponseWriter, r *http.Request, svc *bo
 			end = card.Day
 		}
 		if err := svc.SetDates(ctx, owner, project, uid, *d.Start, end); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return false
 		}
 	} else if d.End != nil {
 		if err := svc.SetDay(ctx, owner, project, uid, *d.End); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return false
 		}
 	}
 	if d.Sprint != nil {
 		if err := svc.SetSprintStart(ctx, owner, project, uid, *d.Sprint); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return false
 		}
 	}
@@ -569,13 +569,13 @@ func (s *Server) applyPlanPatch(w http.ResponseWriter, r *http.Request, svc *boa
 			return false
 		}
 		if err := svc.SetPlan(ctx, owner, project, uid, band); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return false
 		}
 	}
 	if pl.Week != nil {
 		if err := svc.SetWeek(ctx, owner, project, uid, *pl.Week); err != nil {
-			s.apiError(w, err)
+			s.apiError(w, r, err)
 			return false
 		}
 	}
@@ -590,7 +590,7 @@ func (s *Server) handleDeleteCard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := svc.DeleteCard(r.Context(), owner, project, r.PathValue("uid")); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
@@ -612,7 +612,7 @@ func (s *Server) handleRemoveCard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := svc.Remove(r.Context(), owner, project, r.PathValue("uid"), in.From); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
@@ -637,7 +637,7 @@ func (s *Server) handleMoveCard(w http.ResponseWriter, r *http.Request) {
 		return svc.MoveCard(r.Context(), owner, project, r.PathValue("uid"), in.After)
 	}
 	if err := move(); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
@@ -660,7 +660,7 @@ func (s *Server) handleDeferCard(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.Defer(r.Context(), owner, project, uid, in.Days); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.cardResponse(w, r, svc, owner, project, uid)
@@ -673,7 +673,7 @@ func (s *Server) handleInProgress(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.SetInProgress(r.Context(), owner, project, uid); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.cardResponse(w, r, svc, owner, project, uid)
@@ -709,13 +709,13 @@ func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
 	uid := r.PathValue("uid")
 	b, err := svc.Board(ctx, owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	for _, c := range b.Cards {
 		if c.ReviewOf == uid {
 			if err := svc.ReassignReviewer(ctx, owner, project, uid, in.Reviewer, in.Day, zone); err != nil {
-				s.apiError(w, err)
+				s.apiError(w, r, err)
 				return
 			}
 			s.cardResponse(w, r, svc, owner, project, c.ItemID)
@@ -724,12 +724,12 @@ func (s *Server) handleSendToReview(w http.ResponseWriter, r *http.Request) {
 	}
 	review, err := svc.SendToReview(ctx, owner, project, uid, in.Reviewer, in.Day, zone)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	b, err = svc.Board(ctx, owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, apiserver.CardResource(b, review))
@@ -742,7 +742,7 @@ func (s *Server) handleRemoveReviewer(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.RemoveReviewer(r.Context(), owner, project, uid); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.cardResponse(w, r, svc, owner, project, uid)
@@ -771,7 +771,7 @@ func (s *Server) handleTakeIntoPlan(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.TakeIntoPlan(r.Context(), owner, project, uid, in.Engineer, zone, in.Day); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.cardResponse(w, r, svc, owner, project, uid)
@@ -784,7 +784,7 @@ func (s *Server) handleReleaseFromPlan(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.ReleaseFromPlan(r.Context(), owner, project, uid); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.cardResponse(w, r, svc, owner, project, uid)
@@ -802,7 +802,7 @@ func (s *Server) handleListLinks(w http.ResponseWriter, r *http.Request) {
 	}
 	links, err := svc.CardLinks(r.Context(), owner, project, r.PathValue("uid"))
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	if links == nil {
@@ -816,7 +816,7 @@ func (s *Server) handleListLinks(w http.ResponseWriter, r *http.Request) {
 func (s *Server) notesResponse(w http.ResponseWriter, r *http.Request, svc *boardservice.Service, owner string, project int, uid string, status int) {
 	card, err := svc.Card(r.Context(), owner, project, uid)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, status, map[string]any{
@@ -850,7 +850,7 @@ func (s *Server) handleAddNote(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.AddNote(r.Context(), owner, project, uid, in.Text); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.notesResponse(w, r, svc, owner, project, uid, http.StatusCreated)
@@ -869,7 +869,7 @@ func (s *Server) handleEditNote(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.EditNote(r.Context(), owner, project, uid, r.PathValue("noteId"), in.Text); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.notesResponse(w, r, svc, owner, project, uid, http.StatusOK)
@@ -882,7 +882,7 @@ func (s *Server) handleDeleteNote(w http.ResponseWriter, r *http.Request) {
 	}
 	uid := r.PathValue("uid")
 	if err := svc.DeleteNote(r.Context(), owner, project, uid, r.PathValue("noteId")); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	s.notesResponse(w, r, svc, owner, project, uid, http.StatusOK)
@@ -904,7 +904,7 @@ func (s *Server) handlePatchSprint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := svc.SetSprintState(r.Context(), owner, project, in.Team, in.Current, in.Previous); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, apiserver.Sprint{
@@ -934,7 +934,7 @@ func (s *Server) handleCarryOver(w http.ResponseWriter, r *http.Request) {
 	ctx, _ := withStaleAllowed(r.Context())
 	rep, err := svc.CarryOver(ctx, owner, project, in.Team, in.DryRun)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, rep)
@@ -957,7 +957,7 @@ func (s *Server) handleCarryWeek(w http.ResponseWriter, r *http.Request) {
 	ctx, _ := withStaleAllowed(r.Context())
 	rep, err := svc.CarryWeek(ctx, owner, project, in.Team, in.Week, in.DryRun)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, rep)
@@ -980,7 +980,7 @@ func (s *Server) handleReorderTeams(w http.ResponseWriter, r *http.Request) {
 	// Same cached-snapshot read as carry-over (see handleCarryOver).
 	ctx, _ := withStaleAllowed(r.Context())
 	if err := svc.ReorderTeams(ctx, owner, project, in.Teams); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
@@ -1000,7 +1000,7 @@ func (s *Server) handleDeleteTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := svc.DeleteTeam(r.Context(), owner, project, in.Team); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
@@ -1040,7 +1040,7 @@ func (s *Server) handleSetPresence(w http.ResponseWriter, r *http.Request) {
 func (s *Server) cardResponse(w http.ResponseWriter, r *http.Request, svc *boardservice.Service, owner string, project int, uid string) {
 	b, err := svc.Board(r.Context(), owner, project)
 	if err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	for _, c := range b.Cards {
@@ -1049,7 +1049,7 @@ func (s *Server) cardResponse(w http.ResponseWriter, r *http.Request, svc *board
 			return
 		}
 	}
-	s.apiError(w, fmt.Errorf("%w: %s", boardservice.ErrCardNotFound, uid))
+	s.apiError(w, r, fmt.Errorf("%w: %s", boardservice.ErrCardNotFound, uid))
 }
 
 // parseZone validates a semantic zone name ("" clears); on failure it writes
@@ -1097,8 +1097,27 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 }
 
 // apiError maps service errors onto HTTP statuses.
-func (s *Server) apiError(w http.ResponseWriter, err error) {
+func (s *Server) apiError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
+	case errors.Is(err, ghprojects.ErrBadCredentials):
+		// The session was built on a token GitHub now refuses: drop it, so
+		// /api/config reports the user as signed out and the SPA offers the
+		// sign-in it needs instead of failing every request behind a session
+		// that still looks valid.
+		if s.auth != nil {
+			if login := s.auth.dropSession(s.auth.sessionID(r)); login != "" {
+				s.log.Warn("github rejected a session token; session dropped, re-authorization required",
+					"login", login, "path", r.URL.Path)
+			}
+			s.auth.setCookie(w, sessionCookie, "", -1)
+		}
+		// GitHub rejected the caller's token: nothing downstream can fix it,
+		// and answering 502 ("upstream is broken") sends people hunting the
+		// wrong problem. Say plainly that the authorization is gone; the
+		// session behind it is dropped by handleAPI so the next request has
+		// to sign in again.
+		writeJSONError(w, http.StatusUnauthorized,
+			"your GitHub authorization is no longer valid: "+err.Error())
 	case errors.Is(err, boardservice.ErrCardNotFound), errors.Is(err, boardservice.ErrNoteNotFound):
 		writeJSONError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, ghprojects.ErrFieldNotFound), errors.Is(err, ghprojects.ErrNoContent),

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -8,6 +10,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 
 	"github.com/aenix-io/aeman/pkg/apiserver"
 	"github.com/aenix-io/aeman/pkg/board"
@@ -613,5 +617,23 @@ func TestPresenceUsesAuthenticatedLogin(t *testing.T) {
 	}
 	if got.Card != "c1" {
 		t.Fatalf("presence card = %q, want c1", got.Card)
+	}
+}
+
+// GitHub rejecting the caller's token is not an upstream outage: answering
+// 502 sent people hunting a broken server (an agent even concluded aeman used
+// "its own invalid token" — in OAuth mode it holds none). It is a 401 saying
+// the authorization is gone.
+func TestAPIBadCredentialsAnswers401(t *testing.T) {
+	fake := boardservicetest.New(nil, nil)
+	fake.FailLoad(fmt.Errorf("%w: HTTP 401: Bad credentials", ghprojects.ErrBadCredentials))
+	srv := apiServer(t, Options{}, fake)
+
+	rec := do(t, srv, http.MethodGet, "/api/v1/cards?owner=acme&project=1", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "no longer valid") {
+		t.Fatalf("the answer must name the cause, got %s", rec.Body.String())
 	}
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -322,6 +322,25 @@ func (a *authManager) redirectURI() string {
 	return strings.TrimRight(a.cfg.BaseURL, "/") + "/auth/callback"
 }
 
+// dropSession forgets one session by id. It is what a GitHub 401 means: the
+// token this session was built on is dead, so the session backed by it is
+// worthless — keeping it only lets the client retry forever against a token
+// that will never work again. Returns the login it belonged to, for the log.
+func (a *authManager) dropSession(id string) string {
+	if id == "" {
+		return ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.sessions[id]
+	if !ok {
+		return ""
+	}
+	delete(a.sessions, id)
+	a.saveLocked()
+	return s.login
+}
+
 // session resolves the request's session cookie to a live session.
 func (a *authManager) session(r *http.Request) (oauthSession, bool) {
 	c, err := r.Cookie(sessionCookie)

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -3,12 +3,14 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/ghprojects"
 	"github.com/aenix-io/aeman/pkg/mcpserver"
 )
 
@@ -56,7 +58,7 @@ func (s *Server) mcpServerForRequest(*http.Request) *mcp.Server {
 			return &storeBackend{inner: b, store: s.store, multiUser: true}
 		},
 	})
-	srv.AddReceivingMiddleware(injectGitHubToken)
+	srv.AddReceivingMiddleware(injectGitHubToken, s.dropSessionOnBadCredentials)
 	return srv
 }
 
@@ -76,6 +78,40 @@ func injectGitHubToken(next mcp.MethodHandler) mcp.MethodHandler {
 		}
 		return next(ctx, method, req)
 	}
+}
+
+// dropSessionOnBadCredentials turns "GitHub says this token is dead" into the
+// only answer that helps: forget the session, so the next call fails
+// authentication and the client runs the OAuth flow again. Without it the
+// session stays valid for its full TTL while every tool call fails against a
+// token that will never work — the client cannot tell whose credentials are
+// at fault and keeps retrying (an agent reported it as "the server uses its
+// own, invalid token"; the server holds no token of its own).
+func (s *Server) dropSessionOnBadCredentials(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		res, err := next(ctx, method, req)
+		if err == nil || !errors.Is(err, ghprojects.ErrBadCredentials) || s.auth == nil {
+			return res, err
+		}
+		id, _ := extraString(req, sessionIDExtraKey)
+		if login := s.auth.dropSession(id); login != "" {
+			s.log.Warn("github rejected a session token; session dropped, re-authorization required",
+				"login", login, "method", method)
+		}
+		return res, fmt.Errorf(
+			"your GitHub authorization is no longer valid (GitHub rejected the token); "+
+				"sign in again to aeman to reconnect: %w", err)
+	}
+}
+
+// extraString reads one string value off a request's verified TokenInfo.
+func extraString(req mcp.Request, key string) (string, bool) {
+	extra := req.GetExtra()
+	if extra == nil || extra.TokenInfo == nil {
+		return "", false
+	}
+	v, ok := extra.TokenInfo.Extra[key].(string)
+	return v, ok
 }
 
 // resolveTokenFromContext is the MCP ResolveToken seam for the HTTP transport.

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -26,6 +26,11 @@ const authCodeTTL = 5 * time.Minute
 // reads it back from the per-request TokenInfo.
 const githubTokenExtraKey = "github_token"
 
+// sessionIDExtraKey carries the session id (= the MCP bearer token) alongside
+// it, so a handler that learns GitHub has rejected the token can drop that
+// exact session instead of leaving the client to retry a dead one forever.
+const sessionIDExtraKey = "aeman_session"
+
 // registerOAuthServer wires the OAuth 2.0 authorization-server endpoints that
 // front the MCP transport: metadata discovery, dynamic client registration, the
 // authorize redirect and the token endpoint. It is only mounted in OAuth mode.
@@ -435,7 +440,10 @@ func (a *authManager) verifyToken(_ context.Context, token string, _ *http.Reque
 	return &auth.TokenInfo{
 		UserID:     s.login,
 		Expiration: s.created.Add(sessionTTL),
-		Extra:      map[string]any{githubTokenExtraKey: s.token},
+		Extra: map[string]any{
+			githubTokenExtraKey: s.token,
+			sessionIDExtraKey:   token,
+		},
 	}, nil
 }
 

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -737,3 +737,47 @@ func TestPruneEphemeral(t *testing.T) {
 		t.Fatal("live ephemeral entries were wrongly swept")
 	}
 }
+
+// A session is only as good as the GitHub token inside it. When GitHub starts
+// rejecting that token, keeping the session alive for its full TTL is the
+// worst answer: the client's own credentials still verify, so it retries a
+// dead token forever and cannot tell whose authorization broke. Dropping the
+// session forces the one thing that fixes it — signing in again.
+func TestDropSessionForgetsIt(t *testing.T) {
+	a := quietAuth(t, OAuthConfig{SessionFile: t.TempDir() + "/sessions.json"})
+	a.sessions["sid"] = oauthSession{token: "dead-gh-token", login: "octocat", created: time.Now()}
+
+	// While it exists, /mcp accepts the bearer and hands out the token.
+	if _, err := a.verifyToken(context.Background(), "sid", nil); err != nil {
+		t.Fatalf("a live session must verify: %v", err)
+	}
+
+	if login := a.dropSession("sid"); login != "octocat" {
+		t.Fatalf("dropSession must report whose session it was, got %q", login)
+	}
+	if _, ok := a.sessions["sid"]; ok {
+		t.Fatal("the session must be gone")
+	}
+	// Now the MCP client is told to authenticate again, instead of retrying.
+	if _, err := a.verifyToken(context.Background(), "sid", nil); !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("a dropped session must fail verification with ErrInvalidToken, got %v", err)
+	}
+	// Dropping again (a burst of failing calls) is harmless.
+	if login := a.dropSession("sid"); login != "" {
+		t.Fatalf("dropping an unknown session must be a no-op, got %q", login)
+	}
+}
+
+// The MCP verifier hands the session id down with the token, so a handler
+// that sees GitHub reject the call knows exactly which session to drop.
+func TestVerifyTokenCarriesSessionID(t *testing.T) {
+	a := quietAuth(t, OAuthConfig{SessionFile: t.TempDir() + "/sessions.json"})
+	a.sessions["sid"] = oauthSession{token: "gh", login: "octocat", created: time.Now()}
+	info, err := a.verifyToken(context.Background(), "sid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Extra[sessionIDExtraKey] != "sid" || info.Extra[githubTokenExtraKey] != "gh" {
+		t.Fatalf("extras = %+v", info.Extra)
+	}
+}

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -65,7 +65,7 @@ func (s *Server) handleWatch(w http.ResponseWriter, r *http.Request) {
 	// because the connection is hijacked, so opt in explicitly).
 	warmCtx, _ := withStaleAllowed(r.Context())
 	if _, err := svc.Board(warmCtx, owner, project); err != nil {
-		s.apiError(w, err)
+		s.apiError(w, r, err)
 		return
 	}
 	// The Origin is checked so a cross-site page cannot open the stream and

--- a/pkg/boardservice/boardservicetest/fake.go
+++ b/pkg/boardservice/boardservicetest/fake.go
@@ -20,6 +20,7 @@ type Backend struct {
 	// goroutine (resolveTitleAsync), so the fake is hit concurrently with the
 	// test's own requests and assertions.
 	mu      sync.Mutex
+	loadErr error
 	refs    map[string]board.Link
 	board   board.Board
 	log     []string
@@ -109,11 +110,22 @@ func (f *Backend) Creates() []board.CreateInput {
 	return append([]board.CreateInput(nil), f.creates...)
 }
 
+// FailLoad makes every LoadBoard answer err — the seam for testing how the
+// server reacts to an upstream that refuses the caller (a dead token).
+func (f *Backend) FailLoad(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loadErr = err
+}
+
 // LoadBoard returns a copy of the seeded board snapshot.
 func (f *Backend) LoadBoard(_ context.Context, _ string, _ int) (board.Board, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.rec("LoadBoard")
+	if f.loadErr != nil {
+		return board.Board{}, f.loadErr
+	}
 	cards := make([]board.Card, len(f.board.Cards))
 	copy(cards, f.board.Cards)
 	states := map[string]board.SprintState{}

--- a/pkg/ghprojects/client.go
+++ b/pkg/ghprojects/client.go
@@ -26,6 +26,13 @@ var (
 	ErrFieldNotFound = errors.New("field not found")
 	// ErrNoContent is returned for operations needing an underlying issue/draft.
 	ErrNoContent = errors.New("card has no underlying issue")
+
+	// ErrBadCredentials is GitHub rejecting the caller's token (401/403). It
+	// is a distinct condition from a board or field being missing: the token
+	// stored for this user is dead — expired, revoked, or superseded — and no
+	// retry with it will ever work. Callers holding a session behind that
+	// token must drop it and make the user authorize again.
+	ErrBadCredentials = errors.New("github rejected the token")
 )
 
 // Doer is the subset of *http.Client used by the client, so tests can inject a
@@ -166,7 +173,7 @@ func (c *Client) graphql(ctx context.Context, query string, vars map[string]any,
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("github graphql: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("%w: HTTP %d: %s", ErrBadCredentials, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var envelope struct {

--- a/pkg/ghprojects/client_test.go
+++ b/pkg/ghprojects/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -430,5 +431,39 @@ func TestLoadBoardPaginatesItems(t *testing.T) {
 	}
 	if projectQueries != 2 {
 		t.Fatalf("want 2 project page queries (first + one follow-up), got %d", projectQueries)
+	}
+}
+
+// GitHub rejecting the caller's token is its own condition, not a generic
+// upstream failure: the token stored for that user is dead and no retry will
+// help, so the session behind it must be dropped rather than kept alive for
+// its full TTL while every call fails. The sentinel is what lets the server
+// tell the two apart.
+func TestGraphQLBadCredentialsIsTyped(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+			fmt.Fprint(w, `{"message":"Bad credentials"}`)
+		}))
+		var out struct{}
+		err := New("tok", WithEndpoint(srv.URL)).graphql(context.Background(), `query{x}`, nil, &out)
+		srv.Close()
+		if !errors.Is(err, ErrBadCredentials) {
+			t.Fatalf("HTTP %d must be ErrBadCredentials, got %v", code, err)
+		}
+		if !strings.Contains(err.Error(), "Bad credentials") {
+			t.Fatalf("the upstream message must survive for the log: %v", err)
+		}
+	}
+
+	// An ordinary upstream failure stays untyped — it is retryable.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	var out struct{}
+	err := New("tok", WithEndpoint(srv.URL)).graphql(context.Background(), `query{x}`, nil, &out)
+	if errors.Is(err, ErrBadCredentials) {
+		t.Fatalf("a 502 is not a credentials problem: %v", err)
 	}
 }


### PR DESCRIPTION
## What happened in the field

An agent working over `/mcp` started getting `401 Bad credentials` on every card it touched, and reported that "the aeman server calls GitHub under its own token, and that token is invalid". In OAuth mode aeman holds **no token of its own** — every GitHub call rides the caller's, and prod sets no `GITHUB_TOKEN`. But the report was a reasonable inference from what the agent could see: its own MCP bearer token verified fine, yet GitHub refused the call. Both halves were true, which is why the conclusion was wrong and the team spent a morning chasing a server-side credential that does not exist.

The actual mechanism: a session stores the GitHub token captured at sign-in, and nothing ever re-checked it. `verifyToken` only tests the session's own 14-day TTL. Once GitHub stops accepting that token — revoked, superseded, expired — the session stays "valid" while every call behind it fails. The API answered `502` (upstream is broken), the MCP client kept retrying a token that can never work, and the server logged nothing at all.

## Change

GitHub's 401/403 becomes a typed condition (`ghprojects.ErrBadCredentials`) instead of an opaque upstream failure, and it ends the session built on that token:

- **MCP**: the session is dropped, so the next call fails authentication and the client re-runs the OAuth flow — the one action that fixes it. The error returned names the cause instead of leaving the agent to theorise.
- **Web**: the session is dropped and its cookie cleared, so `/api/config` reports the user as signed out and the SPA offers its sign-in.
- **API**: `401` naming the cause, not `502`.
- **Logs**: a warn line with the login that lost its authorization — this was completely invisible before.

## Testing

- `TestGraphQLBadCredentialsIsTyped` — 401 and 403 carry the sentinel and keep GitHub's message for the log; a 502 stays untyped (it is retryable).
- `TestDropSessionForgetsIt` — a dropped session stops verifying (`auth.ErrInvalidToken`, which is what makes a client re-authorize), reports whose it was, and dropping twice is harmless.
- `TestVerifyTokenCarriesSessionID` — the verifier hands the session id down with the token, so the failing call knows which session to end.
- `TestAPIBadCredentialsAnswers401` — the HTTP surface answers 401 and names the cause.
- Full Go suites under `-race`, golangci-lint, 45 web tests.

## Note on the immediate incident

This fixes the failure mode, not the already-broken session: a user whose token died before this ships still needs to sign in again once (which is now what the product tells them to do, rather than failing silently).
