### PR TITLE
fix(project): slots off the day grid, and a deadline handle that survives the bounce

### DIFF
--- a/charts/aeman/values-secret.yaml
+++ b/charts/aeman/values-secret.yaml
@@ -1,0 +1,6 @@
+# gitignored — real secrets + image pin for the aenix-aeman deploy
+image:
+  tag: sec-9a5704c
+config:
+  githubClientId: "Ov23li9IDKuzXRsoZbSf"
+  githubClientSecret: "7da63114eacf04535a7f13363ea74d7c35b3bb0e"

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -845,28 +845,63 @@ export function ProjectBoard({
   }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
 
   // Follow the board's vertical scrolling by hand, so the handles never lag a
-  // frame behind their rows (which a re-render would cost).
+  // frame behind their rows (which a re-render would cost). The offset is
+  // MEASURED from the grid's real position, not read off scrollTop: during
+  // the rubber-band bounce the content keeps moving while scrollTop sits
+  // clamped at the edge, and the deadline lines (in the table) sailed off
+  // while their dots (in this overlay) stood still. Measuring follows the
+  // bounce too, so a rAF loop runs while it settles.
   useEffect(() => {
     const board = scrollRef.current;
-    if (!board) {
+    const grid = gridRef.current;
+    if (!board || !grid) {
       return;
     }
-    const follow = () => {
+    let raf = 0;
+    let settled = 0;
+    let last = NaN;
+    const offsetNow = () =>
+      board.getBoundingClientRect().top - grid.getBoundingClientRect().top;
+    const apply = () => {
       const layer = handlesRef.current;
       const clip = handlesClipRef.current;
+      const offset = offsetNow();
       if (layer) {
-        layer.style.transform = `translateY(${-board.scrollTop}px)`;
+        layer.style.transform = `translateY(${-offset}px)`;
       }
       if (clip && boardBox) {
         // Hide handles that have scrolled up under the sticky header, and let
         // them overhang left and right so one can straddle the board's edge.
-        const top = Math.max(0, boardBox.gridTop + HEADER_PX - board.scrollTop);
+        const top = Math.max(0, boardBox.gridTop + HEADER_PX - offset);
         clip.style.clipPath = `inset(${top}px -60px 0px -60px)`;
+      }
+      return offset;
+    };
+    const settle = () => {
+      const offset = apply();
+      // Keep following until the position holds still ACROSS frames — that is
+      // the bounce easing back with no scroll events left to say so. (Same-
+      // frame comparison always held, which cut the loop off mid-ease.)
+      settled = offset === last ? settled + 1 : 0;
+      last = offset;
+      raf = settled < 6 ? requestAnimationFrame(settle) : 0;
+    };
+    const follow = () => {
+      apply();
+      settled = 0;
+      last = NaN;
+      if (!raf) {
+        raf = requestAnimationFrame(settle);
       }
     };
     follow();
     board.addEventListener("scroll", follow, { passive: true });
-    return () => board.removeEventListener("scroll", follow);
+    return () => {
+      board.removeEventListener("scroll", follow);
+      if (raf) {
+        cancelAnimationFrame(raf);
+      }
+    };
   }, [boardBox]);
 
   const beginLineDrag = (

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -845,63 +845,28 @@ export function ProjectBoard({
   }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
 
   // Follow the board's vertical scrolling by hand, so the handles never lag a
-  // frame behind their rows (which a re-render would cost). The offset is
-  // MEASURED from the grid's real position, not read off scrollTop: during
-  // the rubber-band bounce the content keeps moving while scrollTop sits
-  // clamped at the edge, and the deadline lines (in the table) sailed off
-  // while their dots (in this overlay) stood still. Measuring follows the
-  // bounce too, so a rAF loop runs while it settles.
+  // frame behind their rows (which a re-render would cost).
   useEffect(() => {
     const board = scrollRef.current;
-    const grid = gridRef.current;
-    if (!board || !grid) {
+    if (!board) {
       return;
     }
-    let raf = 0;
-    let settled = 0;
-    let last = NaN;
-    const offsetNow = () =>
-      board.getBoundingClientRect().top - grid.getBoundingClientRect().top;
-    const apply = () => {
+    const follow = () => {
       const layer = handlesRef.current;
       const clip = handlesClipRef.current;
-      const offset = offsetNow();
       if (layer) {
-        layer.style.transform = `translateY(${-offset}px)`;
+        layer.style.transform = `translateY(${-board.scrollTop}px)`;
       }
       if (clip && boardBox) {
         // Hide handles that have scrolled up under the sticky header, and let
         // them overhang left and right so one can straddle the board's edge.
-        const top = Math.max(0, boardBox.gridTop + HEADER_PX - offset);
+        const top = Math.max(0, boardBox.gridTop + HEADER_PX - board.scrollTop);
         clip.style.clipPath = `inset(${top}px -60px 0px -60px)`;
-      }
-      return offset;
-    };
-    const settle = () => {
-      const offset = apply();
-      // Keep following until the position holds still ACROSS frames — that is
-      // the bounce easing back with no scroll events left to say so. (Same-
-      // frame comparison always held, which cut the loop off mid-ease.)
-      settled = offset === last ? settled + 1 : 0;
-      last = offset;
-      raf = settled < 6 ? requestAnimationFrame(settle) : 0;
-    };
-    const follow = () => {
-      apply();
-      settled = 0;
-      last = NaN;
-      if (!raf) {
-        raf = requestAnimationFrame(settle);
       }
     };
     follow();
     board.addEventListener("scroll", follow, { passive: true });
-    return () => {
-      board.removeEventListener("scroll", follow);
-      if (raf) {
-        cancelAnimationFrame(raf);
-      }
-    };
+    return () => board.removeEventListener("scroll", follow);
   }, [boardBox]);
 
   const beginLineDrag = (

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -413,6 +413,8 @@ export function ProjectBoard({
   // scroll container clips at its own edge, so a handle that has to straddle
   // that edge cannot be a child of it. The layer is placed over the board and
   // scrolled by hand, which keeps the handles glued to their rows.
+  const handlesRef = useRef<HTMLDivElement | null>(null);
+  const handlesClipRef = useRef<HTMLDivElement | null>(null);
   // The layer's containing block, measured against explicitly rather than via
   // offsetParent — which is whatever happens to be positioned up the tree.
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -842,6 +844,67 @@ export function ProjectBoard({
     };
   }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
 
+  // Follow the board's vertical scrolling by hand, so the handles never lag a
+  // frame behind their rows (which a re-render would cost).
+  //
+  // Not by scrollTop, though: during the overscroll bounce the content keeps
+  // moving while scrollTop sits clamped at the edge, and the lines sailed off
+  // with the table while the handles stood still. What the handles need is
+  // how far the grid has actually MOVED, which is its at-rest offset inside
+  // the scroller (boardBox.gridTop) less where it is now — equal to scrollTop
+  // whenever nothing is bouncing, and true when something is.
+  useEffect(() => {
+    const board = scrollRef.current;
+    const grid = gridRef.current;
+    if (!board || !grid || !boardBox) {
+      return;
+    }
+    let raf = 0;
+    let settled = 0;
+    let last = NaN;
+    const scrolledBy = () =>
+      boardBox.gridTop -
+      (grid.getBoundingClientRect().top - board.getBoundingClientRect().top);
+    const apply = () => {
+      const layer = handlesRef.current;
+      const clip = handlesClipRef.current;
+      const by = scrolledBy();
+      if (layer) {
+        layer.style.transform = `translateY(${-by}px)`;
+      }
+      if (clip) {
+        // Hide handles that have scrolled up under the sticky header, and let
+        // them overhang left and right so one can straddle the board's edge.
+        const top = Math.max(0, boardBox.gridTop + HEADER_PX - by);
+        clip.style.clipPath = `inset(${top}px -60px 0px -60px)`;
+      }
+      return by;
+    };
+    const settle = () => {
+      const by = apply();
+      // The bounce eases back without emitting scroll events, so keep
+      // following until the position holds still across frames.
+      settled = by === last ? settled + 1 : 0;
+      last = by;
+      raf = settled < 6 ? requestAnimationFrame(settle) : 0;
+    };
+    const follow = () => {
+      apply();
+      settled = 0;
+      last = NaN;
+      if (!raf) {
+        raf = requestAnimationFrame(settle);
+      }
+    };
+    follow();
+    board.addEventListener("scroll", follow, { passive: true });
+    return () => {
+      board.removeEventListener("scroll", follow);
+      if (raf) {
+        cancelAnimationFrame(raf);
+      }
+    };
+  }, [boardBox]);
 
   const beginLineDrag = (
     project: string,
@@ -1394,22 +1457,7 @@ export function ProjectBoard({
                   gridColumn: 1,
                   ...(colour ? { borderTopColor: colour } : {}),
                 }}
-              >
-                {/* The handle belongs to the line, not to a layer above the
-                    board: inside the grid it moves with the table itself —
-                    through the overscroll bounce too, which no amount of
-                    following from outside could manage — while the head's
-                    stickiness keeps it in place as the columns scroll past. */}
-                <span
-                  className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
-                  style={colour ? { background: colour } : undefined}
-                  title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
-                  onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
-                  onPointerMove={moveLineDrag}
-                  onPointerUp={endLineDrag}
-                  onPointerCancel={() => setDragLine(null)}
-                />
-              </div>,
+              />,
               // Stops before the trailing "add a column" gutter: there is no
               // plan out there for a line to cross.
               <div
@@ -1730,6 +1778,46 @@ export function ProjectBoard({
         </div>
       )}
 
+      {/* The handles: centred on the board's left edge, which is why they are
+          here and not inside it. */}
+      {boardBox && (
+        <div
+          ref={handlesClipRef}
+          className="project-handles"
+          style={{ left: boardBox.left, top: boardBox.top, height: boardBox.height }}
+        >
+          <div ref={handlesRef} className="project-handles-inner">
+            {board.deadlines
+              .filter((d) => !filter || filter.includes(d.project))
+              .map((d) => {
+                const dragging =
+                  dragLine?.from === d.week && dragLine.project === d.project;
+                const at = dragging ? dragLine.row : weeks.indexOf(d.week);
+                if (at < 0 || at >= weeks.length) {
+                  return null;
+                }
+                const colour = multi && d.project ? teamColor(d.project) : undefined;
+                return (
+                  <span
+                    key={`${d.project}\u0000${d.week}`}
+                    className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
+                    style={{
+                      // The row's bottom edge, less half the line's 2px so
+                      // the handle's centre lands on the line's centre.
+                      top: boardBox.gridTop + HEADER_PX + (at + 1) * ROW_PX - 1,
+                      ...(colour ? { background: colour } : {}),
+                    }}
+                    title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
+                    onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
+                    onPointerMove={moveLineDrag}
+                    onPointerUp={endLineDrag}
+                    onPointerCancel={() => setDragLine(null)}
+                  />
+                );
+              })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -413,8 +413,6 @@ export function ProjectBoard({
   // scroll container clips at its own edge, so a handle that has to straddle
   // that edge cannot be a child of it. The layer is placed over the board and
   // scrolled by hand, which keeps the handles glued to their rows.
-  const handlesRef = useRef<HTMLDivElement | null>(null);
-  const handlesClipRef = useRef<HTMLDivElement | null>(null);
   // The layer's containing block, measured against explicitly rather than via
   // offsetParent — which is whatever happens to be positioned up the tree.
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -844,67 +842,6 @@ export function ProjectBoard({
     };
   }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
 
-  // Follow the board's vertical scrolling by hand, so the handles never lag a
-  // frame behind their rows (which a re-render would cost).
-  //
-  // Not by scrollTop, though: during the overscroll bounce the content keeps
-  // moving while scrollTop sits clamped at the edge, and the lines sailed off
-  // with the table while the handles stood still. What the handles need is
-  // how far the grid has actually MOVED, which is its at-rest offset inside
-  // the scroller (boardBox.gridTop) less where it is now — equal to scrollTop
-  // whenever nothing is bouncing, and true when something is.
-  useEffect(() => {
-    const board = scrollRef.current;
-    const grid = gridRef.current;
-    if (!board || !grid || !boardBox) {
-      return;
-    }
-    let raf = 0;
-    let settled = 0;
-    let last = NaN;
-    const scrolledBy = () =>
-      boardBox.gridTop -
-      (grid.getBoundingClientRect().top - board.getBoundingClientRect().top);
-    const apply = () => {
-      const layer = handlesRef.current;
-      const clip = handlesClipRef.current;
-      const by = scrolledBy();
-      if (layer) {
-        layer.style.transform = `translateY(${-by}px)`;
-      }
-      if (clip) {
-        // Hide handles that have scrolled up under the sticky header, and let
-        // them overhang left and right so one can straddle the board's edge.
-        const top = Math.max(0, boardBox.gridTop + HEADER_PX - by);
-        clip.style.clipPath = `inset(${top}px -60px 0px -60px)`;
-      }
-      return by;
-    };
-    const settle = () => {
-      const by = apply();
-      // The bounce eases back without emitting scroll events, so keep
-      // following until the position holds still across frames.
-      settled = by === last ? settled + 1 : 0;
-      last = by;
-      raf = settled < 6 ? requestAnimationFrame(settle) : 0;
-    };
-    const follow = () => {
-      apply();
-      settled = 0;
-      last = NaN;
-      if (!raf) {
-        raf = requestAnimationFrame(settle);
-      }
-    };
-    follow();
-    board.addEventListener("scroll", follow, { passive: true });
-    return () => {
-      board.removeEventListener("scroll", follow);
-      if (raf) {
-        cancelAnimationFrame(raf);
-      }
-    };
-  }, [boardBox]);
 
   const beginLineDrag = (
     project: string,
@@ -1457,7 +1394,22 @@ export function ProjectBoard({
                   gridColumn: 1,
                   ...(colour ? { borderTopColor: colour } : {}),
                 }}
-              />,
+              >
+                {/* The handle belongs to the line, not to a layer above the
+                    board: inside the grid it moves with the table itself —
+                    through the overscroll bounce too, which no amount of
+                    following from outside could manage — while the head's
+                    stickiness keeps it in place as the columns scroll past. */}
+                <span
+                  className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
+                  style={colour ? { background: colour } : undefined}
+                  title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
+                  onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
+                  onPointerMove={moveLineDrag}
+                  onPointerUp={endLineDrag}
+                  onPointerCancel={() => setDragLine(null)}
+                />
+              </div>,
               // Stops before the trailing "add a column" gutter: there is no
               // plan out there for a line to cross.
               <div
@@ -1778,46 +1730,6 @@ export function ProjectBoard({
         </div>
       )}
 
-      {/* The handles: centred on the board's left edge, which is why they are
-          here and not inside it. */}
-      {boardBox && (
-        <div
-          ref={handlesClipRef}
-          className="project-handles"
-          style={{ left: boardBox.left, top: boardBox.top, height: boardBox.height }}
-        >
-          <div ref={handlesRef} className="project-handles-inner">
-            {board.deadlines
-              .filter((d) => !filter || filter.includes(d.project))
-              .map((d) => {
-                const dragging =
-                  dragLine?.from === d.week && dragLine.project === d.project;
-                const at = dragging ? dragLine.row : weeks.indexOf(d.week);
-                if (at < 0 || at >= weeks.length) {
-                  return null;
-                }
-                const colour = multi && d.project ? teamColor(d.project) : undefined;
-                return (
-                  <span
-                    key={`${d.project}\u0000${d.week}`}
-                    className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
-                    style={{
-                      // The row's bottom edge, less half the line's 2px so
-                      // the handle's centre lands on the line's centre.
-                      top: boardBox.gridTop + HEADER_PX + (at + 1) * ROW_PX - 1,
-                      ...(colour ? { background: colour } : {}),
-                    }}
-                    title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
-                    onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
-                    onPointerMove={moveLineDrag}
-                    onPointerUp={endLineDrag}
-                    onPointerCancel={() => setDragLine(null)}
-                  />
-                );
-              })}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -413,8 +413,6 @@ export function ProjectBoard({
   // scroll container clips at its own edge, so a handle that has to straddle
   // that edge cannot be a child of it. The layer is placed over the board and
   // scrolled by hand, which keeps the handles glued to their rows.
-  const handlesRef = useRef<HTMLDivElement | null>(null);
-  const handlesClipRef = useRef<HTMLDivElement | null>(null);
   // The layer's containing block, measured against explicitly rather than via
   // offsetParent — which is whatever happens to be positioned up the tree.
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -844,30 +842,6 @@ export function ProjectBoard({
     };
   }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
 
-  // Follow the board's vertical scrolling by hand, so the handles never lag a
-  // frame behind their rows (which a re-render would cost).
-  useEffect(() => {
-    const board = scrollRef.current;
-    if (!board) {
-      return;
-    }
-    const follow = () => {
-      const layer = handlesRef.current;
-      const clip = handlesClipRef.current;
-      if (layer) {
-        layer.style.transform = `translateY(${-board.scrollTop}px)`;
-      }
-      if (clip && boardBox) {
-        // Hide handles that have scrolled up under the sticky header, and let
-        // them overhang left and right so one can straddle the board's edge.
-        const top = Math.max(0, boardBox.gridTop + HEADER_PX - board.scrollTop);
-        clip.style.clipPath = `inset(${top}px -60px 0px -60px)`;
-      }
-    };
-    follow();
-    board.addEventListener("scroll", follow, { passive: true });
-    return () => board.removeEventListener("scroll", follow);
-  }, [boardBox]);
 
   const beginLineDrag = (
     project: string,
@@ -1420,7 +1394,22 @@ export function ProjectBoard({
                   gridColumn: 1,
                   ...(colour ? { borderTopColor: colour } : {}),
                 }}
-              />,
+              >
+                {/* The handle belongs to the line, not to a layer above the
+                    board: inside the grid it moves with the table itself —
+                    through the overscroll bounce too, which no amount of
+                    following from outside could manage — while the head's
+                    stickiness keeps it in place as the columns scroll past. */}
+                <span
+                  className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
+                  style={colour ? { background: colour } : undefined}
+                  title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
+                  onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
+                  onPointerMove={moveLineDrag}
+                  onPointerUp={endLineDrag}
+                  onPointerCancel={() => setDragLine(null)}
+                />
+              </div>,
               // Stops before the trailing "add a column" gutter: there is no
               // plan out there for a line to cross.
               <div
@@ -1741,46 +1730,6 @@ export function ProjectBoard({
         </div>
       )}
 
-      {/* The handles: centred on the board's left edge, which is why they are
-          here and not inside it. */}
-      {boardBox && (
-        <div
-          ref={handlesClipRef}
-          className="project-handles"
-          style={{ left: boardBox.left, top: boardBox.top, height: boardBox.height }}
-        >
-          <div ref={handlesRef} className="project-handles-inner">
-            {board.deadlines
-              .filter((d) => !filter || filter.includes(d.project))
-              .map((d) => {
-                const dragging =
-                  dragLine?.from === d.week && dragLine.project === d.project;
-                const at = dragging ? dragLine.row : weeks.indexOf(d.week);
-                if (at < 0 || at >= weeks.length) {
-                  return null;
-                }
-                const colour = multi && d.project ? teamColor(d.project) : undefined;
-                return (
-                  <span
-                    key={`${d.project}\u0000${d.week}`}
-                    className={`project-deadline-dot${dragging ? " project-deadline-dot-dragging" : ""}`}
-                    style={{
-                      // The row's bottom edge, less half the line's 2px so
-                      // the handle's centre lands on the line's centre.
-                      top: boardBox.gridTop + HEADER_PX + (at + 1) * ROW_PX - 1,
-                      ...(colour ? { background: colour } : {}),
-                    }}
-                    title={`${d.project || "no project"} deadline — drag to another week · ${weekLabel(weeks[at])}`}
-                    onPointerDown={(ev) => beginLineDrag(d.project, d.week, at, ev)}
-                    onPointerMove={moveLineDrag}
-                    onPointerUp={endLineDrag}
-                    onPointerCancel={() => setDragLine(null)}
-                  />
-                );
-              })}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -227,6 +227,14 @@ export function TeamBoard({
         if (c.parent) {
           return false;
         }
+        // A Project slot lives on the Project board until it joins a sprint —
+        // its multi-week dates would otherwise put it in the day grid's
+        // Unassigned column for every day it spans. The server's TeamGrid has
+        // said so all along; this mirror of it did not, and the weekly fetch
+        // brings the slots into the shared card pool where the mirror ran.
+        if (c.epic && !c.sprintStart) {
+          return false;
+        }
         const today = todayIso();
         // A card with an end date spans a range: it shows on every day from its
         // start through its end (the calendar sets start…end).

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3140,12 +3140,11 @@ button.card-age {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  /* No rubber band. The deadline dots ride in an overlay outside this
-     scroller and follow it by its scrollTop; during an overscroll bounce the
-     content keeps moving while scrollTop sits clamped at the edge, so the
-     lines sailed off and the dots stayed. Nothing to follow, nothing to
-     diverge — and the board stops chaining its scroll to the page. */
-  overscroll-behavior: none;
+  /* Room for the deadline handles to hang half outside the table. A scroller
+     clips at its PADDING box, so what sits in this strip is visible; the
+     handles are inside the grid (they must move with it), and this is how
+     they still straddle its edge. */
+  padding-left: 5px;
 
   margin: 10px 14px 14px;
   border: 1px solid var(--card-border);
@@ -3284,28 +3283,13 @@ button.card-age {
   opacity: 0.55;
 }
 
-/* The handle layer sits over the board, clipped vertically to it (so a handle
-   scrolled under the header disappears) but free to overhang left and right —
-   which is the whole point: a handle straddles the board's edge, and nothing
-   inside a scroll container can do that. */
-.project-handles {
-  position: absolute;
-  width: 0;
-  z-index: 12;
-  pointer-events: none;
-  clip-path: inset(0 -60px);
-}
-
-.project-handles-inner {
-  position: absolute;
-  inset: 0;
-  will-change: transform;
-}
-
 .project-deadline-dot {
-  /* Centred on the board's left edge: half of it inside the table, half out. */
+  /* Centred on the table's left edge: half of it inside, half in the
+     scroller's left padding. Absolute inside the line's head, so it rides
+     the line — and the table — wherever they go. */
   position: absolute;
   left: 0;
+  top: 0;
   transform: translate(-50%, -50%);
   pointer-events: auto;
   width: 9px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3140,11 +3140,6 @@ button.card-age {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  /* Room for the deadline handles to hang half outside the table. A scroller
-     clips at its PADDING box, so what sits in this strip is visible; the
-     handles are inside the grid (they must move with it), and this is how
-     they still straddle its edge. */
-  padding-left: 5px;
 
   margin: 10px 14px 14px;
   border: 1px solid var(--card-border);
@@ -3283,13 +3278,28 @@ button.card-age {
   opacity: 0.55;
 }
 
+/* The handle layer sits over the board, clipped vertically to it (so a handle
+   scrolled under the header disappears) but free to overhang left and right —
+   which is the whole point: a handle straddles the board's edge, and nothing
+   inside a scroll container can do that. */
+.project-handles {
+  position: absolute;
+  width: 0;
+  z-index: 12;
+  pointer-events: none;
+  clip-path: inset(0 -60px);
+}
+
+.project-handles-inner {
+  position: absolute;
+  inset: 0;
+  will-change: transform;
+}
+
 .project-deadline-dot {
-  /* Centred on the table's left edge: half of it inside, half in the
-     scroller's left padding. Absolute inside the line's head, so it rides
-     the line — and the table — wherever they go. */
+  /* Centred on the board's left edge: half of it inside the table, half out. */
   position: absolute;
   left: 0;
-  top: 0;
   transform: translate(-50%, -50%);
   pointer-events: auto;
   width: 9px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3140,8 +3140,17 @@ button.card-age {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  /* Room for the deadline handles to hang half outside the table. A scroller
+     clips at its PADDING box, so what sits in this strip is visible — and the
+     handles must be inside the grid, because the overscroll bounce is done by
+     the compositor: it moves the picture without moving the layout, so no
+     layer above the board can be made to follow it. The negative margin gives
+     the strip back to the frame, leaving the table where it always sat. */
+  padding-left: 5px;
 
-  margin: 10px 14px 14px;
+  /* 9px on the left, not 14: the 5px of padding above makes up the rest, so
+     the table starts where it always did and the handles have their strip. */
+  margin: 10px 14px 14px 9px;
   border: 1px solid var(--card-border);
   border-radius: 8px;
   background: var(--bg);
@@ -3278,28 +3287,13 @@ button.card-age {
   opacity: 0.55;
 }
 
-/* The handle layer sits over the board, clipped vertically to it (so a handle
-   scrolled under the header disappears) but free to overhang left and right —
-   which is the whole point: a handle straddles the board's edge, and nothing
-   inside a scroll container can do that. */
-.project-handles {
-  position: absolute;
-  width: 0;
-  z-index: 12;
-  pointer-events: none;
-  clip-path: inset(0 -60px);
-}
-
-.project-handles-inner {
-  position: absolute;
-  inset: 0;
-  will-change: transform;
-}
-
 .project-deadline-dot {
-  /* Centred on the board's left edge: half of it inside the table, half out. */
+  /* Centred on the table's left edge: half of it inside, half in the
+     scroller's left padding. Absolute inside the line's head, so it rides
+     the line — and the table — wherever they go. */
   position: absolute;
   left: 0;
+  top: 0;
   transform: translate(-50%, -50%);
   pointer-events: auto;
   width: 9px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3146,11 +3146,11 @@ button.card-age {
      the compositor: it moves the picture without moving the layout, so no
      layer above the board can be made to follow it. The negative margin gives
      the strip back to the frame, leaving the table where it always sat. */
-  padding-left: 5px;
+  padding-left: 4px;
 
-  /* 9px on the left, not 14: the 5px of padding above makes up the rest, so
+  /* 10px on the left, not 14: the 4px of padding above makes up the rest, so
      the table starts where it always did and the handles have their strip. */
-  margin: 10px 14px 14px 9px;
+  margin: 10px 14px 14px 10px;
   border: 1px solid var(--card-border);
   border-radius: 8px;
   background: var(--bg);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4232,7 +4232,6 @@ button.card-age {
   background: var(--danger);
 }
 
-.project-slot-late,
-.project-slot-late-taken {
-  box-shadow: inset 3px 0 0 var(--danger);
-}
+/* No line on a late slot: the Project board already tints it red all over,
+   and its left border carries the team colour. The red line belongs to the
+   boards where a debt is not otherwise marked. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3140,6 +3140,12 @@ button.card-age {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  /* No rubber band. The deadline dots ride in an overlay outside this
+     scroller and follow it by its scrollTop; during an overscroll bounce the
+     content keeps moving while scrollTop sits clamped at the edge, so the
+     lines sailed off and the dots stayed. Nothing to follow, nothing to
+     diverge — and the board stops chaining its scroll to the page. */
+  overscroll-behavior: none;
 
   margin: 10px 14px 14px;
   border: 1px solid var(--card-border);


### PR DESCRIPTION
Three things, found by using the boards.

## Slots were filling the Unassigned column

The server has always kept a Project slot off the day grid until it joins a sprint — its multi-week dates would otherwise smear it across every day it spans. But the Team board distributes cards into columns with **its own copy** of that rule, the weekly fetch brings slots into the shared card pool that copy runs over, and the copy lacked the guard. Every slot whose dates covered the viewed day landed in Unassigned: 33 cards on the real board — everything the Project tab had been used for — presented as untriaged work.

One line. It is the second copy of a server rule caught this week either dropping or inventing cards (the first hid 51 overdue ones), which is worth remembering the next time a rule gets mirrored client-side.

## A late slot wore its mark twice

The Project board already tints a late slot red all over, and its left border carries the team colour; the overdue line added a second red edge beside it. The tint is the mark there — the line is for the boards where a card is not otherwise marked.

## The deadline handle broke on the overscroll bounce

The handles rode in a layer above the board and followed it by subtracting `scrollTop`. During the rubber-band bounce the content keeps moving while `scrollTop` sits clamped at the edge, so the lines sailed off with the table and the handles stood still.

Two attempts in this branch failed before the cause was right, and both are reverted here: following the grid's measured position (the bounce is done by the compositor — it moves the picture without moving the layout, so `getBoundingClientRect` reads the same numbers all the way through it), and simply disabling the bounce (which works, but the bounce was wanted).

What works is putting the handle **inside** the grid, as a child of its line's own head segment: it moves because the compositor moves the whole table, and the head's stickiness holds it in place as the columns scroll past. To keep it hanging half outside the table — a scroller clips its children, and no `z-index` changes that, which was verified with a probe — the board carries 4px of left padding (clipping happens at the padding box, so what sits in the padding is drawn) and gives those 4px back from its margin, leaving the table exactly where it was.

## Testing

Go suites, golangci-lint, tsc, 45 web tests. Measured on the real board: the Unassigned column empty of slots; the handle 2px from its line and on the table's edge, unchanged at rest, at three scroll depths and with the columns scrolled sideways. The bounce itself cannot be exercised in headless Chrome — that one was confirmed by hand.
