### PR TITLE
fix: drop the deploy secret committed by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ web/dist/*
 
 # Claude Code (worktrees, session state)
 .claude/
+
+# Deploy values holding real credentials. The chart's own values.yaml carries
+# the shape; anything matching this pattern is somebody's filled-in copy and
+# never belongs in the repository.
+charts/**/values-secret.yaml
+charts/**/values-*.secret.yaml
+*.secret.yaml

--- a/charts/aeman/values-secret.yaml
+++ b/charts/aeman/values-secret.yaml
@@ -1,6 +1,0 @@
-# gitignored — real secrets + image pin for the aenix-aeman deploy
-image:
-  tag: sec-9a5704c
-config:
-  githubClientId: "Ov23li9IDKuzXRsoZbSf"
-  githubClientSecret: "7da63114eacf04535a7f13363ea74d7c35b3bb0e"


### PR DESCRIPTION
`charts/aeman/values-secret.yaml` is a filled-in copy of the chart's values, holding the deploy's real GitHub OAuth client secret. Its own first line says it is gitignored — nothing actually ignored it, so a blanket `git add` swept it in and a squash merge put it on `main`.

This removes it from the tree and ignores it by pattern, along with the other shapes a filled-in values file takes.

**This does not remove it from history, and the repository is public.** The secret must be treated as compromised and rotated (Settings → Developer settings → OAuth Apps → Generate a new client secret), and the deploy updated with the new value. Rewriting history is optional once the secret is dead.