### PR TITLE
fix(server): the create pipeline stops eating cards

### DIFF
--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -1406,18 +1406,37 @@ func (b *storeBackend) CreateCard(ctx context.Context, bd board.Board, in board.
 
 	b.installCreated(ctx, e, card)
 
+	var adopted atomic.Bool
 	title := card.Title
 	b.enqueue(ctx, e, pendingOp{
-		key:    "", // a create never coalesces
-		itemID: provisional,
-		desc:   "create «" + title + "»",
-		apply:  func(*board.Board) {},
+		key:     "", // a create never coalesces
+		itemID:  provisional,
+		desc:    "create «" + title + "»",
+		noRetry: true, // an ambiguous failure retried = a duplicate card
+		// The apply re-imposes the provisional row on a freshly installed
+		// board (the recentCards grace covers the first 90 seconds; this
+		// covers a queue that outlives it — GitHub throttling, a long
+		// backlog). Skipped once adopted: the fresh read then carries the
+		// real card itself. NB: apply runs under e.mu (install holds it), so
+		// adoption is read through an atomic, not the entry lock.
+		apply: func(target *board.Board) {
+			if adopted.Load() {
+				return
+			}
+			for _, c := range target.Cards {
+				if c.ItemID == provisional {
+					return
+				}
+			}
+			target.Cards = append(target.Cards, card)
+		},
 		exec: func(ctx context.Context) error {
 			real, err := b.inner.CreateCard(ctx, bd, in)
 			if err != nil {
 				return err
 			}
 			b.adoptLocal(ctx, e, provisional, real)
+			adopted.Store(true)
 			return nil
 		},
 	})

--- a/internal/server/create_async_test.go
+++ b/internal/server/create_async_test.go
@@ -151,3 +151,107 @@ func boardCard(b board.Board, id string) (board.Card, bool) {
 	}
 	return board.Card{}, false
 }
+
+// A provisional card must survive a warm install: the warmer replaces the
+// cached board every few minutes, and the create's pending op is what
+// re-imposes the not-yet-adopted row onto the fresh snapshot. With an empty
+// apply, a warm tick between create and adoption WIPED the row — an
+// immediate rename answered "card not found: local-…", and the client that
+// still held the provisional saw a duplicate once the real card arrived.
+func TestProvisionalSurvivesAWarmInstall(t *testing.T) {
+	store := newBoardStore()
+	fake := boardservicetest.New(nil, map[string]board.SprintState{
+		"alpha": {Current: board.TodayIso(), ItemID: "st1"},
+	})
+	slow := &slowCreates{Backend: fake, delay: 300 * time.Millisecond}
+	be := &storeBackend{inner: &resolvingBackend{inner: slow, store: store}, store: store}
+	svc := boardservice.New(be)
+	ctx := context.Background()
+	if _, err := be.LoadBoard(ctx, "acme", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := svc.CreateCard(ctx, "acme", 1, boardservice.CreateCardArgs{
+		Title: "born mid-warm", Team: "alpha",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(created.ItemID, "local-") {
+		t.Fatalf("expected a provisional id, got %q", created.ItemID)
+	}
+
+	// The warmer replaces the cache with a fresh snapshot that does not
+	// contain the provisional row (GitHub does not know it yet).
+	fresh, err := fake.LoadBoard(ctx, "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := store.entry(storeKey("acme", 1))
+	be.install(e, fresh, "")
+
+	// The provisional row is still on the cached board…
+	bd, err := be.LoadBoard(ctx, "acme", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	present := false
+	for _, c := range bd.Cards {
+		if c.ItemID == created.ItemID {
+			present = true
+		}
+	}
+	if !present {
+		t.Fatal("the warm install wiped the provisional card")
+	}
+	// …and an immediate rename by the provisional id lands.
+	if err := svc.Rename(ctx, "acme", 1, created.ItemID, "renamed mid-warm"); err != nil {
+		t.Fatalf("rename by the provisional id: %v", err)
+	}
+
+	// Once the queue drains, the adopted real card carries the rename.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		bd, _ := be.LoadBoard(ctx, "acme", 1)
+		var found *board.Card
+		for i := range bd.Cards {
+			if bd.Cards[i].Title == "renamed mid-warm" && !strings.HasPrefix(bd.Cards[i].ItemID, "local-") {
+				found = &bd.Cards[i]
+			}
+		}
+		if found != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the adopted card never carried the rename")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// The resolving wrapper must not hide its inner backend's capabilities: the
+// store type-asserts b.inner for the cheap access probe (and the body
+// syncer, and the link resolver), and a wrapper that swallows them silently
+// turned every returning user's read into a full 50-second board load.
+func TestResolvingForwardsCapabilities(t *testing.T) {
+	r := &resolvingBackend{inner: probingBackend{}, store: newBoardStore()}
+	var asIface any = r
+	p, ok := asIface.(accessProber)
+	if !ok {
+		t.Fatal("the wrapper does not offer the access probe")
+	}
+	if err := p.CheckBoardAccess(context.Background(), "acme", 1); err != nil {
+		t.Fatalf("the probe was not delegated: %v", err)
+	}
+	// An inner backend WITHOUT the probe reports failure rather than lying.
+	r2 := &resolvingBackend{inner: boardservicetest.New(nil, nil), store: newBoardStore()}
+	var as2 any = r2
+	if err := as2.(accessProber).CheckBoardAccess(context.Background(), "acme", 1); err == nil {
+		t.Fatal("a probe-less inner backend must report the probe failed")
+	}
+}
+
+// probingBackend is a fake that offers CheckBoardAccess.
+type probingBackend struct{ boardservice.Backend }
+
+func (probingBackend) CheckBoardAccess(context.Context, string, int) error { return nil }

--- a/internal/server/resolving.go
+++ b/internal/server/resolving.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aenix-io/aeman/pkg/board"
 	"github.com/aenix-io/aeman/pkg/boardservice"
@@ -175,3 +176,36 @@ func (r *resolvingBackend) SetSprintState(ctx context.Context, b board.Board, te
 }
 
 var _ boardservice.Backend = (*resolvingBackend)(nil)
+
+// ---- optional capabilities ------------------------------------------------
+// The wrapper must not HIDE what its inner backend can do: the store probes
+// b.inner with type assertions for these, and when the resolving layer landed
+// in between, every assertion silently failed — the cheap access probe died
+// (every returning user paid the full board load), draft-body sync died, and
+// GitHub link resolution died. Each forward delegates when the inner backend
+// offers the capability and reports its absence otherwise.
+
+func (r *resolvingBackend) CheckBoardAccess(ctx context.Context, owner string, project int) error {
+	if p, ok := r.inner.(interface {
+		CheckBoardAccess(ctx context.Context, owner string, project int) error
+	}); ok {
+		return p.CheckBoardAccess(ctx, owner, project)
+	}
+	return fmt.Errorf("backend offers no access probe")
+}
+
+func (r *resolvingBackend) SyncDraftBody(ctx context.Context, card board.Card, description string, notes []board.Note, events []board.Event) ([]board.Note, []board.Event, error) {
+	if s, ok := r.inner.(interface {
+		SyncDraftBody(ctx context.Context, card board.Card, description string, notes []board.Note, events []board.Event) ([]board.Note, []board.Event, error)
+	}); ok {
+		return s.SyncDraftBody(ctx, card, description, notes, events)
+	}
+	return nil, nil, fmt.Errorf("backend cannot sync draft bodies")
+}
+
+func (r *resolvingBackend) ResolveIssueRef(ctx context.Context, link board.Link) (board.Link, error) {
+	if l, ok := r.inner.(boardservice.LinkResolver); ok {
+		return l.ResolveIssueRef(ctx, link)
+	}
+	return link, fmt.Errorf("backend cannot resolve github refs")
+}

--- a/internal/server/writequeue.go
+++ b/internal/server/writequeue.go
@@ -31,9 +31,12 @@ type pendingOp struct {
 	compose bool
 	// desc names the operation for the sync-error message ("set progress on
 	// «title»").
-	desc  string
-	apply func(bd *board.Board)
-	exec  func(ctx context.Context) error
+	desc string
+	// noRetry runs the exec once: a create retried after an ambiguous
+	// failure duplicates the card on the board.
+	noRetry bool
+	apply   func(bd *board.Board)
+	exec    func(ctx context.Context) error
 	// itemID names the card the op writes, so a FAILED write can drop that
 	// card's recent-guard before the rollback reload (or the guard would keep
 	// re-imposing the value GitHub just refused).
@@ -146,13 +149,18 @@ func (b *storeBackend) drain(ctx context.Context, e *boardEntry) {
 
 // execRetry runs the upstream write with a few retries — a transient GitHub
 // hiccup (secondary rate limit, 502) must not roll a user's change back.
+// An op marked noRetry (a create) runs ONCE: an ambiguous failure — the
+// write committed but its response was lost — retried into a SECOND real
+// card on the board, and deleting the visible duplicate then took the
+// original's identity with it. Failing honestly (rollback + sync error)
+// loses a click; retrying blindly loses data.
 func execRetry(ctx context.Context, op pendingOp) error {
 	var err error
 	for attempt := 0; ; attempt++ {
 		if err = op.exec(ctx); err == nil {
 			return nil
 		}
-		if attempt >= len(queueBackoff) {
+		if op.noRetry || attempt >= len(queueBackoff) {
 			return err
 		}
 		select {


### PR DESCRIPTION
Three related defects around cache-first creates, all reported from production within the hour:

## The resolving wrapper hid its inner backend's capabilities

The store type-asserts its backend for the cheap access probe, the draft-body syncer and the GitHub link resolver. Since the resolving layer landed in between (v0.20.0), every one of those assertions silently failed: **every returning user's first read fell through to the full ~50-second board load** — the evening's recurring "aeman lost its cache" — and body sync plus ref resolution were quietly dead. The wrapper now forwards all three capabilities, delegating when the inner backend offers them; `TestResolvingForwardsCapabilities` pins it.

## A warm install could wipe a provisional card

The create's pending op had an empty `apply`, so a warm install between create and adoption removed the provisional row once the 90-second recent grace ran out; an immediate rename answered `card not found: local-…`. The apply now re-imposes the not-yet-adopted row (adoption state read through an atomic — apply runs under the entry lock). `TestProvisionalSurvivesAWarmInstall` covers it.

## Creates are never blind-retried

The queue retried creates like any other write. An ambiguous failure — the write committed, the response lost — retried into a **second real card**, and deleting the visible duplicate then took the original's identity with it. Creates now run once (`noRetry`): failing honestly (rollback + sync error) loses a click; retrying blindly loses data.