### PR TITLE
fix(project): yellow means the work started, not that it has an owner

### DIFF
--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -96,7 +96,11 @@ function slotTone(card: CardModel, today: string): string {
     return "project-slot-done";
   }
   const late = !!card.day && card.day < today;
-  const taken = (card.assignees?.length ?? 0) > 0;
+  // Taken into WORK, not merely assigned: a plan names its owners months
+  // ahead, so an assignee alone would paint the whole roadmap yellow and say
+  // nothing. A slot joins a sprint (or moves off zero) when the work actually
+  // starts — that is the board's own line between planned and underway.
+  const taken = (card.progress ?? 0) > 0 || !!card.sprintStart;
   if (late) {
     return taken ? "project-slot-late-taken" : "project-slot-late";
   }


### PR DESCRIPTION
A plan names its owners months ahead, so colouring a slot by "has an assignee" painted whole roadmaps yellow and said nothing — every workshop of the autumn read as *in work* back in August.

A slot is underway when it joins a sprint or moves off zero progress. That is the board's own line between planned and started — the same line that keeps an untouched slot off the day boards — and it is what takes the colour now. Assignment alone is planning.

## Testing

Checked against the real board's `marketing / workshops`: the two workshops already held are green, the twenty still ahead are plain. Go suites, 45 web tests.
