### PR TITLE
fix(project): lanes, column reordering and the slot's controls

### DIFF
--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -225,21 +225,29 @@ export function ProjectBoard({
   const [colWidth, setColWidth] = useState<number | null>(readColWidth);
   const [resizing, setResizing] = useState<{ x: number; from: number } | null>(null);
 
-  // Dragging a column header sideways reorders the columns. Only inside a
-  // single project: across projects the columns interleave by board position,
-  // and "move this one left" would have no single meaning.
-  const colDrag = useRef<{ key: string; x: number; moved: boolean } | null>(null);
+  // Dragging a column header sideways reorders the columns. A column can
+  // always be moved among the columns of ITS OWN project — that order is what
+  // the board stores — so dragging works whatever the chips are showing; a
+  // header of another project simply is not a landing place.
+  const colDrag = useRef<{
+    key: string;
+    project: string;
+    x: number;
+    moved: boolean;
+  } | null>(null);
   const [dragCol, setDragCol] = useState<string | null>(null);
 
-  const beginColDrag = (e: React.PointerEvent, key: string) => {
-    if (
-      targetProject === null ||
-      (e.target as HTMLElement).closest("button, input, .project-col-resize")
-    ) {
+  const beginColDrag = (e: React.PointerEvent, col: EpicRef) => {
+    if ((e.target as HTMLElement).closest("button, input, .project-col-resize")) {
       return;
     }
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    colDrag.current = { key, x: e.clientX, moved: false };
+    colDrag.current = {
+      key: colKey(col.project, col.name),
+      project: col.project,
+      x: e.clientX,
+      moved: false,
+    };
   };
 
   const moveColDrag = (e: React.PointerEvent) => {
@@ -255,7 +263,10 @@ export function ProjectBoard({
       setDragCol(d.key);
     }
     const over = epicAt(e.clientX);
-    if (!over) {
+    // Only among its own project's columns: dropping a column into another
+    // project's run of columns would be a move between projects, which is a
+    // different action with its own menu entry.
+    if (!over || over.project !== d.project) {
       return;
     }
     const keys = epics.map((x) => colKey(x.project, x.name));
@@ -273,12 +284,14 @@ export function ProjectBoard({
     const d = colDrag.current;
     colDrag.current = null;
     setDragCol(null);
-    if (!d?.moved || targetProject === null) {
+    if (!d?.moved) {
       return;
     }
-    const names = epics.map((x) => x.name);
+    // Only this project's columns are persisted — the others keep the order
+    // the board already has for them.
+    const names = epics.filter((x) => x.project === d.project).map((x) => x.name);
     void provider
-      .reorderEpics(board, targetProject, names)
+      .reorderEpics(board, d.project, names)
       .then(reload)
       .catch((err: unknown) => {
         setOrder(null); // put the board's own order back on screen
@@ -1136,19 +1149,20 @@ export function ProjectBoard({
           return (
             <div
               key={k}
-              className={`project-epic-head${dragCol === k ? " project-epic-head-dragging" : ""}${
-                targetProject !== null ? " project-epic-head-movable" : ""
+              className={`project-epic-head project-epic-head-movable${
+                dragCol === k ? " project-epic-head-dragging" : ""
               }`}
-              title={`${e.name} — ${e.project || "no project"} · double-click to rename${
-                targetProject !== null ? " · drag to reorder" : ""
-              }`}
+              title={`${e.name} — ${e.project || "no project"} · double-click to rename · drag to reorder`}
               onDoubleClick={() => setRenaming(k)}
-              onPointerDown={(ev) => beginColDrag(ev, k)}
+              onPointerDown={(ev) => beginColDrag(ev, e)}
               onPointerMove={moveColDrag}
               onPointerUp={endColDrag}
               onPointerCancel={() => {
+                // A cancelled gesture must not leave the preview standing:
+                // the board's own order is the truth again.
                 colDrag.current = null;
                 setDragCol(null);
+                setOrder(null);
               }}
             >
               <span className="project-epic-name">{e.name}</span>

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -165,10 +165,34 @@ export function ProjectBoard({
   // other derived list follows from this one, so a column and its cards can
   // never disagree about being visible. A column is the (project, name) PAIR —
   // "Docs" exists in every project and they are different columns.
-  const epics = useMemo(
-    () => board.epics.filter((e) => !filter || filter.includes(e.project)),
-    [board.epics, filter],
-  );
+  // While a column is being dragged — and until the server's order catches
+  // up — this is the order the columns are drawn in. Null means "the board's".
+  const [order, setOrder] = useState<string[] | null>(null);
+
+  const epics = useMemo(() => {
+    const shown = board.epics.filter((e) => !filter || filter.includes(e.project));
+    if (!order) {
+      return shown;
+    }
+    const at = (e: EpicRef) => {
+      const i = order.indexOf(colKey(e.project, e.name));
+      return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+    };
+    return [...shown].sort((a, b) => at(a) - at(b));
+  }, [board.epics, filter, order]);
+
+  // The board caught up (or the columns changed under us): stop overriding.
+  useEffect(() => {
+    if (!order) {
+      return;
+    }
+    const live = board.epics
+      .filter((e) => !filter || filter.includes(e.project))
+      .map((e) => colKey(e.project, e.name));
+    if (live.length === order.length && live.every((k, i) => k === order[i])) {
+      setOrder(null);
+    }
+  }, [board.epics, filter, order]);
 
   // Columns belonging to no project are reachable through a "No project" chip
   // — but only while such a column exists, so the chip never sits there as a
@@ -200,6 +224,67 @@ export function ProjectBoard({
   // a grid and columns of assorted widths stop being comparable.
   const [colWidth, setColWidth] = useState<number | null>(readColWidth);
   const [resizing, setResizing] = useState<{ x: number; from: number } | null>(null);
+
+  // Dragging a column header sideways reorders the columns. Only inside a
+  // single project: across projects the columns interleave by board position,
+  // and "move this one left" would have no single meaning.
+  const colDrag = useRef<{ key: string; x: number; moved: boolean } | null>(null);
+  const [dragCol, setDragCol] = useState<string | null>(null);
+
+  const beginColDrag = (e: React.PointerEvent, key: string) => {
+    if (
+      targetProject === null ||
+      (e.target as HTMLElement).closest("button, input, .project-col-resize")
+    ) {
+      return;
+    }
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    colDrag.current = { key, x: e.clientX, moved: false };
+  };
+
+  const moveColDrag = (e: React.PointerEvent) => {
+    const d = colDrag.current;
+    if (!d) {
+      return;
+    }
+    if (!d.moved) {
+      if (Math.abs(e.clientX - d.x) < DRAG_SLOP) {
+        return;
+      }
+      d.moved = true;
+      setDragCol(d.key);
+    }
+    const over = epicAt(e.clientX);
+    if (!over) {
+      return;
+    }
+    const keys = epics.map((x) => colKey(x.project, x.name));
+    const from = keys.indexOf(d.key);
+    const to = keys.indexOf(colKey(over.project, over.name));
+    if (from === -1 || to === -1 || from === to) {
+      return;
+    }
+    const next = [...keys];
+    next.splice(to, 0, ...next.splice(from, 1));
+    setOrder(next);
+  };
+
+  const endColDrag = () => {
+    const d = colDrag.current;
+    colDrag.current = null;
+    setDragCol(null);
+    if (!d?.moved || targetProject === null) {
+      return;
+    }
+    const names = epics.map((x) => x.name);
+    void provider
+      .reorderEpics(board, targetProject, names)
+      .then(reload)
+      .catch((err: unknown) => {
+        setOrder(null); // put the board's own order back on screen
+        onError(errText(err));
+      });
+  };
 
   const beginResize = (e: React.PointerEvent) => {
     e.preventDefault();
@@ -1051,9 +1136,20 @@ export function ProjectBoard({
           return (
             <div
               key={k}
-              className="project-epic-head"
-              title={`${e.name} — ${e.project || "no project"} · double-click to rename`}
+              className={`project-epic-head${dragCol === k ? " project-epic-head-dragging" : ""}${
+                targetProject !== null ? " project-epic-head-movable" : ""
+              }`}
+              title={`${e.name} — ${e.project || "no project"} · double-click to rename${
+                targetProject !== null ? " · drag to reorder" : ""
+              }`}
               onDoubleClick={() => setRenaming(k)}
+              onPointerDown={(ev) => beginColDrag(ev, k)}
+              onPointerMove={moveColDrag}
+              onPointerUp={endColDrag}
+              onPointerCancel={() => {
+                colDrag.current = null;
+                setDragCol(null);
+              }}
             >
               <span className="project-epic-name">{e.name}</span>
               {(colProgress.get(k)?.total ?? 0) > 0 && (

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -865,22 +865,35 @@ export function ProjectBoard({
       });
       byCol.set(k, list);
     }
-    // Interval partitioning per column: earliest first, each card taking the
-    // first lane already free by the week it starts.
+    // Lanes are worked out per CLUSTER of overlapping slots, not per column:
+    // splitting the whole column because two slots happen to share a fortnight
+    // would leave every unrelated card at half width for no reason.
     for (const list of byCol.values()) {
       list.sort((a, b) => a.row - b.row || b.span - a.span);
-      const laneEnd: number[] = [];
+      let cluster: typeof list = [];
+      let laneEnd: number[] = [];
+      const close = () => {
+        for (const s of cluster) {
+          s.lanes = laneEnd.length;
+        }
+        cluster = [];
+        laneEnd = [];
+      };
       for (const s of list) {
+        // A slot that begins after everything so far has ended starts a new
+        // cluster: it shares its weeks with nothing before it.
+        if (laneEnd.length && s.row >= Math.max(...laneEnd)) {
+          close();
+        }
         let lane = laneEnd.findIndex((end) => end <= s.row);
         if (lane === -1) {
           lane = laneEnd.length;
         }
         laneEnd[lane] = s.row + s.span;
         s.lane = lane;
+        cluster.push(s);
       }
-      for (const s of list) {
-        s.lanes = laneEnd.length;
-      }
+      close();
     }
     return byCol;
   }, [cards, weeks, draft]);
@@ -1333,6 +1346,17 @@ export function ProjectBoard({
                 onClose={() => setTeamMenu(null)}
                 className="card-stage-menu"
               >
+                <button
+                  type="button"
+                  className="card-stage-item project-menu-lead"
+                  onClick={() => setDone(card, !complete(card))}
+                >
+                  <span
+                    className="card-stage-dot"
+                    style={{ background: STAGES.done.color }}
+                  />
+                  {complete(card) ? "Reopen" : "Mark as done"}
+                </button>
                 {/* The roster carries "" for the no-team group; the explicit
                     "No team" entry below is that, so skip the blank one. */}
                 {board.teams.filter((t) => t !== "").map((t) => (
@@ -1356,17 +1380,6 @@ export function ProjectBoard({
                 >
                   <span className="card-stage-dot card-stage-dot-none" />
                   No team
-                </button>
-                <button
-                  type="button"
-                  className="card-stage-item card-stage-clear"
-                  onClick={() => setDone(card, !complete(card))}
-                >
-                  <span
-                    className="card-stage-dot"
-                    style={{ background: STAGES.done.color }}
-                  />
-                  {complete(card) ? "Reopen" : "Mark as done"}
                 </button>
               </Dropdown>
               <div

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -389,6 +389,14 @@ export const apiProvider: Provider = {
     await api(board, "POST", "/epics/actions/rename", { project, epic, to });
   },
 
+  async reorderEpics(
+    board: BoardAddr,
+    project: string,
+    epics: string[],
+  ): Promise<void> {
+    await api(board, "POST", "/epics/actions/reorder-epics", { project, epics });
+  },
+
   async setEpicProject(
     board: BoardAddr,
     from: string,

--- a/web/src/providers/types.ts
+++ b/web/src/providers/types.ts
@@ -280,6 +280,12 @@ export interface Provider {
     epic: string,
     to: string,
   ): Promise<void>;
+  /** Apply one project's column order (moves the hidden epic-state cards). */
+  reorderEpics(
+    board: BoardAddr,
+    project: string,
+    epics: string[],
+  ): Promise<void>;
   /** Move a column between projects ("" detaches it from every project). */
   setEpicProject(
     board: BoardAddr,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3177,6 +3177,19 @@ button.card-age {
   box-shadow: -40px 0 0 var(--bg);
 }
 
+/* A header can be dragged sideways to reorder the columns (inside one
+   project). The grip on its right edge still resizes, and the × still
+   deletes — both stop the press before it becomes a drag. */
+.project-epic-head-movable {
+  cursor: grab;
+}
+
+.project-epic-head-dragging {
+  cursor: grabbing;
+  background: var(--hover-overlay);
+  opacity: 0.85;
+}
+
 .project-epic-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3301,12 +3301,6 @@ button.card-age {
   opacity: 0.7;
 }
 
-/* A menu row that only explains why there is nothing to pick. */
-.project-menu-hint {
-  color: var(--muted);
-  cursor: default;
-}
-
 /* How far along the columns are: a percentage beside each header, and one
    wide bar under the table for the whole view. */
 .project-epic-pct {
@@ -3421,6 +3415,13 @@ button.card-age {
   margin-left: auto;
   padding: 2px 10px;
   font-size: 12px;
+}
+
+/* The row that leads a menu, separated from the list beneath it. */
+.project-menu-lead {
+  border-bottom: 1px solid var(--line-soft);
+  margin-bottom: 1px;
+  border-radius: 4px 4px 0 0;
 }
 
 /* A menu row that only explains why there is nothing to pick. */
@@ -3579,10 +3580,10 @@ button.card-age {
    above the badge's grown hit area so it stays reachable. */
 .project-slot-actions {
   position: absolute;
-  /* Beside the owner badge, on the slot's top row: sitting on top of the badge
-     made it impossible to press, and drifting to the bottom edge parted it
-     from the controls it belongs with. */
-  right: 19px;
+  /* Beside the owner badge, on the slot's top row. The badge is 15px wide
+     inside 5px of padding, so anything left of 20px overlaps it — and a badge
+     under the delete button cannot be pressed. */
+  right: 23px;
   top: 2px;
   z-index: 3;
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3602,9 +3602,6 @@ button.card-age {
   display: flex;
   gap: 2px;
   opacity: 0;
-  border-radius: 4px;
-  background: var(--bg);
-  box-shadow: 0 0 3px 3px var(--bg);
 }
 
 .project-slot:hover .project-slot-actions {


### PR DESCRIPTION
Six things found while the Project board met its first real plan — the roadmap spreadsheet, 21 columns and 128 slots.

- **Lanes are per overlap, not per column.** A column split its whole width the moment any two slots shared a fortnight, so every unrelated card in it went to half width. Lanes are worked out per cluster of overlapping slots now.
- **Columns reorder by dragging their header.** The order was fixed at creation and only the REST endpoint could change it — nothing in the board could. The grid reorders live under the pointer and the release persists it, the way the team roster does. A column moves among its own project's columns, so it works whatever the chips are showing; a cancelled gesture puts the board's own order back instead of leaving the preview standing.
- **Delete clears the owner badge.** The button sat on top of it (the badge is 15px inside 5px of padding), which made the badge unpressable — and on an unassigned card, impossible to find. It also loses the halo it was painted on: no longer needed, and on a tinted card it read as a hole.
- **"Mark as done" leads the badge menu** instead of being buried under the team list.

## Testing

Go suites, 45 web tests. Every change was driven in headless Chrome against the real board: the lane widths across all 21 columns of the imported plan, the reorder (live preview, persisted order, and a cancel that reverts) and the delete/badge geometry. The reorder checks against the live board were run read-only — the gesture was cancelled, never released.
