### PR TITLE
fix(project): a slot's week follows its dates

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,8 @@ The HTTP API takes them as query parameters (`?owner=acme&board=7`), falling bac
 
 A project also carries **deadlines**: a line across the grid on a given week. One project holds at most one per week, so dragging one of its lines onto another merges them — but two projects can each have something due the same week, and those are two lines.
 
+A slot's **row is the week of its `dates.start`** — always derived, never stored beside the dates where the two could drift. `plan.week` belongs to weekly-plan cards (those created with a band and no dates); setting it on a card filed under an epic is refused (422).
+
 A **column** of the Project board is the pair `(project, epic)`. Epic names are unique only *within* a project, so every project can have its own `Docs` or `Auth`, and a card names both halves. Anything acting on a column — filing a card, deleting, renaming, reordering — names both.
 
 When started with `--lock-board` (or `AEMAN_LOCK_BOARD=1`), aeman pins the board to its configured `--owner`/`--board` and ignores any client-supplied owner/board. Use this when exposing aeman to clients that must not roam across boards.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -364,8 +364,8 @@ type createCardRequest struct {
 		Week string `json:"week"`
 	} `json:"plan"`
 	// Epic + Project file the card on the Project board, under the column that
-	// pair identifies (its week defaults to the Monday of dates.start; dates
-	// may span several weeks).
+	// pair identifies. Its row is the week of dates.start — plan.week is for
+	// weekly-plan cards and is ignored here — and dates may span weeks.
 	Epic           string `json:"epic"`
 	CardProject    string `json:"project"`
 	ReviewOf       string `json:"reviewOf"`
@@ -1445,7 +1445,8 @@ func (s *Server) apiError(w http.ResponseWriter, r *http.Request, err error) {
 		errors.Is(err, boardservice.ErrEpicNotFound),
 		errors.Is(err, boardservice.ErrProjectInUse),
 		errors.Is(err, boardservice.ErrProjectExists),
-		errors.Is(err, boardservice.ErrProjectNotFound):
+		errors.Is(err, boardservice.ErrProjectNotFound),
+		errors.Is(err, boardservice.ErrWeekDerived):
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 	default:
 		writeJSONError(w, http.StatusBadGateway, err.Error())

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -326,6 +326,16 @@ func NewBoard(fields []ProjectField, cards []Card) Board {
 		}
 		b.Cards = append(b.Cards, c)
 	}
+	// A slot's row is its START date's week, never a week stored beside it.
+	// The two used to be written separately, so editing a card's dates left it
+	// sitting in the week it was created in — the board said one thing and the
+	// card's own dates said another. Deriving here makes every reader agree at
+	// once, and the stored field converges as cards are written.
+	for i := range b.Cards {
+		if b.Cards[i].Epic != "" && b.Cards[i].StartDate != "" {
+			b.Cards[i].Week = MondayOf(b.Cards[i].StartDate)
+		}
+	}
 	// A card can name an epic without naming a project: it predates the pair,
 	// or someone set the Epic field straight in the GitHub UI. When exactly one
 	// column bears that name it can only be that one, so it is adopted on READ

--- a/pkg/boardservice/epics.go
+++ b/pkg/boardservice/epics.go
@@ -18,6 +18,11 @@ var ErrEpicInUse = errors.New("epic still has cards")
 // repeat across projects on purpose — every project has its own "Docs".
 var ErrEpicExists = errors.New("epic already exists")
 
+// ErrWeekDerived is setting the week of a Project-board slot by hand: it is
+// derived from the card's start date, so there is nothing to set. A rejected
+// input (422), not an upstream failure.
+var ErrWeekDerived = errors.New("a slot's week is derived from its dates")
+
 // ErrEpicNotFound is filing a card under a column that does not exist — a
 // typo must not mint a phantom column the way a stray team value used to
 // mint a team. It is a rejected input (422), not an upstream failure.

--- a/pkg/boardservice/epics_test.go
+++ b/pkg/boardservice/epics_test.go
@@ -467,3 +467,104 @@ func TestDeadlines(t *testing.T) {
 		t.Fatalf("the deleted line is still there: %+v", b.Deadlines)
 	}
 }
+
+// The row of a Project-board slot is its start date's week — always, and
+// without anyone having to say so twice. This is the bug that prompted the
+// rule: cards created in one week, re-dated to another, stayed in the row they
+// were created in because the week was a second value nobody updated.
+func TestSlotWeekFollowsItsStart(t *testing.T) {
+	fake := epicBoard()
+	svc := New(fake)
+	ctx := context.Background()
+	card, err := svc.CreateCard(ctx, "acme", 1, CreateCardArgs{
+		Title: "Workshop", Epic: "Infra", Project: "Cozystack",
+		Start: "2026-08-24", Day: "2026-08-28",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Week != "2026-08-24" {
+		t.Fatalf("created week = %q, want the start's Monday", card.Week)
+	}
+
+	// Re-date it to an earlier week: the row must move with the dates.
+	if err := svc.SetDates(ctx, "acme", 1, card.ItemID, "2026-08-06", "2026-08-06"); err != nil {
+		t.Fatal(err)
+	}
+	got := fake.get(card.ItemID)
+	if got.Week != "2026-08-03" {
+		t.Fatalf("week = %q, want the Monday of 2026-08-06", got.Week)
+	}
+	// ...and re-dating a plan slot must not drag it into a sprint.
+	if got.SprintStart != "" {
+		t.Fatalf("a slot that was never taken into work joined sprint %q", got.SprintStart)
+	}
+
+	// The same through the single-date path.
+	if err := svc.SetStart(ctx, "acme", 1, card.ItemID, "2026-09-16"); err != nil {
+		t.Fatal(err)
+	}
+	if got := fake.get(card.ItemID); got.Week != "2026-09-14" {
+		t.Fatalf("week = %q after SetStart, want 2026-09-14", got.Week)
+	}
+}
+
+// Setting a slot's week by hand is refused: there is nothing to set, and
+// accepting a value here is how the two came to disagree. A weekly-plan card
+// — which has no dates at all — still moves between weeks.
+func TestSlotWeekIsNotSettable(t *testing.T) {
+	today := board.TodayIso()
+	fake := newFake([]board.Card{
+		{ItemID: "p1", Title: board.ProjectStateTitle, Project: "Cozystack"},
+		{ItemID: "e1", Title: board.EpicStateTitle, Epic: "Infra", Project: "Cozystack"},
+		{ItemID: "slot", Title: "a slot", Epic: "Infra", Project: "Cozystack",
+			StartDate: "2026-08-24", Day: "2026-08-28", Week: "2026-08-24"},
+		{ItemID: "plan", Title: "a weekly-plan card", Team: "alpha",
+			Plan: board.PlanFri, Week: board.MondayOf(today)},
+	}, map[string]board.SprintState{"alpha": {Current: today, ItemID: "s1"}})
+	svc := New(fake)
+	ctx := context.Background()
+
+	err := svc.SetWeek(ctx, "acme", 1, "slot", "2026-09-07")
+	if !errors.Is(err, ErrWeekDerived) {
+		t.Fatalf("SetWeek on a slot = %v, want ErrWeekDerived", err)
+	}
+	if got := fake.get("slot"); got.Week != "2026-08-24" {
+		t.Fatalf("the refused write still landed: week = %q", got.Week)
+	}
+	if err := svc.SetWeek(ctx, "acme", 1, "plan", "2026-09-07"); err != nil {
+		t.Fatalf("a weekly-plan card must still move between weeks: %v", err)
+	}
+	if got := fake.get("plan"); got.Week != "2026-09-07" {
+		t.Fatalf("plan card week = %q", got.Week)
+	}
+}
+
+// A board read repairs the rows of cards written before the rule, so nobody
+// has to migrate anything: the dates are the truth, whatever is stored.
+func TestBoardRepairsStaleSlotWeeks(t *testing.T) {
+	b := board.NewBoard(nil, []board.Card{
+		{ItemID: "p1", Title: board.ProjectStateTitle, Project: "P"},
+		{ItemID: "e1", Title: board.EpicStateTitle, Epic: "E", Project: "P"},
+		// Written by the old code: dates moved, the week stayed behind.
+		{ItemID: "c1", Title: "stale", Epic: "E", Project: "P",
+			StartDate: "2026-08-06", Day: "2026-08-07", Week: "2026-08-24"},
+		// No start at all: nothing to derive from, so the week stands.
+		{ItemID: "c2", Title: "dateless", Epic: "E", Project: "P", Week: "2026-08-24"},
+		// Not a slot: a weekly-plan card keeps its own week.
+		{ItemID: "c3", Title: "plan", Plan: board.PlanFri, Week: "2026-08-24"},
+	})
+	byID := map[string]board.Card{}
+	for _, c := range b.Cards {
+		byID[c.ItemID] = c
+	}
+	if got := byID["c1"].Week; got != "2026-08-03" {
+		t.Fatalf("stale slot week = %q, want the Monday of its start", got)
+	}
+	if got := byID["c2"].Week; got != "2026-08-24" {
+		t.Fatalf("a slot with no start keeps its week, got %q", got)
+	}
+	if got := byID["c3"].Week; got != "2026-08-24" {
+		t.Fatalf("a weekly-plan card must be left alone, got %q", got)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -404,10 +404,9 @@ func (s *Service) createEpicCard(ctx context.Context, b board.Board, args Create
 	if day == "" {
 		day = start
 	}
-	week := args.Week
-	if week == "" {
-		week = board.MondayOf(start)
-	}
+	// The row is the start's week, full stop: an explicit week here would be
+	// a second value free to disagree with the dates the moment either moves.
+	week := board.MondayOf(start)
 	card, err := s.backend.CreateCard(ctx, b, board.CreateInput{
 		Title:    args.Title,
 		Zone:     args.Zone,
@@ -920,6 +919,11 @@ func (s *Service) SetDates(ctx context.Context, owner string, project int, itemI
 			}
 		}
 	}
+	// A Project-board slot that has not been taken into work stays out of the
+	// sprints: re-dating a plan is planning, not starting the work.
+	if c.Epic != "" && c.SprintStart == "" {
+		sprint = ""
+	}
 	if err := s.backend.SetStart(ctx, b, c, start); err != nil {
 		return err
 	}
@@ -927,6 +931,9 @@ func (s *Service) SetDates(ctx context.Context, owner string, project int, itemI
 		return err
 	}
 	if err := s.backend.SetDay(ctx, b, c, end); err != nil {
+		return err
+	}
+	if err := s.syncSlotWeek(ctx, b, c, start); err != nil {
 		return err
 	}
 	s.logEvent(ctx, b, c, board.EventDates,
@@ -1376,6 +1383,24 @@ func (s *Service) SetDay(ctx context.Context, owner string, project int, itemID,
 	return nil
 }
 
+// syncSlotWeek keeps a Project-board slot's row under its start date. The week
+// is not a second thing to set: it IS the start's week, and a card whose dates
+// moved while its week stayed behind sat in a row its own dates contradicted.
+func (s *Service) syncSlotWeek(ctx context.Context, b board.Board, c board.Card, start string) error {
+	if c.Epic == "" || start == "" {
+		return nil
+	}
+	week := board.MondayOf(start)
+	if week == c.Week {
+		return nil
+	}
+	if err := s.backend.SetWeek(ctx, b, c, week); err != nil {
+		return err
+	}
+	s.logEvent(ctx, b, c, board.EventWeek, c.Week, week)
+	return nil
+}
+
 // SetStart sets a card's start date (date = "" clears it).
 func (s *Service) SetStart(ctx context.Context, owner string, project int, itemID, date string) error {
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
@@ -1383,6 +1408,9 @@ func (s *Service) SetStart(ctx context.Context, owner string, project int, itemI
 		return err
 	}
 	if err := s.backend.SetStart(ctx, b, card, date); err != nil {
+		return err
+	}
+	if err := s.syncSlotWeek(ctx, b, card, date); err != nil {
 		return err
 	}
 	s.logEvent(ctx, b, card, board.EventDates,
@@ -1428,10 +1456,16 @@ func (s *Service) SetPlan(ctx context.Context, owner string, project int, itemID
 }
 
 // SetWeek sets a card's plan week, a Monday (week = "" clears it).
+// SetWeek moves a WEEKLY-PLAN card to another week. A Project-board slot is
+// refused: its week comes from its start date, and accepting a second value
+// here is exactly how the two came to disagree.
 func (s *Service) SetWeek(ctx context.Context, owner string, project int, itemID, week string) error {
 	b, card, err := s.loadCard(ctx, owner, project, itemID)
 	if err != nil {
 		return err
+	}
+	if card.Epic != "" {
+		return fmt.Errorf("%w: a slot's week follows its start date — move the dates instead", ErrWeekDerived)
 	}
 	if err := s.backend.SetWeek(ctx, b, card, week); err != nil {
 		return err

--- a/pkg/mcpserver/tools.go
+++ b/pkg/mcpserver/tools.go
@@ -195,7 +195,7 @@ type createCardInput struct {
 	End      string `json:"end,omitempty" jsonschema:"end/due day as yyyy-mm-dd; defaults to start, else today"`
 	Sprint   string `json:"sprint,omitempty" jsonschema:"sprint start day the card joins; defaults to the team's current sprint"`
 	Plan     string `json:"plan,omitempty" jsonschema:"weekly-plan band, wed or fri: creates a plan card with no dates instead of a day card"`
-	Week     string `json:"week,omitempty" jsonschema:"plan week Monday as yyyy-mm-dd; defaults to the current week (plan cards only)"`
+	Week     string `json:"week,omitempty" jsonschema:"WEEKLY-PLAN cards only (those created with plan=wed|fri): the plan week's Monday as yyyy-mm-dd, defaulting to the current week. A card filed under an epic ignores it — the slot's row is the week of its start date"`
 	Epic     string `json:"epic,omitempty" jsonschema:"Project-board column to file the card under, together with project. MUST be an EXISTING column — read them from get_board metadata.epics; add_epic creates one when the user explicitly asks. The card's week is its row; start/end dates may span several weeks"`
 	Project  string `json:"project,omitempty" jsonschema:"the project half of the column named by epic (columns are the (project, epic) pair — epic names repeat across projects)"`
 	ReviewOf string `json:"reviewOf,omitempty" jsonschema:"uid of the card this one reviews"`
@@ -253,7 +253,7 @@ type updateCardInput struct {
 	Epic        *string `json:"epic,omitempty" jsonschema:"Project-board column to file the card under; empty clears it. MUST be an EXISTING column from get_board metadata.epics — and columns are identified by the (project, epic) pair, so pass project too unless the card is already in the right project"`
 	Project     *string `json:"project,omitempty" jsonschema:"the project half of the card's column (see epic). Epic names repeat across projects, so filing a card into another project's column needs both"`
 	PlanBand    *string `json:"planBand,omitempty" jsonschema:"weekly-plan band, wed or fri; empty clears it"`
-	PlanWeek    *string `json:"planWeek,omitempty" jsonschema:"plan week Monday as yyyy-mm-dd; empty clears it"`
+	PlanWeek    *string `json:"planWeek,omitempty" jsonschema:"WEEKLY-PLAN cards only: the plan week's Monday as yyyy-mm-dd, empty clears it. A Project-board slot (a card with an epic) refuses it — its week IS its start date's week, so move the dates instead and the row follows"`
 	ReviewOf    *string `json:"reviewOf,omitempty" jsonschema:"uid of the card this one reviews; empty breaks the link"`
 	Parent      *string `json:"parent,omitempty" jsonschema:"uid of the card to group this one under as a subtask (one level deep; empty ungroups it back to a standalone card); a subtask keeps its own description/notes/log, feeds the parent's derived progress and rides with it through carry-over"`
 }

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -609,7 +609,7 @@ export function ProjectBoard({
       .patchCard(board, card.itemId, {
         epic: epic.name,
         project: epic.project,
-        plan: { week },
+        // No plan.week: the server takes the row from dates.start.
         dates: { start: week, end },
       })
       .then(addCard)
@@ -791,7 +791,7 @@ export function ProjectBoard({
     void provider
       .patchCard(board, card.itemId, {
         team: team ?? "",
-        ...(team && !card.plan ? { plan: { band: "fri", week: card.week ?? "" } } : {}),
+        ...(team && !card.plan ? { plan: { band: "fri" } } : {}),
       })
       .then(addCard)
       .catch((err: unknown) => {
@@ -974,10 +974,13 @@ export function ProjectBoard({
       return byCol;
     }
     for (const c of cards) {
-      if (!c.epic || !c.week) {
+      // The row is the START date's week. A card's own stored week is only a
+      // fallback for one that has no start at all.
+      const from = c.startDate || c.week;
+      if (!c.epic || !from) {
         continue;
       }
-      const anchor = mondayOf(c.week);
+      const anchor = mondayOf(from);
       const row = weeksBetween(weeks[0], anchor);
       if (row < 0 || row >= weeks.length) {
         continue;

--- a/web/src/providers/api/apiProvider.ts
+++ b/web/src/providers/api/apiProvider.ts
@@ -227,9 +227,7 @@ export const apiProvider: Provider = {
     if (input.epic) {
       body.epic = input.epic;
       body.project = input.project ?? "";
-      if (input.week) {
-        body.plan = { band: "", week: input.week };
-      }
+      // No plan.week: a slot's row is the week of its start date.
     }
     if (input.startNewSprint !== undefined) {
       body.startNewSprint = input.startNewSprint;


### PR DESCRIPTION
## The bug

A card had two places saying which week it sits in — its `dates.start` and `plan.week` — and only one of them moved when someone re-dated the card. Cards created in one week and re-dated to another stayed in the row they were created in: the board showed a plan its own cards contradicted, and the remedy was to remember to move a second field by hand.

## The rule

**A slot's row is the week of its start date.** Derived on create, on every date write, and on read.

Deriving *on read* means a board written by the old code repairs itself the moment it is loaded — no migration, and no stale rows waiting for someone to touch each card. The stored field converges as cards are written. A slot with no start at all keeps whatever week it has: there is nothing to derive from.

Setting the week by hand on a card filed under an epic is refused with `422` rather than silently diverging again.

## What happens to `plan.week` — the question in the brief

**It stays, for weekly-plan cards only.** Those are created with a band (`wed`/`fri`) and no dates at all, so their week is the only thing that places them — `WeeklyPlan` matches on it, and deleting the field would take the Me/Team weekly plan with it. They still move between weeks exactly as before (`carry_week` included).

So the field is not removed; it stops being an *input* for slots. On the MCP surface `create_card`'s `week` is ignored for a card with an epic, and `update_card`'s `planWeek` is refused for one; both schemas now say where a slot's week comes from. The UI stopped sending it: moving a slot patches dates alone, and assigning a team sends the band alone.

## One more thing found on the way

Re-dating a slot dragged it into a sprint — `SetDates` computed the active sprint for any card. A plan slot that was never taken into work now stays out of the sprints: planning is not starting the work, and only a card taken into work belongs on a day board.

## Testing

- `TestSlotWeekFollowsItsStart` — the reported scenario: create in one week, re-date to another, the row moves (through both the dates and the single-date path), and no sprint is acquired.
- `TestSlotWeekIsNotSettable` — a slot refuses an explicit week and keeps the one it had; a weekly-plan card still moves between weeks.
- `TestBoardRepairsStaleSlotWeeks` — a board written by the old code comes back repaired, a slot with no start is left alone, and a weekly-plan card is untouched.
- Go suites, golangci-lint clean, 45 web tests. End-to-end against a running server: created 24 Aug → re-dated to 6 Aug → week became 3 Aug with no sprint; `plan.week` by hand answered 422; assigning a team still works.
