### PR TITLE
fix(board): taking a card into work puts it on the day it was taken

### DIFF
--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -2118,6 +2118,27 @@ func (s *Service) TakeIntoPlan(ctx context.Context, owner string, project int, i
 	if err := s.backend.SetSprintStart(ctx, b, card, sprintStart); err != nil {
 		return err
 	}
+	// Taking a card into work on day D puts it ON day D. A card scheduled for
+	// a later day is DEFERRED, and the deferral outranks the sprint in every
+	// day view — so the drop was accepted, the event recorded, and the card
+	// stayed invisible. On the live board that showed up as four identical
+	// plan-taken events inside one minute: the same card dropped again and
+	// again because nothing appeared. Only the near end moves; a slot's far
+	// end is its plan on the roadmap and stays where it was.
+	if card.StartDate != "" && card.StartDate > day {
+		if err := s.backend.SetStart(ctx, b, card, day); err != nil {
+			return err
+		}
+		end := card.Day
+		if end != "" && end < day {
+			end = day
+			if err := s.backend.SetDay(ctx, b, card, end); err != nil {
+				return err
+			}
+		}
+		s.logEvent(ctx, b, card, board.EventDates,
+			board.DateRange(card.StartDate, card.Day), board.DateRange(day, end))
+	}
 	s.logEvent(ctx, b, card, board.EventPlanTaken, "", engineer)
 	return nil
 }

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -2750,3 +2750,63 @@ func TestReopenFallsBackWithoutHistory(t *testing.T) {
 		t.Fatalf("fallback progress %d, want the in-progress nudge 90", c.Progress)
 	}
 }
+
+// Taking a card into work on day D puts it ON day D. A card scheduled for a
+// later day used to accept the drop, record plan-taken and stay invisible —
+// the deferral rule outranks the sprint in every day view, so the gesture was
+// a silent no-op and people dropped the same card again and again.
+func TestTakeIntoPlanPullsADeferredCardOntoTheDay(t *testing.T) {
+	const today = "2026-08-25"
+	fake := newFake([]board.Card{
+		{ItemID: "c1", Title: "webinar prep", Team: "t", Assignees: []string{"kvaps"},
+			StartDate: "2026-08-26", Day: "2026-08-28", SprintStart: today,
+			Epic: "Webinars", Project: "events"},
+		{ItemID: "st", Title: board.SprintStateTitle, Team: "t"},
+	}, map[string]board.SprintState{"t": {Current: today, ItemID: "st"}})
+	svc := New(fake)
+	ctx := t.Context()
+	if err := svc.TakeIntoPlan(ctx, "o", 1, "c1", "kvaps", board.ZoneYellow, today); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(ctx, "o", 1)
+	c, _ := findCard(b, "c1")
+	if c.StartDate != today {
+		t.Fatalf("start = %q, want %q — the card must land on the day it was taken", c.StartDate, today)
+	}
+	// The far end of a slot's span is its plan and stays where it was.
+	if c.Day != "2026-08-28" {
+		t.Fatalf("end = %q, want the slot's own end 2026-08-28", c.Day)
+	}
+	if !TeamGridHas(b, "t", today, "c1") {
+		t.Fatal("the card is still invisible on the day it was taken into work")
+	}
+}
+
+// A card already scheduled for today (or earlier) keeps its dates: taking it
+// into work must not rewrite a start someone chose.
+func TestTakeIntoPlanKeepsAPresentStart(t *testing.T) {
+	const today = "2026-08-25"
+	fake := newFake([]board.Card{
+		{ItemID: "c1", Title: "one", Team: "t", StartDate: "2026-08-20", Day: "2026-08-27", SprintStart: today},
+		{ItemID: "st", Title: board.SprintStateTitle, Team: "t"},
+	}, map[string]board.SprintState{"t": {Current: today, ItemID: "st"}})
+	svc := New(fake)
+	if err := svc.TakeIntoPlan(t.Context(), "o", 1, "c1", "kvaps", board.ZoneYellow, today); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(t.Context(), "o", 1)
+	c, _ := findCard(b, "c1")
+	if c.StartDate != "2026-08-20" || c.Day != "2026-08-27" {
+		t.Fatalf("dates were rewritten: %s..%s", c.StartDate, c.Day)
+	}
+}
+
+// TeamGridHas reports whether the team's day grid delivers the card.
+func TeamGridHas(b board.Board, team, day, itemID string) bool {
+	for _, c := range board.TeamGrid(b, team, day) {
+		if c.ItemID == itemID {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -544,11 +544,24 @@ export function TeamBoard({
       assignees: card.assignees,
       zone: card.zone,
       sprintStart: card.sprintStart,
+      startDate: card.startDate,
+      day: card.day,
     };
+    // A card scheduled for a later day is deferred, and the deferral outranks
+    // the sprint in the grid: taking it into work moves its near end onto the
+    // day it was taken, or the row would land nowhere and the drop would look
+    // like it did nothing. The server does the same (TakeIntoPlan).
+    const deferred = !!card.startDate && card.startDate > selectedDate;
     patchCard(card.itemId, {
       assignees: login ? [login] : [],
       zone,
       sprintStart,
+      ...(deferred
+        ? {
+            startDate: selectedDate,
+            ...(card.day && card.day < selectedDate ? { day: selectedDate } : {}),
+          }
+        : {}),
     });
     const request = login
       ? provider.takeIntoPlan(board, card.itemId, login, zone, selectedDate)


### PR DESCRIPTION
## The report

"Tried to drag a card onto myself in Team, doesn't work." The card's activity log shows **four identical `plan-taken` events inside one minute** — the drop was accepted every time, and every time nothing appeared, so the gesture was repeated.

## Why

The card was scheduled for tomorrow. A card whose start date is in the future is *deferred*, and the deferral rule outranks the sprint in every day view: it shows only on its own future day, never on today. So take-into-plan set the assignee, the zone and the sprint, wrote its event — and the row stayed invisible. A silent no-op that looks exactly like a broken feature.

## The rule now

Taking a card into work on day D puts it **on** day D: its near end moves to D. Only the near end — a Project-board slot's far end is its plan on the roadmap and stays where it was (the reported card is a webinar slot spanning 26–28 August; it now starts today and still ends on the 28th). A card already scheduled for today or earlier keeps its dates untouched. The frontend mirrors the rule so the row lands under the pointer instead of after the round trip.

## Testing

- `TestTakeIntoPlanPullsADeferredCardOntoTheDay` — the deferred card lands on the day, keeps its far end, and is delivered by `TeamGrid` for that day.
- `TestTakeIntoPlanKeepsAPresentStart` — a start someone chose is never rewritten.
- Verified against the live board on the card from the report: absent from today's grid before, present after, span preserved.