### PR TITLE
fix(project): name the first column where you asked for it

### DIFF
--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -1053,7 +1053,11 @@ export function ProjectBoard({
   // in its body. An early return here used to leave the shared furniture — the
   // chip row, the manage dialog — out of the empty state, where they are
   // exactly what a person needs to get started.
-  const empty = epics.length === 0 && !addingEpic;
+  // A board with no columns stays on the empty state even while the first one
+  // is being named: the field belongs there, in the middle of the screen.
+  // Flipping to the grid put it in the 34px gutter beside a table that does
+  // not exist yet — six pixels tall, in the far corner.
+  const empty = epics.length === 0;
 
   return (
     <div className="project" ref={wrapRef}>
@@ -1084,13 +1088,32 @@ export function ProjectBoard({
               Start with a project — “manage” above adds one.
             </p>
           ) : targetProject !== null ? (
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={() => setAddingEpic(true)}
-            >
-              + Add the first epic{targetProject ? ` of ${targetProject}` : ""}
-            </button>
+            addingEpic ? (
+              <input
+                type="text"
+                className="add-card-input project-empty-input"
+                autoFocus
+                placeholder={
+                  targetProject ? `Epic in ${targetProject}…` : "Epic with no project…"
+                }
+                onKeyDown={(ev) => {
+                  if (ev.key === "Enter") {
+                    addEpic((ev.target as HTMLInputElement).value);
+                  } else if (ev.key === "Escape") {
+                    setAddingEpic(false);
+                  }
+                }}
+                onBlur={(ev) => addEpic(ev.target.value)}
+              />
+            ) : (
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => setAddingEpic(true)}
+              >
+                + Add the first epic{targetProject ? ` of ${targetProject}` : ""}
+              </button>
+            )
           ) : (
             <p className="project-empty-hint">
               Pick one project above to add its first epic.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3443,6 +3443,15 @@ button.card-age {
   cursor: default;
 }
 
+/* Naming the first column: a plain field in the middle of the empty board. */
+.project-empty-input {
+  width: 260px;
+  max-width: 70vw;
+  font-size: 13px;
+  padding: 6px 10px;
+  text-align: center;
+}
+
 .project-empty-hint {
   color: var(--muted);
   font-size: 13px;


### PR DESCRIPTION
Pressing **add the first epic** swapped the empty board for the grid, and the field went with it — into the 34px "add a column" gutter beside a table that does not exist yet. Measured: 180px wide, **6px tall**, in the far bottom-right corner.

A board with no columns now stays on its empty state while the first column is named, and the field is an ordinary one (260×29) in the middle of the screen. The gutter field is unchanged for every column after the first, where there is a table for it to sit beside.

## Testing

Reproduced and re-checked in headless Chrome against a project with no columns: the field's geometry before and after, then the whole flow — typing a name creates the column, the grid replaces the empty state, and the next column still goes through the gutter field.
