### PR TITLE
fix(process): clicking the date opens the calendar

### DIFF
--- a/web/src/components/ProcessBoard.tsx
+++ b/web/src/components/ProcessBoard.tsx
@@ -626,7 +626,19 @@ function TaskRow({
             type="date"
             className="process-from-input"
             value={t.start ?? ""}
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              // Clicking a date input only FOCUSES it; the picker opens from
+              // the calendar icon, which is invisible here (the input is an
+              // opacity-0 overlay over the text). Ask for the picker
+              // outright, or the click does nothing a person can see.
+              try {
+                (e.target as HTMLInputElement).showPicker();
+              } catch {
+                // Some browsers gate showPicker (or lack it); focus still
+                // lets the keyboard edit the date.
+              }
+            }}
             onChange={(e) => {
               if (e.target.value && e.target.value !== t.start) {
                 onSetStart(e.target.value);


### PR DESCRIPTION
Clicking a date input only focuses it; the picker opens from its calendar icon, which is invisible here (the input is an opacity-0 overlay over the text). The click asks for the picker explicitly now — `showPicker()` under the click's user gesture — with focus as the fallback where a browser gates it. Verified with a real mouse click in headless Chrome: the picker is requested once, and a typed date still saves.