### PR TITLE
fix(watch): the board's structure reaches the other tabs

### DIFF
--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -31,6 +31,17 @@ import (
 // version is overridden at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
+// boardEnv reads the board number's environment variable. AEMAN_PROJECT is
+// the pre-rename name and is still honoured: "project" became aeman's own
+// planning entity, and a rename that silently stops a deployment from booting
+// is not a rename anyone should have to read release notes to survive.
+func boardEnv() string {
+	if v := os.Getenv("AEMAN_BOARD"); v != "" {
+		return v
+	}
+	return os.Getenv("AEMAN_PROJECT")
+}
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "aeman:", err)
@@ -84,7 +95,7 @@ func runServe(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	addr := fs.String("addr", "127.0.0.1:8765", "address to listen on")
 	owner := fs.String("owner", os.Getenv("AEMAN_OWNER"), "default GitHub org/user to load projects from")
-	projectDefault, _ := strconv.Atoi(os.Getenv("AEMAN_BOARD"))
+	projectDefault, _ := strconv.Atoi(boardEnv())
 	project := fs.Int("board", projectDefault, "GitHub Project number of the board to open")
 	lockBoard := fs.Bool("lock-board", os.Getenv("AEMAN_LOCK_BOARD") == "true", "pin the UI to --owner/--project and hide the board picker")
 	open := fs.Bool("open", true, "open the UI in a browser on start")
@@ -142,7 +153,7 @@ func runServe(args []string) error {
 func runMCP(args []string) error {
 	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
 	owner := fs.String("owner", os.Getenv("AEMAN_OWNER"), "default GitHub org/user")
-	projectDefault, _ := strconv.Atoi(os.Getenv("AEMAN_BOARD"))
+	projectDefault, _ := strconv.Atoi(boardEnv())
 	project := fs.Int("board", projectDefault, "GitHub Project number of the board")
 	lockBoard := fs.Bool("lock-board", os.Getenv("AEMAN_LOCK_BOARD") == "true", "pin owner/project, ignoring per-tool overrides")
 	verbose := fs.Bool("verbose", false, "enable debug logging")

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -1144,6 +1144,21 @@ func (e *boardEntry) diffNotify(old board.Board) {
 // were served a stale snapshot use it to drop their revalidation hold — the
 // data itself already arrived as the diff's ordinary events. The caller holds
 // e.mu.
+// rosterBroadcast tells every watcher that the board's STRUCTURE changed —
+// its projects, epic columns or deadlines. Those live in the board metadata
+// rather than in any card, so a client cannot learn about them from the card
+// events it is already receiving: it has to re-read /board, and this is what
+// tells it to. Sent to every watcher regardless of the view it selected,
+// because the roster is the same for all of them.
+func (e *boardEntry) rosterBroadcast() {
+	frame := watchFrame{Type: "MODIFIED", Kind: "Board", Object: map[string]string{
+		"loadedAt": e.loadedAt.UTC().Format(time.RFC3339),
+	}}
+	for sub := range e.watchers {
+		sub.send(frame)
+	}
+}
+
 func (e *boardEntry) syncBroadcast() {
 	frame := watchFrame{Type: "MODIFIED", Kind: "Sync", Object: map[string]string{
 		"loadedAt": e.loadedAt.UTC().Format(time.RFC3339),
@@ -1219,7 +1234,7 @@ func (b *storeBackend) CreateCard(ctx context.Context, bd board.Board, in board.
 				board.Deadline{Week: card.Week, Project: card.Project, ItemID: card.ItemID})
 		}
 		e.markRecent(card.ItemID)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		e.mu.Unlock()
 		return card, nil
 	}
@@ -1234,7 +1249,7 @@ func (b *storeBackend) CreateCard(ctx context.Context, bd board.Board, in board.
 			e.board.ProjectStates[card.Project] = card.ItemID
 		}
 		e.markRecent(card.ItemID)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		e.mu.Unlock()
 		return card, nil
 	}
@@ -1247,7 +1262,7 @@ func (b *storeBackend) CreateCard(ctx context.Context, bd board.Board, in board.
 			})
 		}
 		e.markRecent(card.ItemID)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		e.mu.Unlock()
 		return card, nil
 	}
@@ -1284,7 +1299,7 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 			continue
 		}
 		e.board.Epics = append(e.board.Epics[:i:i], e.board.Epics[i+1:]...)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		break
 	}
 	// ...a deleted deadline card takes its line off the grid...
@@ -1293,7 +1308,7 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 			continue
 		}
 		e.board.Deadlines = append(e.board.Deadlines[:i:i], e.board.Deadlines[i+1:]...)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		break
 	}
 	// ...and a deleted project-state card takes its chip.
@@ -1303,7 +1318,7 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 		}
 		delete(e.board.ProjectStates, project)
 		e.board.Projects = removeString(e.board.Projects, project)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 		break
 	}
 	e.cardChanged(clientIDFrom(ctx), card, "DELETED")
@@ -1428,11 +1443,11 @@ func (b *storeBackend) MoveCard(ctx context.Context, bd board.Board, card board.
 	// /board keeps serving the old order until the next revalidation.
 	if from := epicIndexOf(e.board.Epics, card.ItemID); from >= 0 {
 		e.board.Epics = moveEpicAfter(e.board.Epics, from, afterID)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 	}
 	if project, ok := nameOfState(e.board.ProjectStates, card.ItemID); ok {
 		e.board.Projects = moveNameAfter(e.board.Projects, e.board.ProjectStates, project, afterID)
-		e.syncBroadcast()
+		e.rosterBroadcast()
 	}
 	e.recentMove = time.Now()
 	e.orderingChanged(clientIDFrom(ctx))
@@ -1755,7 +1770,7 @@ func (b *storeBackend) SetWeek(ctx context.Context, bd board.Board, card board.C
 		for i := range e.board.Deadlines {
 			if e.board.Deadlines[i].ItemID == card.ItemID {
 				e.board.Deadlines[i].Week = week
-				e.syncBroadcast()
+				e.rosterBroadcast()
 				break
 			}
 		}
@@ -1796,7 +1811,7 @@ func (b *storeBackend) SetEpic(ctx context.Context, bd board.Board, card board.C
 		e.mu.Lock()
 		if i := epicIndexOf(e.board.Epics, card.ItemID); i >= 0 {
 			e.board.Epics[i].Name = epic
-			e.syncBroadcast()
+			e.rosterBroadcast()
 		}
 		e.mu.Unlock()
 		b.enqueue(ctx, e, pendingOp{
@@ -1827,13 +1842,13 @@ func (b *storeBackend) SetProject(ctx context.Context, bd board.Board, card boar
 	e.mu.Lock()
 	if i := epicIndexOf(e.board.Epics, card.ItemID); i >= 0 {
 		e.board.Epics[i].Project = project
-		e.syncBroadcast()
+		e.rosterBroadcast()
 	} else if old, ok := nameOfState(e.board.ProjectStates, card.ItemID); ok {
 		// A project-state card renamed: re-key the roster in place.
 		e.board.Projects = renameInList(e.board.Projects, old, project)
 		delete(e.board.ProjectStates, old)
 		e.board.ProjectStates[project] = card.ItemID
-		e.syncBroadcast()
+		e.rosterBroadcast()
 	} else {
 		// An ordinary card: the project is half of the column it is filed
 		// under, so it lives on the card row like any other field.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -733,6 +733,32 @@ export function App() {
       if (frame.kind === "Sync") {
         return;
       }
+      // The board's STRUCTURE changed under us — someone added a project, a
+      // column or a deadline. None of that lives in a card, so it cannot
+      // arrive as a card event: re-read the board and keep the cards we hold.
+      if (frame.kind === "Board") {
+        if (watchOwner && watchProject != null) {
+          void provider
+            .loadBoard(watchOwner, watchProject)
+            .then((fresh) =>
+              setBoard((cur) =>
+                cur
+                  ? {
+                      ...cur,
+                      teams: fresh.teams,
+                      projects: fresh.projects,
+                      epics: fresh.epics,
+                      deadlines: fresh.deadlines,
+                      members: fresh.members,
+                      sprintStates: fresh.sprintStates,
+                    }
+                  : cur,
+              ),
+            )
+            .catch(() => undefined);
+        }
+        return;
+      }
       // The write-behind queue's depth: changes applied everywhere but not
       // yet confirmed by GitHub.
       if (frame.kind === "Queue") {


### PR DESCRIPTION
## Two problems found while preparing the deploy

**1. Structure did not sync.** Cards have always streamed to everyone with the board open — verified with two tabs: marking a card done in one moved the other's counter from `2/3` to `3/3` without a reload. Projects, epic columns and deadlines did not: they live in the board metadata, not in any card, so no card event could carry them. A teammate adding a column stayed invisible until someone happened to reload — on a shared planning board, that is the difference between one plan and several.

Roster changes now emit their own watch frame, and the client re-reads the board on it while keeping the cards it holds. Re-verified with two tabs: the second picked up a new column and its rename without being touched.

**2. Prod would not have started.** The board number's environment variable became `AEMAN_BOARD`; the server's `.env` sets `AEMAN_PROJECT`, and with `AEMAN_LOCK_BOARD=true` the old name missing is not a lost default — `serve` refuses to boot. The CLI reads the old name as a fallback now, so no deployment has to read release notes to survive the upgrade.

## Testing

Go suites, golangci-lint clean, 45 web tests. The two-tab propagation was driven in headless Chrome with real events, before and after the change.
