### PR TITLE
fix(auth): renew a session's GitHub token instead of dying with it

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -57,6 +57,12 @@ type oauthSession struct {
 	token   string
 	login   string
 	created time.Time
+	// refresh and tokenExpiry track a GitHub App user token, which expires
+	// (8h by default) and renews with a SINGLE-USE refresh token. Zero
+	// tokenExpiry means the token does not expire (a classic OAuth app, or
+	// expiration opted out) and refresh stays empty.
+	refresh     string
+	tokenExpiry time.Time
 }
 
 // persistedState is the on-disk envelope. Only the dynamically registered MCP
@@ -85,6 +91,10 @@ type persistedSession struct {
 	Token   string    `json:"token"`
 	Login   string    `json:"login"`
 	Created time.Time `json:"created"`
+	// Refresh/TokenExpiry survive restarts with the session: losing the
+	// refresh token would sign everyone out at the next expiry instead.
+	Refresh     string    `json:"refresh,omitempty"`
+	TokenExpiry time.Time `json:"tokenExpiry,omitempty"`
 }
 
 // authManager runs the GitHub OAuth web flow and keeps per-user sessions. They
@@ -113,6 +123,12 @@ type authManager struct {
 
 	mu       sync.Mutex
 	sessions map[string]oauthSession
+	// refreshing single-flights token renewal per session: GitHub's refresh
+	// token is SINGLE-USE, so two concurrent renewals would burn it — the
+	// second gets "bad_refresh_token" and the session dies for no reason.
+	// Callers land here only when the token is already past its expiry;
+	// while a renewal is in flight they wait on its channel.
+	refreshing map[string]chan struct{}
 	// clients holds dynamically-registered MCP OAuth clients (RFC 7591).
 	clients map[string]oauthClient
 	// pendingAuth tracks in-flight MCP authorizations, keyed by the GitHub
@@ -160,7 +176,7 @@ type authCode struct {
 // issued until the user confirms the client and (remote) redirect target, so a
 // phished authorize link cannot silently deliver a code to an attacker's URI.
 type pendingConsent struct {
-	ghToken       string
+	grant         ghGrant
 	login         string
 	clientID      string
 	redirectURI   string
@@ -264,7 +280,10 @@ func (a *authManager) load() {
 			now := time.Now()
 			for sid, s := range sessions {
 				if now.Sub(s.Created) <= sessionTTL {
-					a.sessions[sid] = oauthSession{token: s.Token, login: s.Login, created: s.Created}
+					a.sessions[sid] = oauthSession{
+						token: s.Token, login: s.Login, created: s.Created,
+						refresh: s.Refresh, tokenExpiry: s.TokenExpiry,
+					}
 				}
 			}
 		}
@@ -289,7 +308,10 @@ func (a *authManager) saveLocked() {
 	if a.sessionKey != nil && len(a.sessions) > 0 {
 		sessions := make(map[string]persistedSession, len(a.sessions))
 		for sid, s := range a.sessions {
-			sessions[sid] = persistedSession{Token: s.token, Login: s.login, Created: s.created}
+			sessions[sid] = persistedSession{
+				Token: s.token, Login: s.login, Created: s.created,
+				Refresh: s.refresh, TokenExpiry: s.tokenExpiry,
+			}
 		}
 		if enc, err := encryptSessions(a.sessionKey, sessions); err != nil {
 			a.log.Error("session encrypt failed; not persisting sessions", "err", err)
@@ -341,24 +363,103 @@ func (a *authManager) dropSession(id string) string {
 	return s.login
 }
 
-// session resolves the request's session cookie to a live session.
+// session resolves the request's session cookie to a live session, renewing
+// its GitHub token when the token has expired (a GitHub App user token lives
+// 8h; the session is allowed to outlive it precisely because of this).
 func (a *authManager) session(r *http.Request) (oauthSession, bool) {
 	c, err := r.Cookie(sessionCookie)
 	if err != nil || c.Value == "" {
 		return oauthSession{}, false
 	}
+	return a.sessionByID(r.Context(), c.Value)
+}
+
+// sessionByID is session for a bare id — the MCP bearer path uses it too.
+func (a *authManager) sessionByID(ctx context.Context, sid string) (oauthSession, bool) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	s, ok := a.sessions[c.Value]
+	s, ok := a.sessions[sid]
 	if !ok {
+		a.mu.Unlock()
 		return oauthSession{}, false
 	}
 	if time.Since(s.created) > sessionTTL {
-		delete(a.sessions, c.Value)
+		delete(a.sessions, sid)
 		a.saveLocked()
+		a.mu.Unlock()
 		return oauthSession{}, false
 	}
-	return s, true
+	// The GitHub token is renewed a little AHEAD of its expiry, so requests
+	// keep riding a valid token instead of queueing behind a renewal.
+	if s.tokenExpiry.IsZero() || time.Until(s.tokenExpiry) > tokenRenewAhead || s.refresh == "" {
+		a.mu.Unlock()
+		return s, true
+	}
+	return a.renewSession(ctx, sid, s)
+}
+
+// tokenRenewAhead is how early a session's GitHub token is renewed. Well
+// inside the 8h lifetime, and long enough that a request never has to use a
+// token in its final seconds.
+const tokenRenewAhead = 10 * time.Minute
+
+// renewSession refreshes sid's GitHub token, single-flight. Called with a.mu
+// HELD; returns with it released.
+func (a *authManager) renewSession(ctx context.Context, sid string, s oauthSession) (oauthSession, bool) {
+	if ch, busy := a.refreshing[sid]; busy {
+		stillValid := time.Now().Before(s.tokenExpiry)
+		a.mu.Unlock()
+		if stillValid {
+			// The old token still works; no reason to queue behind the renewal.
+			return s, true
+		}
+		<-ch
+		a.mu.Lock()
+		s, ok := a.sessions[sid]
+		a.mu.Unlock()
+		return s, ok
+	}
+	ch := make(chan struct{})
+	if a.refreshing == nil {
+		a.refreshing = map[string]chan struct{}{}
+	}
+	a.refreshing[sid] = ch
+	a.mu.Unlock()
+
+	grant, err := a.refreshGrant(ctx, s.refresh)
+
+	a.mu.Lock()
+	delete(a.refreshing, sid)
+	close(ch)
+	cur, ok := a.sessions[sid]
+	if !ok {
+		a.mu.Unlock()
+		return oauthSession{}, false
+	}
+	if err != nil {
+		// The refresh token was refused or unreachable. Keep the session as
+		// long as its access token might still work — a network blip must
+		// not sign anyone out — and only drop it once both are dead.
+		if time.Now().After(cur.tokenExpiry) {
+			delete(a.sessions, sid)
+			a.saveLocked()
+			a.mu.Unlock()
+			a.log.Warn("github token renewal failed; session dropped", "login", cur.login, "err", err)
+			return oauthSession{}, false
+		}
+		a.mu.Unlock()
+		a.log.Warn("github token renewal failed; keeping the current token", "login", cur.login, "err", err)
+		return cur, true
+	}
+	cur.token = grant.token
+	cur.tokenExpiry = grant.expiry
+	if grant.refresh != "" {
+		cur.refresh = grant.refresh
+	}
+	a.sessions[sid] = cur
+	a.saveLocked()
+	a.mu.Unlock()
+	a.log.Info("github token renewed", "login", cur.login)
+	return cur, true
 }
 
 // sessionID returns the caller's session cookie value ("" when absent). It
@@ -438,13 +539,13 @@ func (a *authManager) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := a.exchange(r.Context(), code)
+	grant, err := a.exchange(r.Context(), code)
 	if err != nil {
 		a.log.Error("oauth token exchange failed", "err", err)
 		writeJSONError(w, http.StatusBadGateway, "token exchange failed")
 		return
 	}
-	login, err := a.fetchLogin(r.Context(), token)
+	login, err := a.fetchLogin(r.Context(), grant.token)
 	if err != nil {
 		a.log.Error("oauth user lookup failed", "err", err)
 		writeJSONError(w, http.StatusBadGateway, "could not read GitHub user")
@@ -453,7 +554,10 @@ func (a *authManager) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	sid := randToken()
 	a.mu.Lock()
-	a.sessions[sid] = oauthSession{token: token, login: login, created: time.Now()}
+	a.sessions[sid] = oauthSession{
+		token: grant.token, login: login, created: time.Now(),
+		refresh: grant.refresh, tokenExpiry: grant.expiry,
+	}
 	a.saveLocked()
 	a.mu.Unlock()
 	a.setCookie(w, sessionCookie, sid, int(sessionTTL/time.Second))
@@ -472,38 +576,70 @@ func (a *authManager) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 
-func (a *authManager) exchange(ctx context.Context, code string) (string, error) {
+// ghGrant is what GitHub's token endpoint hands back. A GitHub App issues
+// expiring user tokens (8h) with a single-use refresh token; a classic OAuth
+// app leaves ExpiresIn and RefreshToken empty and the token lives until it is
+// revoked.
+type ghGrant struct {
+	token   string
+	refresh string
+	expiry  time.Time // zero = does not expire
+}
+
+func (a *authManager) exchange(ctx context.Context, code string) (ghGrant, error) {
 	form := url.Values{}
 	form.Set("client_id", a.cfg.ClientID)
 	form.Set("client_secret", a.cfg.ClientSecret)
 	form.Set("code", code)
 	form.Set("redirect_uri", a.redirectURI())
 
+	return a.tokenGrant(ctx, form)
+}
+
+// refreshGrant renews an expiring GitHub App user token. The refresh token is
+// single-use: the grant that comes back carries its replacement.
+func (a *authManager) refreshGrant(ctx context.Context, refresh string) (ghGrant, error) {
+	form := url.Values{}
+	form.Set("client_id", a.cfg.ClientID)
+	form.Set("client_secret", a.cfg.ClientSecret)
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refresh)
+	return a.tokenGrant(ctx, form)
+}
+
+// tokenGrant posts a form to GitHub's token endpoint and reads the grant.
+func (a *authManager) tokenGrant(ctx context.Context, form url.Values) (ghGrant, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return "", err
+		return ghGrant{}, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return "", err
+		return ghGrant{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	var out struct {
 		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		ExpiresIn        int64  `json:"expires_in"`
 		Error            string `json:"error"`
 		ErrorDescription string `json:"error_description"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return "", err
+		return ghGrant{}, err
 	}
 	if out.AccessToken == "" {
-		return "", fmt.Errorf("no access token (%s: %s)", out.Error, out.ErrorDescription)
+		return ghGrant{}, fmt.Errorf("no access token (%s: %s)", out.Error, out.ErrorDescription)
 	}
-	return out.AccessToken, nil
+	g := ghGrant{token: out.AccessToken, refresh: out.RefreshToken}
+	if out.ExpiresIn > 0 {
+		g.expiry = time.Now().Add(time.Duration(out.ExpiresIn) * time.Second)
+	}
+	return g, nil
 }
 
 func (a *authManager) fetchLogin(ctx context.Context, token string) (string, error) {

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -231,13 +231,13 @@ func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, 
 		a.redirectError(w, r, p.redirectURI, p.clientState, "invalid_request", "missing authorization code")
 		return
 	}
-	ghToken, err := a.exchange(r.Context(), code)
+	grant, err := a.exchange(r.Context(), code)
 	if err != nil {
 		a.log.Error("mcp oauth token exchange failed", "err", err)
 		a.redirectError(w, r, p.redirectURI, p.clientState, "server_error", "token exchange failed")
 		return
 	}
-	login, err := a.fetchLogin(r.Context(), ghToken)
+	login, err := a.fetchLogin(r.Context(), grant.token)
 	if err != nil {
 		a.log.Error("mcp oauth user lookup failed", "err", err)
 		a.redirectError(w, r, p.redirectURI, p.clientState, "server_error", "could not read GitHub user")
@@ -245,21 +245,24 @@ func (a *authManager) handleMCPCallback(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if isLoopbackRedirect(p.redirectURI) {
-		a.completeMCPAuth(w, r, ghToken, login, p)
+		a.completeMCPAuth(w, r, grant, login, p)
 		return
 	}
-	a.promptConsent(w, ghToken, login, p)
+	a.promptConsent(w, grant, login, p)
 }
 
 // completeMCPAuth opens the session, mints a single-use MCP authorization code
 // and bounces the browser back to the client's redirect_uri. It runs only for a
 // loopback redirect or after the user approves the consent screen.
-func (a *authManager) completeMCPAuth(w http.ResponseWriter, r *http.Request, ghToken, login string, p pendingAuth) {
+func (a *authManager) completeMCPAuth(w http.ResponseWriter, r *http.Request, grant ghGrant, login string, p pendingAuth) {
 	now := time.Now()
 	sid := randToken()
 	mcpCode := randToken()
 	a.mu.Lock()
-	a.sessions[sid] = oauthSession{token: ghToken, login: login, created: now}
+	a.sessions[sid] = oauthSession{
+		token: grant.token, login: login, created: now,
+		refresh: grant.refresh, tokenExpiry: grant.expiry,
+	}
 	a.saveLocked()
 	a.authCodes[mcpCode] = authCode{
 		sid:           sid,
@@ -289,13 +292,13 @@ func (a *authManager) completeMCPAuth(w http.ResponseWriter, r *http.Request, gh
 // screen, binding it to this browser via a cookie so only the user who just
 // authenticated can approve (and a cross-site POST, which drops the Lax cookie,
 // cannot).
-func (a *authManager) promptConsent(w http.ResponseWriter, ghToken, login string, p pendingAuth) {
+func (a *authManager) promptConsent(w http.ResponseWriter, grant ghGrant, login string, p pendingAuth) {
 	consentID := randToken()
 	browserToken := randToken()
 	a.mu.Lock()
 	a.pruneEphemeralLocked()
 	a.pendingConsent[consentID] = pendingConsent{
-		ghToken:       ghToken,
+		grant:         grant,
 		login:         login,
 		clientID:      p.clientID,
 		redirectURI:   p.redirectURI,
@@ -352,7 +355,7 @@ func (a *authManager) handleConsent(w http.ResponseWriter, r *http.Request) {
 		a.redirectError(w, r, pc.redirectURI, pc.clientState, "access_denied", "user denied the request")
 		return
 	}
-	a.completeMCPAuth(w, r, pc.ghToken, pc.login, p)
+	a.completeMCPAuth(w, r, pc.grant, pc.login, p)
 }
 
 // handleToken redeems an MCP authorization code for an access token. The token
@@ -425,15 +428,11 @@ func (a *authManager) handleToken(w http.ResponseWriter, r *http.Request) {
 
 // verifyToken is the auth.TokenVerifier backing /mcp: it maps a bearer token
 // (= session id) to its TokenInfo, carrying the user's GitHub token in Extra.
-func (a *authManager) verifyToken(_ context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
-	a.mu.Lock()
-	s, ok := a.sessions[token]
-	if ok && time.Since(s.created) > sessionTTL {
-		delete(a.sessions, token)
-		a.saveLocked()
-		ok = false
-	}
-	a.mu.Unlock()
+func (a *authManager) verifyToken(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+	// Through the same gate the web session uses: it renews an expiring
+	// GitHub token in place, which is what stops the MCP token "slipping"
+	// every eight hours while the aeman session behind it is still live.
+	s, ok := a.sessionByID(ctx, token)
 	if !ok {
 		return nil, fmt.Errorf("unknown or expired session: %w", auth.ErrInvalidToken)
 	}

--- a/internal/server/token_refresh_test.go
+++ b/internal/server/token_refresh_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A GitHub stub whose refresh tokens are single-use, like the real one's.
+type ghStub struct {
+	mu       sync.Mutex
+	refreshN atomic.Int32
+	valid    map[string]bool // refresh tokens still redeemable
+}
+
+func (g *ghStub) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") == "refresh_token" {
+			n := g.refreshN.Add(1)
+			g.mu.Lock()
+			ok := g.valid[r.Form.Get("refresh_token")]
+			if ok {
+				delete(g.valid, r.Form.Get("refresh_token")) // single-use
+				g.valid[fmt.Sprintf("refresh-%d", n)] = true
+			}
+			g.mu.Unlock()
+			if !ok {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "bad_refresh_token"})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  fmt.Sprintf("gh-token-%d", n),
+				"refresh_token": fmt.Sprintf("refresh-%d", n),
+				"expires_in":    28800,
+			})
+			return
+		}
+		http.Error(w, "unexpected grant", http.StatusBadRequest)
+	})
+	return mux
+}
+
+// An expired GitHub token renews on the next session read — web or MCP — and
+// two concurrent reads burn the single-use refresh token exactly once.
+func TestSessionRenewsItsGitHubToken(t *testing.T) {
+	stub := &ghStub{valid: map[string]bool{"refresh-0": true}}
+	srv := httptest.NewServer(stub.handler())
+	defer srv.Close()
+
+	a := newAuthManager(OAuthConfig{ClientID: "id", ClientSecret: "sec", BaseURL: "http://localhost"}, slog.Default())
+	a.tokenURL = srv.URL + "/token"
+	a.client = srv.Client()
+
+	a.mu.Lock()
+	a.sessions["sid1"] = oauthSession{
+		token: "gh-token-0", login: "kvaps", created: time.Now(),
+		refresh: "refresh-0", tokenExpiry: time.Now().Add(-time.Minute), // already expired
+	}
+	a.mu.Unlock()
+
+	var wg sync.WaitGroup
+	tokens := make([]string, 4)
+	for i := range tokens {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, ok := a.sessionByID(context.Background(), "sid1")
+			if !ok {
+				t.Errorf("reader %d lost the session", i)
+				return
+			}
+			tokens[i] = s.token
+		}(i)
+	}
+	wg.Wait()
+	if n := stub.refreshN.Load(); n != 1 {
+		t.Fatalf("the single-use refresh token was redeemed %d times", n)
+	}
+	for i, tok := range tokens {
+		if tok != "gh-token-1" {
+			t.Fatalf("reader %d got token %q, want the renewed one", i, tok)
+		}
+	}
+	// The stored refresh token is the NEW one; the next expiry renews again.
+	a.mu.Lock()
+	s := a.sessions["sid1"]
+	s.tokenExpiry = time.Now().Add(-time.Second)
+	a.sessions["sid1"] = s
+	a.mu.Unlock()
+	if s.refresh != "refresh-1" {
+		t.Fatalf("the replacement refresh token was not kept: %q", s.refresh)
+	}
+	if got, ok := a.sessionByID(context.Background(), "sid1"); !ok || got.token != "gh-token-2" {
+		t.Fatalf("second renewal: %v %q", ok, got.token)
+	}
+}
+
+// A renewal failure while the access token is still alive must not sign the
+// user out — a network blip is not a logout.
+func TestRenewalFailureKeepsALiveToken(t *testing.T) {
+	stub := &ghStub{valid: map[string]bool{}} // every refresh is refused
+	srv := httptest.NewServer(stub.handler())
+	defer srv.Close()
+	a := newAuthManager(OAuthConfig{ClientID: "id", ClientSecret: "sec", BaseURL: "http://localhost"}, slog.Default())
+	a.tokenURL = srv.URL + "/token"
+	a.client = srv.Client()
+	a.mu.Lock()
+	a.sessions["sid1"] = oauthSession{
+		token: "gh-token-0", login: "kvaps", created: time.Now(),
+		refresh: "refresh-dead", tokenExpiry: time.Now().Add(5 * time.Minute), // inside renew-ahead, still valid
+	}
+	a.mu.Unlock()
+	s, ok := a.sessionByID(context.Background(), "sid1")
+	if !ok || s.token != "gh-token-0" {
+		t.Fatalf("a failed renewal dropped a session whose token still works: %v %q", ok, s.token)
+	}
+	// Once the token is dead too, the session goes.
+	a.mu.Lock()
+	cur := a.sessions["sid1"]
+	cur.tokenExpiry = time.Now().Add(-time.Minute)
+	a.sessions["sid1"] = cur
+	a.mu.Unlock()
+	if _, ok := a.sessionByID(context.Background(), "sid1"); ok {
+		t.Fatal("a session with a dead token and a dead refresh token must end")
+	}
+}


### PR DESCRIPTION
## What

A signed-in session now survives its GitHub token expiring: the token is renewed in place, ahead of the expiry, instead of the session being dropped.

## Why

The sign-in app is a GitHub App, whose user tokens expire (8 hours by default) and come with a single-use refresh token. The token exchange read only `access_token`, so eight hours after signing in GitHub started answering `Bad credentials`, the session was dropped and the user had to sign in again — several times a day, on both the web UI and MCP.

## How it behaves now

- The exchange keeps the whole grant — token, refresh token, expiry — in the session, encrypted at rest with the rest of the session state and surviving restarts.
- The session gate renews the token shortly before it expires, on whichever path touches the session first: the web cookie or the MCP bearer token, which now resolves through that same gate.
- Renewal is single-flight per session, because the refresh token is single-use: two concurrent renewals would burn it and end the session for no reason. Concurrent readers keep riding the still-valid token while one renewal is in flight, and the replacement refresh token is stored.
- A renewal failure while the access token still works is logged and ignored — a network blip must not sign anyone out. Only a session whose access token and refresh token are both dead is ended.
- Nothing changes for a classic OAuth app, whose grant carries no expiry.

## Known seam

The board-cache warmer holds the token it was seeded with, so its first refresh after a renewal fails once and it re-seeds from the next live request. One tick of degradation, no data loss.

## Upgrade note

Sessions created before this change carry no refresh token, so everyone signs in once more after the deploy — and that is the last unprompted sign-in.

## Testing

- New tests drive a GitHub stub whose refresh tokens are single-use: an expired token renews on the next read, four concurrent readers redeem it exactly once and all see the renewed token, the replacement refresh token is used for the following renewal, and a refused renewal keeps a still-valid session but ends a fully dead one.
- Full `go test ./...` and `golangci-lint run` (0 issues).