### PR TITLE
fix(project): resize drags that stick, batch echoes that vanish, silent slow paths

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -71,6 +71,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 | V4 | Watch (view-scoped): entering/leaving the selection delivers ADDED/DELETED for that subscription | 🆕 apiserver `TestScopedWatch*` |
 | V5 | Ordering singleton: move emits one MODIFIED Ordering; LIST stays sorted | 🆕 apiserver `TestOrdering*` |
 
+| V+ | Echo suppression is scoped to the ADDRESSED card: the author's watch is spared the echo only for the {uid} their request named — a batch fan-out (epic rename over its cards) or a cascade (a subtask following its parent) echoes even to the author, who holds no optimistic copy of those cards. Unscoped suppression made a renamed column's cards vanish from the very board that renamed it | internal/server echoOrigin + clientIDMiddleware | ✅ TestBatchEchoesReachTheirAuthor / TestAddressedCardStaysSuppressed |
+
 ## Card object mapping
 
 | # | Rule | Test |

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -899,6 +899,8 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		err error
 	}
 	done := make(chan loaded, 1)
+	b.store.logger().Info("board load began", "board", storeKey(owner, project), "login", login)
+	started := time.Now()
 	go func() { //nolint:gosec // G118: the whole point — the fetch must outlive its request
 		defer e.loadMu.Unlock()
 		// Deliberately NOT the request context: the detachment is the fix.
@@ -906,10 +908,13 @@ func (b *storeBackend) LoadBoard(ctx context.Context, owner string, project int)
 		defer cancel()
 		fresh, err := b.inner.LoadBoard(lctx, owner, project)
 		if err != nil {
-			b.store.logger().Warn("board load failed", "owner", owner, "project", project, "err", err)
+			b.store.logger().Warn("board load failed", "board", storeKey(owner, project),
+				"dur", time.Since(started), "err", err)
 			done <- loaded{err: err}
 			return
 		}
+		b.store.logger().Info("board load done", "board", storeKey(owner, project),
+			"cards", len(fresh.Cards), "dur", time.Since(started))
 		installed := b.install(e, fresh, login)
 		b.setWarmSrc(e, login)
 		b.ensureWarm(e, owner, project)
@@ -1101,6 +1106,7 @@ func (b *storeBackend) ensureWarm(e *boardEntry, owner string, project int) {
 		return
 	}
 	e.warming = true
+	b.store.logger().Info("board warmer started", "board", storeKey(owner, project), "login", e.warmSrc.login)
 	e.mu.Unlock()
 	store := b.store
 	key := storeKey(owner, project)

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -63,6 +63,37 @@ func withClientID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, clientIDCtxKey{}, id)
 }
 
+// targetItemCtxKey carries the item id the client's request ADDRESSED — the
+// {uid} of a /cards/{uid} route. Echo suppression is scoped to it: the author
+// holds an optimistic copy of the card they patched, and only of that card.
+type targetItemCtxKey struct{}
+
+func withTargetItem(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, targetItemCtxKey{}, id)
+}
+
+// echoOrigin is clientIDFrom for one card's change: the author's own watch is
+// spared the echo only when THIS card is the one their request addressed. A
+// cascade onto any other card — an epic rename fanning out, a subtask
+// following its parent — has no optimistic copy on the author's side, and
+// suppressing it left the author's board stale until a reload (the "renamed
+// column loses its cards" bug). A request that addressed no card (a batch
+// action) suppresses nothing.
+func echoOrigin(ctx context.Context, itemID string) string {
+	origin := clientIDFrom(ctx)
+	if origin == "" {
+		return ""
+	}
+	if target, _ := ctx.Value(targetItemCtxKey{}).(string); target != itemID {
+		// The one blind spot: a client still patching by a provisional
+		// local-N id it created moments ago is compared against the adopted
+		// id here; its echo goes through, harmlessly re-asserting the same
+		// values.
+		return ""
+	}
+	return origin
+}
+
 func clientIDFrom(ctx context.Context) string {
 	// Server-side work on nobody's behalf (a background title resolve) must
 	// reach every watcher, including the tab that triggered the create — an
@@ -1334,7 +1365,7 @@ func (b *storeBackend) touched(ctx context.Context, bd board.Board, itemID strin
 	e.markRecent(card.ItemID)
 	for i := range e.board.Cards {
 		if e.board.Cards[i].ItemID == itemID {
-			e.cardChanged(clientIDFrom(ctx), e.board.Cards[i], "MODIFIED")
+			e.cardChanged(echoOrigin(ctx, e.board.Cards[i].ItemID), e.board.Cards[i], "MODIFIED")
 			break
 		}
 	}
@@ -1524,7 +1555,7 @@ func (b *storeBackend) DeleteCard(ctx context.Context, bd board.Board, card boar
 		e.rosterBroadcast()
 		break
 	}
-	e.cardChanged(clientIDFrom(ctx), card, "DELETED")
+	e.cardChanged(echoOrigin(ctx, card.ItemID), card, "DELETED")
 	e.mu.Unlock()
 	return nil
 }
@@ -2097,7 +2128,7 @@ func (b *storeBackend) SetProject(ctx context.Context, bd board.Board, card boar
 		for i := range e.board.Cards {
 			if e.board.Cards[i].ItemID == card.ItemID {
 				e.board.Cards[i].Project = project
-				e.cardChanged(clientIDFrom(ctx), e.board.Cards[i], "MODIFIED")
+				e.cardChanged(echoOrigin(ctx, e.board.Cards[i].ItemID), e.board.Cards[i], "MODIFIED")
 				break
 			}
 		}

--- a/internal/server/echo_test.go
+++ b/internal/server/echo_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+	"github.com/aenix-io/aeman/pkg/boardservice/boardservicetest"
+)
+
+// drainFrames empties a subscription channel into parsed frames.
+func drainFrames(t *testing.T, sub *subscription) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for {
+		select {
+		case raw := <-sub.ch:
+			var f map[string]any
+			if err := json.Unmarshal(raw, &f); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, f)
+		default:
+			return out
+		}
+	}
+}
+
+// cardTitles collects the UNIQUE titles of Card frames with the given verb —
+// the write-behind queue may legitimately re-announce a card after its op
+// lands, and the SPA upserts by item id, so duplicates carry no meaning.
+func cardTitles(frames []map[string]any, verb string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, f := range frames {
+		if f["type"] != verb || f["kind"] != "Card" {
+			continue
+		}
+		obj, _ := f["object"].(map[string]any)
+		spec, _ := obj["spec"].(map[string]any)
+		if s, ok := spec["title"].(string); ok && !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// The author's own watch is spared the echo ONLY for the card their request
+// addressed. A batch operation — an epic rename fanning out over its cards —
+// has no optimistic copy on the author's side: suppressing its echoes made
+// the renamed column's cards vanish from the very board that renamed it.
+func TestBatchEchoesReachTheirAuthor(t *testing.T) {
+	store := newBoardStore()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "e1", Title: board.EpicStateTitle, Epic: "Infra", Project: "p"},
+		{ItemID: "c1", Title: "one", Epic: "Infra", Project: "p"},
+		{ItemID: "c2", Title: "two", Epic: "Infra", Project: "p"},
+	}, nil)
+	be := &storeBackend{inner: fake, store: store}
+	svc := boardservice.New(be)
+	ctx := context.Background()
+	if _, err := be.LoadBoard(ctx, "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	author, cancelA := store.subscribe(storeKey("acme", 1), "tab-A", nil, map[string]bool{"cards": true})
+	defer cancelA()
+	other, cancelB := store.subscribe(storeKey("acme", 1), "tab-B", nil, map[string]bool{"cards": true})
+	defer cancelB()
+
+	// The rename arrives as the author's request (client id, NO target card).
+	rctx := withClientID(ctx, "tab-A")
+	if err := svc.RenameEpic(rctx, "acme", 1, "p", "Infra", "Infra2"); err != nil {
+		t.Fatal(err)
+	}
+	got := cardTitles(drainFrames(t, author), "MODIFIED")
+	if len(got) != 2 || !strings.Contains(strings.Join(got, " "), "one") {
+		t.Fatalf("the author saw %v, want both member cards", got)
+	}
+	if got := cardTitles(drainFrames(t, other), "MODIFIED"); len(got) != 2 {
+		t.Fatalf("the other tab saw %v, want both member cards", got)
+	}
+}
+
+// A single-card patch stays suppressed for its author — that is what the
+// optimistic UI depends on — while cascades onto OTHER cards (a subtask
+// following its parent) echo even to the author.
+func TestAddressedCardStaysSuppressed(t *testing.T) {
+	store := newBoardStore()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "c1", Title: "one", Progress: 10},
+	}, nil)
+	be := &storeBackend{inner: fake, store: store}
+	svc := boardservice.New(be)
+	ctx := context.Background()
+	if _, err := be.LoadBoard(ctx, "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+	author, cancelA := store.subscribe(storeKey("acme", 1), "tab-A", nil, map[string]bool{"cards": true})
+	defer cancelA()
+	other, cancelB := store.subscribe(storeKey("acme", 1), "tab-B", nil, map[string]bool{"cards": true})
+	defer cancelB()
+
+	rctx := withTargetItem(withClientID(ctx, "tab-A"), "c1")
+	if err := svc.SetProgress(rctx, "acme", 1, "c1", 40); err != nil {
+		t.Fatal(err)
+	}
+	if got := cardTitles(drainFrames(t, author), "MODIFIED"); len(got) != 0 {
+		t.Fatalf("the author was echoed their own patch: %v", got)
+	}
+	if got := cardTitles(drainFrames(t, other), "MODIFIED"); len(got) != 1 {
+		t.Fatalf("the other tab saw %v, want the patch", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -424,7 +424,18 @@ func logRequests(log *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		next.ServeHTTP(w, r)
-		log.Debug("request", "method", r.Method, "path", r.URL.Path, "dur", time.Since(start))
+		dur := time.Since(start)
+		switch {
+		// A slow request is the fact that explains every "aeman is down"
+		// report; at Debug they were invisible on production. The watch
+		// socket is exempt — it is SUPPOSED to stay open for hours.
+		case dur > 5*time.Second && !strings.HasPrefix(r.URL.Path, "/api/v1/watch"):
+			log.Warn("slow request", "method", r.Method, "path", r.URL.Path, "dur", dur)
+		case dur > time.Second && !strings.HasPrefix(r.URL.Path, "/api/v1/watch"):
+			log.Info("slow request", "method", r.Method, "path", r.URL.Path, "dur", dur)
+		default:
+			log.Debug("request", "method", r.Method, "path", r.URL.Path, "dur", dur)
+		}
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -435,6 +435,19 @@ func clientIDMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if id := r.Header.Get("X-Aeman-Client"); id != "" {
 			r = r.WithContext(withClientID(r.Context(), id))
+			// The card the request ADDRESSES (the {uid} of /cards/{uid}/...)
+			// scopes the echo suppression: only that card's change is the
+			// author's own optimistic state; everything else a request
+			// touches — batch fan-outs, cascades — echoes even to them.
+			if rest, ok := strings.CutPrefix(r.URL.Path, "/api/v1/cards/"); ok && rest != "" {
+				uid := rest
+				if i := strings.IndexByte(uid, '/'); i >= 0 {
+					uid = uid[:i]
+				}
+				if uid != "" {
+					r = r.WithContext(withTargetItem(r.Context(), uid))
+				}
+			}
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/internal/server/writequeue.go
+++ b/internal/server/writequeue.go
@@ -231,7 +231,7 @@ func (b *storeBackend) mutateCardOp(ctx context.Context, bd board.Board, itemID,
 	for i := range e.board.Cards {
 		if e.board.Cards[i].ItemID == itemID {
 			e.markRecent(itemID)
-			e.cardChanged(clientIDFrom(ctx), e.board.Cards[i], "MODIFIED")
+			e.cardChanged(echoOrigin(ctx, itemID), e.board.Cards[i], "MODIFIED")
 			announced = true
 			break
 		}

--- a/pkg/boardservice/epics_test.go
+++ b/pkg/boardservice/epics_test.go
@@ -591,3 +591,25 @@ func TestTeamFilesASlotInTheWeeklyPlan(t *testing.T) {
 		t.Fatalf("an ordinary card must not be filed in the weekly plan, got %q", got.Plan)
 	}
 }
+
+// SetWeek on a slot: re-asserting the week the slot already derives from its
+// start date is a harmless no-op — the SPA and API writers echo the visible
+// week back — while a CONFLICTING week is refused; accepting it is exactly
+// how a slot's week and dates came to disagree. Ungrouping a slot subtask
+// used to die on this: the pull-out wrote the PARENT's week.
+func TestSetWeekOnASlot(t *testing.T) {
+	fake := newFake([]board.Card{
+		{ItemID: "s1", Title: "slot", Epic: "E", Project: "P", Team: "t",
+			StartDate: "2026-08-25", Week: "2026-08-24", Day: "2026-08-28"},
+	}, nil)
+	svc := New(fake)
+	ctx := context.Background()
+	// The derived week (the start date's Monday) is accepted silently.
+	if err := svc.SetWeek(ctx, "o", 1, "s1", "2026-08-24"); err != nil {
+		t.Fatalf("re-asserting the derived week: %v", err)
+	}
+	// Any other week is refused.
+	if err := svc.SetWeek(ctx, "o", 1, "s1", "2026-08-03"); !errors.Is(err, ErrWeekDerived) {
+		t.Fatalf("a conflicting week got %v, want ErrWeekDerived", err)
+	}
+}

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1511,6 +1511,18 @@ func (s *Service) SetWeek(ctx context.Context, owner string, project int, itemID
 		return err
 	}
 	if card.Epic != "" {
+		// Re-asserting the week the slot already derives from its start date
+		// is a harmless no-op — the SPA and API writers echo the visible week
+		// back (ungrouping a slot subtask used to die here on the parent's
+		// week). Only a CONFLICTING week is refused: accepting it is exactly
+		// how a slot's week and dates came to disagree.
+		derived := card.Week
+		if card.StartDate != "" {
+			derived = board.MondayOf(card.StartDate)
+		}
+		if week == derived {
+			return nil
+		}
 		return fmt.Errorf("%w: a slot's week follows its start date — move the dates instead", ErrWeekDerived)
 	}
 	if err := s.backend.SetWeek(ctx, b, card, week); err != nil {

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -392,7 +392,14 @@ export function ProjectBoard({
   };
 
   // ---- drag-to-create (and resize): a pressed column stretch becomes a slot.
-  const [drag, setDrag] = useState<{
+  // The gestures listen on the WINDOW for their whole life: the live
+  // preview re-lanes and remounts slots, and a removed element takes its
+  // pointer capture — and the rest of the gesture — with it (the stuck,
+  // unreleasable drag). Window listeners are closures of the press-time
+  // render, so the state they read lives in refs.
+  const dragRef = useRef<typeof drag>(null);
+  const moveRef = useRef<typeof move>(null);
+  const [drag, setDragState] = useState<{
     epic: EpicRef;
     from: number;
     to: number;
@@ -423,14 +430,22 @@ export function ProjectBoard({
     gridTop: number;
   } | null>(null);
 
+  const setDrag = (v: typeof drag) => {
+    dragRef.current = v;
+    setDragState(v);
+  };
   // A slot being dragged to another week / epic. It follows the pointer as a
   // preview and only writes on release.
-  const [move, setMove] = useState<{
+  const [move, setMoveState] = useState<{
     card: CardModel;
     span: number;
     row: number;
     epic: EpicRef;
   } | null>(null);
+  const setMove = (v: typeof move) => {
+    moveRef.current = v;
+    setMoveState(v);
+  };
   // The press behind a possible drag: held in a ref so that merely pressing a
   // card re-renders nothing, and so a click that never travels stays a click.
   const press = useRef<{
@@ -481,13 +496,14 @@ export function ProjectBoard({
   ) => {
     e.preventDefault();
     e.stopPropagation();
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     // "from" is the edge that stays put: the card's first row when the bottom
     // is pulled, its last row when the top is.
     setDrag({ epic, from: week, to: week, resize, edge });
+    armGesture(moveDrag, endDrag, () => setDrag(null));
   };
 
-  const moveDrag = (e: React.PointerEvent) => {
+  const moveDrag = (e: PointerEvent) => {
+    const drag = dragRef.current;
     if (!drag) {
       return;
     }
@@ -507,6 +523,7 @@ export function ProjectBoard({
   };
 
   const endDrag = () => {
+    const drag = dragRef.current;
     if (!drag) {
       return;
     }
@@ -553,6 +570,30 @@ export function ProjectBoard({
     setDraft({ epic, from: Math.min(from, to), to: Math.max(from, to) });
   };
 
+  // armGesture wires a gesture's move/up/cancel to the window for its whole
+  // life and tears them down when it ends, however it ends.
+  const armGesture = (
+    onMove: (e: PointerEvent) => void,
+    onUp: () => void,
+    onCancel: () => void,
+  ) => {
+    const up = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", up);
+      window.removeEventListener("pointercancel", cancel);
+      onUp();
+    };
+    const cancel = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", up);
+      window.removeEventListener("pointercancel", cancel);
+      onCancel();
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", up);
+    window.addEventListener("pointercancel", cancel);
+  };
+
   const beginMove = (card: CardModel, row: number, span: number, e: React.PointerEvent) => {
     // Only the slot's BODY drags. A press that started on a control inside it
     // (the team badge, delete, the resize grip) must reach that control: the
@@ -562,7 +603,6 @@ export function ProjectBoard({
       return;
     }
     e.preventDefault();
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     // Remember WHERE on the card the press landed. A press is not yet a drag:
     // it becomes one only once the pointer travels, so a stray click leaves
     // the card exactly where it was.
@@ -574,13 +614,18 @@ export function ProjectBoard({
       x: e.clientX,
       y: e.clientY,
     };
+    armGesture(moveMove, endMove, () => {
+      press.current = null;
+      setMove(null);
+    });
   };
 
-  const moveMove = (e: React.PointerEvent) => {
+  const moveMove = (e: PointerEvent) => {
     const p = press.current;
     if (!p) {
       return;
     }
+    const move = moveRef.current;
     if (!move) {
       if (Math.abs(e.clientX - p.x) < DRAG_SLOP && Math.abs(e.clientY - p.y) < DRAG_SLOP) {
         return;
@@ -608,6 +653,7 @@ export function ProjectBoard({
 
   const endMove = () => {
     press.current = null;
+    const move = moveRef.current;
     if (!move) {
       return;
     }
@@ -942,6 +988,9 @@ export function ProjectBoard({
       width: number;
     };
     const byCol = new Map<string, Slot[]>();
+    // A second, preview-less collection exists only while an edge is being
+    // pulled: it tells the pin which lane the slot rests in.
+    const rest = drag?.resize ? new Map<string, Slot[]>() : null;
     if (weeks.length === 0) {
       return byCol;
     }
@@ -982,6 +1031,17 @@ export function ProjectBoard({
       const list = byCol.get(k) ?? [];
       list.push({ card: c, row, span, lane: 0, lanes: 1, width: 1 });
       byCol.set(k, list);
+      if (rest) {
+        // The same card at REST — pre-preview geometry, for the lane pin.
+        const rr = weeksBetween(weeks[0], anchor);
+        if (rr >= 0 && rr < weeks.length) {
+          const rs = Math.max(1, Math.min(weeksBetween(anchor, endMon) + 1, weeks.length - rr));
+          const rk = colKey(c.project ?? "", c.epic);
+          const rl = rest.get(rk) ?? [];
+          rl.push({ card: c, row: rr, span: rs, lane: 0, lanes: 1, width: 1 });
+          rest.set(rk, rl);
+        }
+      }
     }
     if (draft) {
       const k = colKey(draft.epic.project, draft.epic.name);
@@ -998,56 +1058,98 @@ export function ProjectBoard({
     }
     // Lanes are worked out per CLUSTER of overlapping slots, not per column:
     // splitting the whole column because two slots happen to share a fortnight
-    // would leave every unrelated card at half width for no reason.
-    for (const list of byCol.values()) {
-      list.sort((a, b) => a.row - b.row || b.span - a.span);
-      let cluster: typeof list = [];
-      let laneEnd: number[] = [];
-      const close = () => {
-        const lanes = laneEnd.length;
-        for (const s of cluster) {
-          s.lanes = lanes;
-          // A cluster's lane count is what the busiest week in it needs, but
-          // a slot beside a quiet week has room the busy weeks do not: it
-          // grows rightwards over every lane that is free for ALL of its own
-          // rows. Without this a card sat at half width beside empty space,
-          // as if the space were spoken for.
-          let width = 1;
-          while (s.lane + width < lanes) {
-            const nextLane = s.lane + width;
-            const taken = cluster.some(
-              (o) =>
-                o !== s &&
-                o.lane === nextLane &&
-                o.row < s.row + s.span &&
-                s.row < o.row + o.span,
-            );
-            if (taken) {
-              break;
+    // would leave every unrelated card at half width for no reason. A pin
+    // holds one card in a KNOWN lane: while an edge is being pulled, the slot
+    // must not hop lanes under the pointer — the neighbours pack around it.
+    const pack = (
+      lists: Map<string, Slot[]>,
+      pin?: { id: string; lane: number; row: number; span: number },
+    ) => {
+      for (const list of lists.values()) {
+        list.sort((a, b) => a.row - b.row || b.span - a.span);
+        let cluster: typeof list = [];
+        let laneEnd: number[] = [];
+        const close = () => {
+          const lanes = laneEnd.length;
+          for (const s of cluster) {
+            s.lanes = lanes;
+            // A cluster's lane count is what the busiest week in it needs, but
+            // a slot beside a quiet week has room the busy weeks do not: it
+            // grows rightwards over every lane that is free for ALL of its own
+            // rows. Without this a card sat at half width beside empty space,
+            // as if the space were spoken for.
+            let width = 1;
+            while (s.lane + width < lanes) {
+              const nextLane = s.lane + width;
+              const taken = cluster.some(
+                (o) =>
+                  o !== s &&
+                  o.lane === nextLane &&
+                  o.row < s.row + s.span &&
+                  s.row < o.row + o.span,
+              );
+              if (taken) {
+                break;
+              }
+              width += 1;
             }
-            width += 1;
+            s.width = width;
           }
-          s.width = width;
+          cluster = [];
+          laneEnd = [];
+        };
+        // Whether a slot's rows overlap the pinned card's previewed extent.
+        const meetsPin = (s: Slot) =>
+          !!pin && s.row < pin.row + pin.span && pin.row < s.row + s.span;
+        for (const s of list) {
+          // A slot that begins after everything so far has ended starts a new
+          // cluster: it shares its weeks with nothing before it.
+          if (laneEnd.length && s.row >= Math.max(...laneEnd)) {
+            close();
+          }
+          let lane: number;
+          if (pin && s.card?.itemId === pin.id) {
+            lane = pin.lane;
+            while (laneEnd.length <= lane) {
+              laneEnd.push(0);
+            }
+          } else {
+            // First fit — but never into the pinned lane while sharing rows
+            // with the pinned card, even before it is placed.
+            lane = laneEnd.findIndex(
+              (end, i) => end <= s.row && !(pin && i === pin.lane && meetsPin(s)),
+            );
+            if (lane === -1) {
+              lane = laneEnd.length;
+              if (pin && lane === pin.lane && meetsPin(s)) {
+                laneEnd.push(0);
+                lane += 1;
+              }
+            }
+          }
+          laneEnd[lane] = Math.max(laneEnd[lane] ?? 0, s.row + s.span);
+          s.lane = lane;
+          cluster.push(s);
         }
-        cluster = [];
-        laneEnd = [];
-      };
-      for (const s of list) {
-        // A slot that begins after everything so far has ended starts a new
-        // cluster: it shares its weeks with nothing before it.
-        if (laneEnd.length && s.row >= Math.max(...laneEnd)) {
-          close();
-        }
-        let lane = laneEnd.findIndex((end) => end <= s.row);
-        if (lane === -1) {
-          lane = laneEnd.length;
-        }
-        laneEnd[lane] = s.row + s.span;
-        s.lane = lane;
-        cluster.push(s);
+        close();
       }
-      close();
+    };
+    let pin: { id: string; lane: number; row: number; span: number } | undefined;
+    if (rest && drag?.resize) {
+      pack(rest);
+      for (const list of rest.values()) {
+        const own = list.find((s) => s.card?.itemId === drag.resize?.itemId);
+        if (own) {
+          const preview = [...byCol.values()]
+            .flat()
+            .find((s) => s.card?.itemId === drag.resize?.itemId);
+          if (preview) {
+            pin = { id: drag.resize.itemId, lane: own.lane, row: preview.row, span: preview.span };
+          }
+        }
+      }
     }
+    pack(byCol, pin);
     return byCol;
   }, [cards, weeks, draft, move, drag]);
 
@@ -1382,8 +1484,6 @@ export function ProjectBoard({
               }`}
               style={{ gridRow: row + 2, gridColumn: col + 2 }}
               onPointerDown={(ev) => beginDrag(e, row, ev)}
-              onPointerMove={moveDrag}
-              onPointerUp={endDrag}
               onPointerCancel={() => setDrag(null)}
             />
           )),
@@ -1514,12 +1614,6 @@ export function ProjectBoard({
                   : {}),
               }}
               onPointerDown={(ev) => beginMove(card, row, span, ev)}
-              onPointerMove={moveMove}
-              onPointerUp={endMove}
-              onPointerCancel={() => {
-                press.current = null;
-                setMove(null);
-              }}
               onDoubleClick={() => onOpen(card)}
               title={card.title}
             >
@@ -1614,17 +1708,11 @@ export function ProjectBoard({
                 className="project-slot-resize project-slot-resize-top"
                 title="Drag to move the start"
                 onPointerDown={(ev) => beginDrag(e, row + span - 1, ev, card, "top")}
-                onPointerCancel={() => setDrag(null)}
-                onPointerMove={moveDrag}
-                onPointerUp={endDrag}
               />
               <div
                 className="project-slot-resize"
                 title="Drag to stretch over more weeks"
                 onPointerDown={(ev) => beginDrag(e, row, ev, card, "bottom")}
-                onPointerCancel={() => setDrag(null)}
-                onPointerMove={moveDrag}
-                onPointerUp={endDrag}
               />
             </div>
           )),

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -863,6 +863,10 @@ export function TeamBoard({
           if (!parentCard?.plan) {
             return;
           }
+          // A slot's week derives from its start date: the pull-out must
+          // not write the PARENT's week onto it — that conflicting write is
+          // refused, and refusing the whole patch kept the subtask stuck.
+          const slot = isSlot(card);
           const week = parentCard.week ?? currentWeek;
           const prev: Partial<CardModel> = {
             parent: card.parent,
@@ -872,12 +876,12 @@ export function TeamBoard({
           patchCard(card.itemId, {
             parent: undefined,
             plan: toMeta.band,
-            week,
+            ...(slot ? {} : { week }),
           });
           void provider
             .patchCard(board, card.itemId, {
               parent: "",
-              plan: { band: toMeta.band, week },
+              plan: slot ? { band: toMeta.band } : { band: toMeta.band, week },
             })
             .then((c) => {
               addCard(c);


### PR DESCRIPTION
Three production-reported fixes in one evening pass:

## An edge pull keeps its lane and always releases

Pulling a slot's top edge made it hop to another lane mid-gesture, and the gesture then stuck: the live preview re-lanes and remounts slots, and a removed element takes its pointer capture — and the rest of the drag — with it. The board's gestures (edge pulls, slot moves, drag-to-create) now listen on the window for their whole life, reading their state through refs, so a remount cannot end them; and while an edge is being pulled the slot is pinned to its resting lane — the neighbours pack around it, nothing hops under the pointer.

Driven in headless Chrome: the slot's x is unchanged through the pull, the release writes the new start, and a wandering pointer afterwards moves nothing.

## Renaming an epic no longer empties the column — for its renamer

The watch stream spares the mutating client every echo of its own request, assuming it holds an optimistic copy. A batch fan-out (an epic rename moving every member card) has no such copy: the column rename arrived, the member cards' moves were suppressed, and the renamer watched the column lose its cards until a reload. Suppression is now scoped to the one card the request ADDRESSED (the `{uid}` of its `/cards/{uid}` route): single-card patches stay suppressed for their author — what the optimistic UI depends on — while batch fan-outs and cascades (a subtask following its parent) echo to everyone.

Reproduced and verified live in headless Chrome; covered by `TestBatchEchoesReachTheirAuthor` / `TestAddressedCardStaysSuppressed`, and a row in the behaviour matrix.

## Slow paths log themselves

Every "aeman is down" report this evening met a log that said nothing: requests logged at Debug, board loads only on failure, the warmer only on stop. Requests slower than 1s now log at Info (5s — Warn; the watch socket exempt), every full board load logs begin/done with card count and duration, and the warmer logs its start.