### PR TITLE
feat(server): detached cold loads and a startup-warmed cache

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -224,6 +224,16 @@ func (s *Server) apiClient(r *http.Request) (*ghprojects.Client, error) {
 	return ghprojects.New(tok, opts...), nil
 }
 
+// newGHClient builds the ghprojects client for a bare token — the same
+// construction apiClient does for a request, reused by the startup warmer.
+func (s *Server) newGHClient(token string) *ghprojects.Client {
+	opts := []ghprojects.Option{ghprojects.WithHTTPClient(s.httpClient)}
+	if s.graphqlEndpoint != "" {
+		opts = append(opts, ghprojects.WithEndpoint(s.graphqlEndpoint))
+	}
+	return ghprojects.New(token, opts...)
+}
+
 // defaultService is the production newService: it builds a boardservice over the
 // per-request ghprojects client (*ghprojects.Client satisfies boardservice.Backend).
 func (s *Server) defaultService(r *http.Request) (*boardservice.Service, error) {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -472,6 +472,26 @@ func (a *authManager) sessionID(r *http.Request) string {
 	return c.Value
 }
 
+// newestSessionFor finds a login's freshest live session — the startup
+// warmer's way back onto a token after a restart — renewing its GitHub token
+// through the usual gate when it is close to expiry.
+func (a *authManager) newestSessionFor(ctx context.Context, login string) (string, oauthSession, bool) {
+	a.mu.Lock()
+	best := ""
+	var bestAt time.Time
+	for sid, s := range a.sessions {
+		if s.login == login && time.Since(s.created) <= sessionTTL && s.created.After(bestAt) {
+			best, bestAt = sid, s.created
+		}
+	}
+	a.mu.Unlock()
+	if best == "" {
+		return "", oauthSession{}, false
+	}
+	s, ok := a.sessionByID(ctx, best)
+	return best, s, ok
+}
+
 // sessionAlive reports whether sid still maps to a live, unexpired session.
 // The board warmer polls it each tick so a captured token stops being used
 // once its owner's session ends (logout or TTL) — not merely when GitHub

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -827,13 +827,13 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		// error (no access, rate limit, network) to the caller.
 	}
 	e.loadMu.Lock()
-	defer e.loadMu.Unlock()
 	// A concurrent loader — the warmer included — may have refreshed the
 	// cache while we waited on loadMu; a mutation that queued behind the
 	// warmer's reload must ride that result (proving its own access by probe
 	// when needed — but not re-asking after a probe that just failed) instead
 	// of re-paying the full load.
 	if bd, st, rp := e.cached(login, b.multiUser); st == cacheFresh {
+		e.loadMu.Unlock()
 		if rp {
 			b.reproveAsync(ctx, e, owner, project, login)
 		}
@@ -841,6 +841,7 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		return bd, nil
 	} else if st == cacheUnauthed && login != "" && !probeFailed {
 		if bd, st2, ok := b.admitByProbe(ctx, e, owner, project, login); ok && st2 == cacheFresh {
+			e.loadMu.Unlock()
 			b.markRead(e)
 			return bd, nil
 		}
@@ -848,15 +849,46 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 	// The token-scoped backend load is the authorization check: GitHub rejects a
 	// token that can't read this board, so reaching a cached result requires
 	// having passed it (recorded per login in install).
-	fresh, err := b.inner.LoadBoard(ctx, owner, project)
-	if err != nil {
-		return board.Board{}, err
+	//
+	// The fetch is DETACHED from the request: a big board takes the better
+	// part of a minute, the user refreshes the page, the refresh cancels the
+	// request context — and with it, before this, the fetch. Every refresh
+	// restarted the fetch from zero, so a refresh-happy user could keep a
+	// board cold forever while every request appeared to hang. Now the fetch
+	// runs on its own context, the goroutine owns loadMu until it is done
+	// (waiters ride the SAME fetch), and the result lands in the cache — and
+	// seeds the warmer — whether or not anyone is still waiting for it.
+	type loaded struct {
+		bd  board.Board
+		err error
 	}
-	installed := b.install(e, fresh, login)
-	b.setWarmSrc(e, login)
-	b.ensureWarm(e, owner, project)
-	b.markRead(e)
-	return installed, nil
+	done := make(chan loaded, 1)
+	go func() {
+		defer e.loadMu.Unlock()
+		lctx, cancel := context.WithTimeout(context.Background(), warmLoadTimeout)
+		defer cancel()
+		fresh, err := b.inner.LoadBoard(lctx, owner, project)
+		if err != nil {
+			b.store.logger().Warn("board load failed", "owner", owner, "project", project, "err", err)
+			done <- loaded{err: err}
+			return
+		}
+		installed := b.install(e, fresh, login)
+		b.setWarmSrc(e, login)
+		b.ensureWarm(e, owner, project)
+		done <- loaded{bd: installed}
+	}()
+	select {
+	case l := <-done:
+		if l.err != nil {
+			return board.Board{}, l.err
+		}
+		b.markRead(e)
+		return l.bd, nil
+	case <-ctx.Done():
+		// The fetch carries on without us; the next request finds it warm.
+		return board.Board{}, ctx.Err()
+	}
 }
 
 // accessProber is the cheap authorization check a backend may offer: can this

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -659,6 +659,11 @@ type boardStore struct {
 	// log receives warmer lifecycle events (start/stop and on whose token it
 	// runs). Nil-safe via logger().
 	log *slog.Logger
+	// warmFile persists the warm roster (board -> warming login) across
+	// restarts, so startup can bring the cache up before the first request.
+	// Empty = no persistence. warmRoster is its in-memory copy.
+	warmFile   string
+	warmRoster map[string]string
 }
 
 // logger returns the store's logger, or a discard logger when none was wired
@@ -863,8 +868,9 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		err error
 	}
 	done := make(chan loaded, 1)
-	go func() {
+	go func() { //nolint:gosec // G118: the whole point — the fetch must outlive its request
 		defer e.loadMu.Unlock()
+		// Deliberately NOT the request context: the detachment is the fix.
 		lctx, cancel := context.WithTimeout(context.Background(), warmLoadTimeout)
 		defer cancel()
 		fresh, err := b.inner.LoadBoard(lctx, owner, project)
@@ -1023,7 +1029,21 @@ func (b *storeBackend) setWarmSrc(e *boardEntry, login string) {
 	}
 	e.mu.Lock()
 	e.warmSrc = &warmSource{inner: b.inner, alive: b.warmAlive, login: login}
+	key := storeKeyOf(b.store, e)
 	e.mu.Unlock()
+	b.store.recordWarm(key, login)
+}
+
+// storeKeyOf finds an entry's key (entries are few; a scan is fine).
+func storeKeyOf(s *boardStore, e *boardEntry) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, v := range s.entries {
+		if v == e {
+			return k
+		}
+	}
+	return ""
 }
 
 // ensureWarm keeps a board's cache from ever crossing boardFreshFor while

--- a/internal/server/detached_load_test.go
+++ b/internal/server/detached_load_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/boardservice/boardservicetest"
+)
+
+// gatedLoads wraps the test backend so a full load blocks until released —
+// the shape of a multi-page GitHub fetch on a big board.
+type gatedLoads struct {
+	boardservice.Backend
+	gate  chan struct{}
+	loads atomic.Int32
+}
+
+func (g *gatedLoads) LoadBoard(ctx context.Context, owner string, project int) (board.Board, error) {
+	g.loads.Add(1)
+	select {
+	case <-g.gate:
+	case <-ctx.Done():
+		return board.Board{}, ctx.Err()
+	}
+	return g.Backend.LoadBoard(ctx, owner, project)
+}
+
+// A cold load survives the request that started it: the user refreshing the
+// page (their context dying) must not kill the minute-long fetch — the next
+// request rides the load already in flight, and its result lands in the
+// cache. Before this, every refresh restarted the fetch from zero and a
+// refresh-happy user could keep a board cold forever.
+func TestColdLoadSurvivesItsRequest(t *testing.T) {
+	store := newBoardStore()
+	fake := boardservicetest.New([]board.Card{{ItemID: "c1", Title: "one"}}, nil)
+	gated := &gatedLoads{Backend: fake, gate: make(chan struct{})}
+	be := &storeBackend{inner: gated, store: store}
+
+	// The first request dies mid-load.
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, err := be.LoadBoard(ctx, "o", 1); err == nil {
+			t.Error("a canceled request should answer with its context error")
+		}
+	}()
+	time.Sleep(50 * time.Millisecond) // let it reach the gate
+	cancel()
+	wg.Wait()
+
+	// The fetch is still in flight; releasing it must fill the cache.
+	close(gated.gate)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		bd, err := be.LoadBoard(context.Background(), "o", 1)
+		if err == nil && len(bd.Cards) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the detached load never landed in the cache")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// The whole episode cost ONE backend fetch: the second request joined the
+	// first one's load instead of restarting it.
+	if n := gated.loads.Load(); n != 1 {
+		t.Fatalf("backend was loaded %d times, want 1", n)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,11 @@ func New(opts Options) (*Server, error) {
 	s.store.log = s.log
 	if opts.Auth != nil {
 		s.auth = newAuthManager(*opts.Auth, opts.Logger)
+		// The warm roster lives next to the session file: restarts bring the
+		// cache back up instead of leaving a cold-load pit (startupWarm).
+		if opts.Auth.SessionFile != "" {
+			s.store.warmFile = opts.Auth.SessionFile + ".boards"
+		}
 	}
 
 	mux := http.NewServeMux()
@@ -198,6 +203,11 @@ func (s *Server) Run(ctx context.Context) error {
 		Handler:           s.handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+
+	// Bring the cache up in the background: the boards that were warm before
+	// the restart, or the default board in local mode. Nothing waits on it —
+	// requests that arrive first simply ride the same detached loads.
+	go s.startupWarm()
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/server/startupwarm.go
+++ b/internal/server/startupwarm.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aenix-io/aeman/pkg/board"
+)
+
+// The warm roster: which boards were being kept warm, and on whose session.
+// It exists so a RESTART does not leave a cold-cache pit — before it, every
+// deploy meant the first person on each board personally paid the minute-long
+// load while the UI looked broken. The file sits next to the session file and
+// holds no secrets: board keys and logins only, the tokens stay in the
+// session store.
+
+// recordWarm notes that a board is warmed on some login's session and saves
+// the roster when that changed.
+func (s *boardStore) recordWarm(key, login string) {
+	if s.warmFile == "" || key == "" || login == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.warmRoster == nil {
+		s.warmRoster = map[string]string{}
+	}
+	if s.warmRoster[key] == login {
+		s.mu.Unlock()
+		return
+	}
+	s.warmRoster[key] = login
+	data, err := json.Marshal(s.warmRoster)
+	path := s.warmFile
+	s.mu.Unlock()
+	if err != nil {
+		return
+	}
+	// Best-effort, atomic: a torn write must not eat the roster.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		s.logger().Warn("warm roster not saved", "err", err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		s.logger().Warn("warm roster not saved", "err", err)
+	}
+}
+
+// loadWarmRoster reads the persisted roster (missing file = empty roster).
+func (s *boardStore) loadWarmRoster() map[string]string {
+	if s.warmFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(s.warmFile)
+	if err != nil {
+		return nil
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		s.logger().Warn("warm roster unreadable; starting empty", "err", err)
+		return nil
+	}
+	s.mu.Lock()
+	s.warmRoster = out
+	s.mu.Unlock()
+	return out
+}
+
+// startupWarm brings the cache up right after start instead of waiting for
+// the first request to pay the cold load.
+func (s *Server) startupWarm() {
+	if s.auth == nil {
+		// Local mode: one user, one token — warm the default board with it.
+		if s.opts.DefaultOwner == "" || s.opts.DefaultProject == 0 {
+			return
+		}
+		s.warmOne(s.opts.DefaultOwner, s.opts.DefaultProject, "")
+		return
+	}
+	for key, login := range s.store.loadWarmRoster() {
+		owner, numStr, ok := strings.Cut(key, "/")
+		num, err := strconv.Atoi(numStr)
+		if !ok || err != nil || owner == "" || login == "" {
+			continue
+		}
+		go s.warmOne(owner, num, login)
+	}
+}
+
+// warmOne loads one board into the cache on the given login's freshest live
+// session (or the local token when login is empty), seeding the warmer.
+func (s *Server) warmOne(owner string, num int, login string) {
+	ctx := context.Background()
+	var be *storeBackend
+	if s.auth == nil {
+		tok, err := s.tokens.Token(ctx)
+		if err != nil {
+			s.log.Warn("startup warm skipped: no local token", "err", err)
+			return
+		}
+		be = &storeBackend{inner: &resolvingBackend{inner: s.newGHClient(tok), store: s.store}, store: s.store}
+	} else {
+		sid, sess, ok := s.auth.newestSessionFor(ctx, login)
+		if !ok {
+			s.log.Info("startup warm skipped: no live session", "board", storeKey(owner, num), "login", login)
+			return
+		}
+		client := s.newGHClient(sess.token)
+		auth := s.auth
+		be = &storeBackend{
+			inner: &resolvingBackend{inner: client, store: s.store}, store: s.store,
+			multiUser: true,
+			warmAlive: func() bool { return auth.sessionAlive(sid) },
+		}
+		ctx = board.WithActor(ctx, login)
+	}
+	s.log.Info("startup warm began", "board", storeKey(owner, num), "login", login)
+	if _, err := be.LoadBoard(ctx, owner, num); err != nil {
+		s.log.Warn("startup warm failed", "board", storeKey(owner, num), "err", err)
+		return
+	}
+	s.log.Info("startup warm done", "board", storeKey(owner, num))
+}

--- a/internal/server/startupwarm_test.go
+++ b/internal/server/startupwarm_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice/boardservicetest"
+)
+
+// The warm roster survives a restart: a session-bound load records which
+// board is warmed on whose login, and a fresh store reads the roster back —
+// that is what startupWarm feeds on so a deploy leaves no cold-cache pit.
+func TestWarmRosterSurvivesRestart(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "sessions.json.boards")
+	store := newBoardStore()
+	store.warmFile = file
+	fake := boardservicetest.New([]board.Card{{ItemID: "c1", Title: "one"}}, nil)
+	be := &storeBackend{
+		inner: fake, store: store, multiUser: true,
+		warmAlive: func() bool { return true },
+	}
+	ctx := board.WithActor(context.Background(), "kvaps")
+	if _, err := be.LoadBoard(ctx, "acme", 7); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := newBoardStore()
+	restarted.warmFile = file
+	roster := restarted.loadWarmRoster()
+	if roster["acme/7"] != "kvaps" {
+		t.Fatalf("roster after restart = %v, want acme/7 -> kvaps", roster)
+	}
+}
+
+// An MCP-style load (no session liveness check) must not be recorded: its
+// token has nothing to ever stop the warmer, so it may not power one.
+func TestUncheckedTokenNotRecorded(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "roster.json")
+	store := newBoardStore()
+	store.warmFile = file
+	fake := boardservicetest.New(nil, nil)
+	be := &storeBackend{inner: fake, store: store, multiUser: true} // no warmAlive
+	ctx := board.WithActor(context.Background(), "kvaps")
+	if _, err := be.LoadBoard(ctx, "acme", 7); err != nil {
+		t.Fatal(err)
+	}
+	if roster := newBoardStoreWithFile(file).loadWarmRoster(); len(roster) != 0 {
+		t.Fatalf("an unchecked token was recorded: %v", roster)
+	}
+}
+
+func newBoardStoreWithFile(file string) *boardStore {
+	s := newBoardStore()
+	s.warmFile = file
+	return s
+}
+
+// newestSessionFor picks the login's freshest live session — the way back
+// onto a token after a restart.
+func TestNewestSessionFor(t *testing.T) {
+	a := newAuthManager(OAuthConfig{ClientID: "id", ClientSecret: "s", BaseURL: "http://x"}, nil)
+	now := time.Now()
+	a.sessions["old"] = oauthSession{token: "t-old", login: "kvaps", created: now.Add(-2 * time.Hour)}
+	a.sessions["new"] = oauthSession{token: "t-new", login: "kvaps", created: now.Add(-time.Minute)}
+	a.sessions["other"] = oauthSession{token: "t-x", login: "tym83", created: now}
+	sid, s, ok := a.newestSessionFor(context.Background(), "kvaps")
+	if !ok || sid != "new" || s.token != "t-new" {
+		t.Fatalf("got %q %q %v, want the freshest kvaps session", sid, s.token, ok)
+	}
+	if _, _, ok := a.newestSessionFor(context.Background(), "nobody"); ok {
+		t.Fatal("a login with no sessions must not resolve")
+	}
+}


### PR DESCRIPTION
## What

Two halves of one production incident — "aeman is down", then "it came back on its own":

1. **A cold board load survives the request that started it.** A big board's first fetch takes the better part of a minute and rode the request context: refreshing the page canceled the fetch, the next request started it from zero, and a refresh-happy user could keep a board cold forever while every request appeared to hang. The fetch now runs detached on its own context (with the warm-load timeout); the loading goroutine owns the load lock, so every concurrent request rides the SAME fetch; the result lands in the cache — and seeds the warmer — whether or not anyone is still waiting. A failed fetch is logged instead of vanishing with its dead client. This also closes a quieter hole: the warmer is seeded only by a successful load, so a board whose loads kept being canceled never got a warmer at all.

2. **The cache warms at startup.** A restart wiped the in-memory cache and every deploy left a pit: the first person on each board paid the cold load while the UI looked broken. The store now keeps a warm roster (board → the login whose session warms it) in a file next to the session store — keys and logins only, no secrets — and startup replays it: each board loads in the background on that login's freshest live session, renewed through the usual token gate, seeding the warmer exactly as a live request would. In local mode the default board warms on the CLI token. A load on a token with no liveness check (MCP) is never recorded, since nothing would ever stop that warmer.

## Testing

- `TestColdLoadSurvivesItsRequest` — the canceled request answers with its context error, the fetch lands in the cache, and the whole episode costs ONE backend fetch.
- `TestWarmRosterSurvivesRestart`, `TestUncheckedTokenNotRecorded`, `TestNewestSessionFor`.
- Live smoke test: a fresh local server logs `startup warm began/done` and the first board read answers warm.

## Note for this deploy

The roster file does not exist on production yet — it is written by the new binary on the first session-bound load of each board. So this one deploy still starts cold; every restart after it warms automatically.