### PR TITLE
fix(project): the weekly plan, a slow roster, and two things the board would not let you do

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1068,6 +1068,11 @@ func (s *Server) handleAddEpic(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.AddEpic(r.Context(), owner, boardNum, in.Name, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1090,6 +1095,11 @@ func (s *Server) handleSetEpicProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.SetEpicProject(r.Context(), owner, boardNum, in.From, in.Epic, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1112,6 +1122,11 @@ func (s *Server) handleRenameEpic(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.RenameEpic(r.Context(), owner, boardNum, in.Project, in.Epic, in.To); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1133,6 +1148,11 @@ func (s *Server) handleRenameProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.RenameProject(r.Context(), owner, boardNum, in.Project, in.To); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1167,6 +1187,11 @@ func (s *Server) handleAddDeadline(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.AddDeadline(r.Context(), owner, boardNum, in.Week, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1188,6 +1213,11 @@ func (s *Server) handleDeleteDeadline(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.DeleteDeadline(r.Context(), owner, boardNum, in.Week, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1210,6 +1240,11 @@ func (s *Server) handleMoveDeadline(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.MoveDeadline(r.Context(), owner, boardNum, in.Project, in.From, in.To); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1230,6 +1265,11 @@ func (s *Server) handleAddProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.AddProject(r.Context(), owner, boardNum, in.Name); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1250,6 +1290,11 @@ func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.DeleteProject(r.Context(), owner, boardNum, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1269,6 +1314,11 @@ func (s *Server) handleReorderProjects(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.ReorderProjects(r.Context(), owner, boardNum, in.Projects); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1290,6 +1340,11 @@ func (s *Server) handleDeleteEpic(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.DeleteEpic(r.Context(), owner, project, in.Epic, in.Project); err != nil {
 		s.apiError(w, r, err)
 		return
@@ -1311,6 +1366,11 @@ func (s *Server) handleReorderEpics(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The roster is read here to check a name and to carry the board's
+	// ids into the write; a snapshot minutes old answers both, and
+	// blocking on a full reload made adding a column feel broken on a
+	// big board. The background revalidation catches the rest up.
+	r = r.WithContext(staleOK(r.Context()))
 	if err := svc.ReorderEpics(r.Context(), owner, project, in.Project, in.Epics); err != nil {
 		s.apiError(w, r, err)
 		return

--- a/internal/server/stale.go
+++ b/internal/server/stale.go
@@ -24,6 +24,14 @@ func withStaleAllowed(ctx context.Context) (context.Context, *staleControl) {
 	return context.WithValue(ctx, staleCtxKey{}, sc), sc
 }
 
+// staleOK is withStaleAllowed for callers that do not care to know whether the
+// snapshot they got was stale — the roster mutations, which read the board
+// only to check a name and to carry its ids into the write.
+func staleOK(ctx context.Context) context.Context {
+	c, _ := withStaleAllowed(ctx)
+	return c
+}
+
 // staleControlFrom returns the request's stale marker, or nil when the request
 // must be served current data (every mutation path).
 func staleControlFrom(ctx context.Context) *staleControl {

--- a/pkg/boardservice/epics_test.go
+++ b/pkg/boardservice/epics_test.go
@@ -568,3 +568,55 @@ func TestBoardRepairsStaleSlotWeeks(t *testing.T) {
 		t.Fatalf("a weekly-plan card must be left alone, got %q", got)
 	}
 }
+
+// Handing a slot to a team files it in that team's weekly plan, whichever door
+// the change came through — the frontend used to add the band on its own, so
+// the same assignment made over MCP left the card in nobody's plan.
+func TestTeamFilesASlotInTheWeeklyPlan(t *testing.T) {
+	today := board.TodayIso()
+	week := board.MondayOf(today)
+	fake := newFake([]board.Card{
+		{ItemID: "p1", Title: board.ProjectStateTitle, Project: "Cozystack"},
+		{ItemID: "e1", Title: board.EpicStateTitle, Epic: "Infra", Project: "Cozystack"},
+		{ItemID: "slot", Title: "a slot", Epic: "Infra", Project: "Cozystack",
+			StartDate: today, Day: today, Week: week},
+		{ItemID: "day", Title: "an ordinary card", StartDate: today, Day: today},
+	}, map[string]board.SprintState{"alpha": {Current: today, ItemID: "s1"}})
+	svc := New(fake)
+	ctx := context.Background()
+
+	if err := svc.SetTeam(ctx, "acme", 1, "slot", "alpha", ""); err != nil {
+		t.Fatal(err)
+	}
+	got := fake.get("slot")
+	if got.Plan != board.PlanFri {
+		t.Fatalf("band = %q, want the slot filed in the weekly plan", got.Plan)
+	}
+	if got.SprintStart != "" {
+		t.Fatalf("filing a slot in a plan must not start it, got sprint %q", got.SprintStart)
+	}
+	b, err := svc.Board(ctx, "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bands := board.WeeklyPlan(b, "alpha", week)
+	if len(bands.Fri) != 1 || bands.Fri[0].ItemID != "slot" {
+		t.Fatalf("the slot must show in alpha's plan for its week; got %+v", bands)
+	}
+
+	// Taking the team away takes an unstarted slot back out of the plan.
+	if err := svc.SetTeam(ctx, "acme", 1, "slot", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := fake.get("slot"); got.Plan != board.PlanNone {
+		t.Fatalf("band = %q, want the slot out of the plan again", got.Plan)
+	}
+
+	// An ordinary day card is untouched by any of this.
+	if err := svc.SetTeam(ctx, "acme", 1, "day", "alpha", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := fake.get("day"); got.Plan != board.PlanNone {
+		t.Fatalf("an ordinary card must not be filed in the weekly plan, got %q", got.Plan)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1735,11 +1735,42 @@ func (s *Service) SetTeam(ctx context.Context, owner string, project int, itemID
 	if err := s.setTeamOne(ctx, b, card, team, sprintStart); err != nil {
 		return err
 	}
+	if err := s.syncSlotPlan(ctx, b, card, team); err != nil {
+		return err
+	}
 	// The team travels with the whole group: subtasks follow their parent.
 	for _, c := range board.Children(b, card.ItemID) {
 		if err := s.setTeamOne(ctx, b, c, team, sprintStart); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// syncSlotPlan files a Project-board slot in its team's weekly plan, or takes
+// it back out. The band is what puts a card in that plan, and it used to be
+// added by the frontend alone — so the same assignment made over MCP or the
+// HTTP API left the card with a team and in nobody's plan. The rule belongs
+// here, where every door passes.
+func (s *Service) syncSlotPlan(ctx context.Context, b board.Board, card board.Card, team string) error {
+	if card.Epic == "" {
+		return nil
+	}
+	if team != "" && card.Plan == board.PlanNone {
+		if err := s.backend.SetPlan(ctx, b, card, board.PlanFri); err != nil {
+			return err
+		}
+		s.logEvent(ctx, b, card, board.EventPlanBand, "", string(board.PlanFri))
+		return nil
+	}
+	// Taking the team away from a slot nobody has started takes it out of the
+	// plan with it: a weekly plan belongs to a team, and a card in no team's
+	// plan is just clutter in the last one's.
+	if team == "" && card.Plan != board.PlanNone && card.SprintStart == "" && card.Progress == 0 {
+		if err := s.backend.SetPlan(ctx, b, card, board.PlanNone); err != nil {
+			return err
+		}
+		s.logEvent(ctx, b, card, board.EventPlanBand, string(card.Plan), "")
 	}
 	return nil
 }

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -5,6 +5,7 @@ import type {
   EpicRef,
   Provider,
 } from "../providers/types";
+import { registerPendingCard } from "../api/pending";
 import { addDays, mondayOf, todayIso } from "../date";
 import { teamColor, teamInitial } from "../avatar";
 import { Dropdown } from "./Dropdown";
@@ -405,6 +406,9 @@ export function ProjectBoard({
     from: number;
     to: number;
     resize?: CardModel;
+    // Which edge a resize is pulling: the top moves the slot's start (its
+    // row), the bottom its end. The other edge stays where it is.
+    edge?: "top" | "bottom";
   } | null>(null);
   const [draft, setDraft] = useState<{
     epic: EpicRef;
@@ -479,10 +483,19 @@ export function ProjectBoard({
     return rows.length - 1;
   };
 
-  const beginDrag = (epic: EpicRef, week: number, e: React.PointerEvent, resize?: CardModel) => {
+  const beginDrag = (
+    epic: EpicRef,
+    week: number,
+    e: React.PointerEvent,
+    resize?: CardModel,
+    edge: "top" | "bottom" = "bottom",
+  ) => {
     e.preventDefault();
+    e.stopPropagation();
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    setDrag({ epic, from: week, to: week, resize });
+    // "from" is the edge that stays put: the card's first row when the bottom
+    // is pulled, its last row when the top is.
+    setDrag({ epic, from: week, to: week, resize, edge });
   };
 
   const moveDrag = (e: React.PointerEvent) => {
@@ -491,10 +504,16 @@ export function ProjectBoard({
     }
     const row = rowAt(e.clientY);
     if (row !== drag.to) {
-      // A new slot may be pulled either way from where it was started; only a
-      // RESIZE is one-directional, since it moves the end and the start is
-      // history. endDrag sorts the two rows out.
-      setDrag({ ...drag, to: drag.resize ? Math.max(drag.from, row) : row });
+      // A new slot may be pulled either way from where it was started. A
+      // resize may not cross the edge that is staying put: the bottom stops
+      // at the first row, the top stops at the last one.
+      let to = row;
+      if (drag.resize) {
+        to = drag.edge === "top"
+          ? Math.min(drag.from, row)
+          : Math.max(drag.from, row);
+      }
+      setDrag({ ...drag, to });
     }
   };
 
@@ -504,6 +523,24 @@ export function ProjectBoard({
     }
     const { epic, from, to, resize } = drag;
     setDrag(null);
+    if (resize && drag.edge === "top") {
+      // The top edge moves the slot's START; its end stays. The row follows
+      // the start date on the server, so only the date is sent.
+      const start = weeks[Math.min(from, to)];
+      if (start === resize.startDate) {
+        return;
+      }
+      const prev = { startDate: resize.startDate, week: resize.week };
+      patchCard(resize.itemId, { startDate: start, week: start });
+      void provider
+        .patchCard(board, resize.itemId, { dates: { start } })
+        .then(addCard)
+        .catch((err: unknown) => {
+          patchCard(resize.itemId, prev);
+          onError(errText(err));
+        });
+      return;
+    }
     if (resize) {
       // Stretch (or shrink) an existing slot: its anchor week stays, the end
       // lands on the Friday of the released week.
@@ -649,15 +686,23 @@ export function ProjectBoard({
       description: "",
       progress: 0,
     });
-    void provider
-      .createCard(board, {
-        title: title.trim(),
-        epic: epic.name,
-        project: epic.project,
-        week,
-        start,
-        day: end,
-      })
+    const created = provider.createCard(board, {
+      title: title.trim(),
+      epic: epic.name,
+      project: epic.project,
+      week,
+      start,
+      day: end,
+    });
+    // Anything done to the new slot before the create lands — dragging it,
+    // stretching it, handing it to a team — waits here for the real uid
+    // instead of erroring out with "card is still being created", which is
+    // what every other board already does.
+    registerPendingCard(
+      tempId,
+      created.then((c) => c.itemId),
+    );
+    created
       .then((c) => replaceCard(tempId, c))
       .catch((err: unknown) => {
         removeCard(tempId);
@@ -951,9 +996,21 @@ export function ProjectBoard({
 
   // While a slot is being stretched, its span follows the pointer — the drag
   // has to be visible on the thing being dragged, not only on the cursor.
+  // While an edge is being pulled, the slot itself shows where it would land:
+  // the preview IS the card, so there is nothing to imagine.
+  const previewRow = (card: CardModel, row: number, span: number): number => {
+    if (!drag?.resize || drag.resize.itemId !== card.itemId || drag.edge !== "top") {
+      return row;
+    }
+    return Math.max(0, Math.min(drag.to, row + span - 1));
+  };
+
   const previewSpan = (card: CardModel, row: number, span: number): number => {
     if (!drag?.resize || drag.resize.itemId !== card.itemId) {
       return span;
+    }
+    if (drag.edge === "top") {
+      return row + span - previewRow(card, row, span);
     }
     return Math.max(1, Math.min(drag.to - row + 1, weeks.length - row));
   };
@@ -1072,6 +1129,29 @@ export function ProjectBoard({
   }, [board.cards, board.projects]);
 
   const todayRow = weeks.indexOf(thisMonday);
+
+  // Open on today. A plan reaches months back, and the board opened at its
+  // very first week — someone arriving had to scroll past a spent quarter to
+  // find out where the team is. Once per project shown: after that the scroll
+  // is the reader's, and pressing "earlier weeks" must not yank it back.
+  const scrolledFor = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller || !boardBox || todayRow < 0 || scrolledFor.current === widthKey) {
+      return;
+    }
+    const top = Math.max(0, boardBox.gridTop + HEADER_PX + (todayRow - 2) * ROW_PX);
+    // After the paint: switching project rebuilds the grid, and a scroll set
+    // before it has its new height is clamped to the old one. The mark is set
+    // in the callback, not here — this effect re-runs as the new board is
+    // measured, and a mark set up front would cancel the pending frame and
+    // then refuse to schedule another, which is why switching never moved.
+    const frame = requestAnimationFrame(() => {
+      scrolledFor.current = widthKey;
+      scroller.scrollTop = top;
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [boardBox, todayRow, widthKey, weeks.length]);
 
   // The projects the week menu can act on: those in view, or the whole roster
   // when nothing is filtered. The no-project bucket is included in both cases
@@ -1451,7 +1531,7 @@ export function ProjectBoard({
                 // the preview IS the card, so there is nothing to guess.
                 gridColumn:
                   (move?.card.itemId === card.itemId ? colIndex(move.epic) : col) + 2,
-                gridRow: `${(move?.card.itemId === card.itemId ? move.row : row) + 2} / span ${previewSpan(card, row, span)}`,
+                gridRow: `${(move?.card.itemId === card.itemId ? move.row : previewRow(card, row, span)) + 2} / span ${previewSpan(card, row, span)}`,
                 borderLeftColor: card.team ? teamColor(card.team) : undefined,
                 // Cards sharing weeks in one column split its width instead
                 // of hiding each other. The width holds while the card is
@@ -1559,13 +1639,20 @@ export function ProjectBoard({
                   No team
                 </button>
               </Dropdown>
+              {/* One grip per edge: the top moves the slot's start, the
+                  bottom its end. "from" is whichever edge stays put. */}
+              <div
+                className="project-slot-resize project-slot-resize-top"
+                title="Drag to move the start"
+                onPointerDown={(ev) => beginDrag(e, row + span - 1, ev, card, "top")}
+                onPointerCancel={() => setDrag(null)}
+                onPointerMove={moveDrag}
+                onPointerUp={endDrag}
+              />
               <div
                 className="project-slot-resize"
                 title="Drag to stretch over more weeks"
-                onPointerDown={(ev) => {
-                  ev.stopPropagation();
-                  beginDrag(e, row, ev, card);
-                }}
+                onPointerDown={(ev) => beginDrag(e, row, ev, card, "bottom")}
                 onPointerCancel={() => setDrag(null)}
                 onPointerMove={moveDrag}
                 onPointerUp={endDrag}

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -793,10 +793,8 @@ export function ProjectBoard({
     const prev = { team: card.team, plan: card.plan };
     patchCard(card.itemId, { team: team ?? undefined, plan: card.plan ?? (team ? "fri" : undefined) });
     void provider
-      .patchCard(board, card.itemId, {
-        team: team ?? "",
-        ...(team && !card.plan ? { plan: { band: "fri" } } : {}),
-      })
+      // Just the team: the server files the slot in that team's weekly plan.
+      .patchCard(board, card.itemId, { team: team ?? "" })
       .then(addCard)
       .catch((err: unknown) => {
         patchCard(card.itemId, prev);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3676,6 +3676,14 @@ button.card-age {
   touch-action: none;
 }
 
+/* The same grip on the other edge: a slot stretches from either end. It stops
+   short of the right so it never covers the badge or delete. */
+.project-slot-resize-top {
+  top: -2px;
+  bottom: auto;
+  right: 40px;
+}
+
 .project-slot {
   cursor: grab;
 }


### PR DESCRIPTION
Four things a real nine-month plan made obvious, found by using the board rather than by reading it.

## A team's slot lands in that team's weekly plan

Handing a slot to a team is supposed to file it in that team's weekly plan — the comment in `SetTeam` has said so all along — but the band that actually files it was added by the frontend. The same assignment made over MCP or the HTTP API left the card with a team and in nobody's plan, which is where the workshop cards ended up.

The rule moved to the service, where every door passes: a slot given a team gets the week-end band, and a slot whose team is taken away — one nobody has started — comes back out of the plan with it. Ordinary day cards are untouched. Cards assigned before this still need their band: the rule fires on a team change, not on a read.

## Roster changes stop paying for a full board reload

Adding a column blocked on a *fresh* board, because a mutation never accepts a cached snapshot. On a big board the request sat through the whole multi-page read before writing a single field — **47s measured**.

The roster mutations read the board only to check a name and to carry the board's ids into the write, and a snapshot minutes old answers both. They accept a stale one now, with the background revalidation catching up behind: **2.5s instead of 47s** on a stale cache, unchanged (~1s) on a warm one. A cold cache still pays the load — there is nothing yet to serve.

## A slot stretches from either end

Only the bottom edge had a grip, so moving a slot's start meant dragging the whole card and stretching it back — two gestures for one intent. The top edge now moves the start with the end held still, and each edge stops at the other instead of turning the slot inside out.

## Opening the board, and a create that answered with an error

- The board opened at its first week, so arriving meant scrolling past a spent quarter to find where the team is. It opens on today with two weeks of context above, once per project shown; after that the scroll belongs to the reader, and switching project scrolls again.
- Acting on a slot while its create was still in flight answered *"card is still being created"*. Every other board registers the pending create so the edit waits for the real id; this one never did.

## Testing

`TestTeamFilesASlotInTheWeeklyPlan` covers the service rule in all three directions (filed on assignment, out again when the team is removed from an unstarted slot, ordinary cards untouched). Go suites, golangci-lint clean, 45 web tests.

The rest was driven in headless Chrome against the real board: the open-on-today scroll (including that the reader's own scrolling is not overridden, and that switching project scrolls again), the top-edge stretch on a scratch card (start moved two weeks earlier, end unchanged), and the timings above measured against a live server on a 400-card board.
