### PR TITLE
fix(board): marking a review card done passes the review

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -73,6 +73,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 
 | V+ | Echo suppression is scoped to the ADDRESSED card: the author's watch is spared the echo only for the {uid} their request named — a batch fan-out (epic rename over its cards) or a cascade (a subtask following its parent) echoes even to the author, who holds no optimistic copy of those cards. Unscoped suppression made a renamed column's cards vanish from the very board that renamed it | internal/server echoOrigin + clientIDMiddleware | ✅ TestBatchEchoesReachTheirAuthor / TestAddressedCardStaysSuppressed |
 
+| R+ | A review card's own STAGE drives its original exactly as its progress does: marking the review card done passes the review (the original leaves the review stage, a review-passed event names the reviewer), and lowering it below 100 — Reopen — sends the original back on review. Clearing the stage of a card at 100 changes nothing: it is complete whatever the stage says. Only the progress paths synced this, so "mark as done" on a review card left the original stuck on review with nothing in its log | boardservice.SetStage → syncReviewLink | ✅ TestReviewDoneByStagePassesTheOriginal / TestReopeningAReviewCardReturnsTheOriginal |
+
 ## Card object mapping
 
 | # | Rule | Test |

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1218,6 +1218,16 @@ func (s *Service) SetStage(ctx context.Context, owner string, project int, itemI
 			return err
 		}
 	}
+	// A REVIEW card's own stage drives its original the same way its progress
+	// does: marking it done passes the review, reopening it sends the original
+	// back. Only the progress paths synced the link, so "mark as done" on the
+	// review card left the original stuck on review — with nothing in its log
+	// to say why (seen on the live board: review card done at 13:18, original
+	// still on review).
+	if card.ReviewOf != "" {
+		_, newProgress := board.ApplyStage(stage, card.Progress)
+		return s.syncReviewLink(ctx, b, card, newProgress)
+	}
 	// Leaving review cancels the unfinished linked review card.
 	if card.Stage == board.StageReview && stage != board.StageReview {
 		return s.cancelLinkedReview(ctx, b, card)

--- a/pkg/boardservice/service_test.go
+++ b/pkg/boardservice/service_test.go
@@ -2810,3 +2810,66 @@ func TeamGridHas(b board.Board, team, day, itemID string) bool {
 	}
 	return false
 }
+
+// Closing a review card through the STAGE menu passes the review, exactly as
+// dragging its progress to 100 does: the original leaves the review stage.
+// Only the progress paths synced the link, so "mark as done" on the review
+// card left the original stuck on review with nothing in its log to say why.
+func TestReviewDoneByStagePassesTheOriginal(t *testing.T) {
+	fake := newFake([]board.Card{
+		{ItemID: "orig", Title: "the work", Team: "t", Stage: board.StageReview, Progress: 85},
+		{ItemID: "rev", Title: "review: the work", Team: "t", ReviewOf: "orig",
+			Assignees: []string{"lllamnyp"}, Progress: 50},
+	}, nil)
+	svc := New(fake)
+	ctx := t.Context()
+	if err := svc.SetStage(ctx, "o", 1, "rev", board.StageDone); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(ctx, "o", 1)
+	orig, _ := findCard(b, "orig")
+	if orig.Stage == board.StageReview {
+		t.Fatalf("the original is still on review after its review card was marked done")
+	}
+	// The pass is recorded on the original, naming the reviewer.
+	passed := false
+	for _, e := range orig.Events {
+		if e.Kind == board.EventReviewPassed && e.From == "lllamnyp" {
+			passed = true
+		}
+	}
+	if !passed {
+		t.Fatal("no review-passed event on the original")
+	}
+}
+
+// Reopening a done review card puts its original back on review — the same
+// rule read the other way. Note what does NOT do it: merely clearing the
+// stage, since a card at 100 is complete whatever its stage says. Reopen
+// lowers the progress, and that is what reverses the pass.
+func TestReopeningAReviewCardReturnsTheOriginal(t *testing.T) {
+	fake := newFake([]board.Card{
+		{ItemID: "orig", Title: "the work", Team: "t", Progress: 85},
+		{ItemID: "rev", Title: "review: the work", Team: "t", ReviewOf: "orig",
+			Assignees: []string{"lllamnyp"}, Stage: board.StageDone, Progress: 100},
+	}, nil)
+	svc := New(fake)
+	ctx := t.Context()
+	// Clearing the stage alone leaves it complete: the original stays passed.
+	if err := svc.SetStage(ctx, "o", 1, "rev", board.StageNone); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(ctx, "o", 1)
+	if orig, _ := findCard(b, "orig"); orig.Stage == board.StageReview {
+		t.Fatal("clearing the stage of a 100% review card must not reopen the review")
+	}
+	// Reopen drops the progress, and the original goes back on review.
+	if err := svc.Reopen(ctx, "o", 1, "rev"); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = fake.LoadBoard(ctx, "o", 1)
+	orig, _ := findCard(b, "orig")
+	if orig.Stage != board.StageReview {
+		t.Fatalf("original stage = %q, want review again", orig.Stage)
+	}
+}


### PR DESCRIPTION
## The report

A reviewer closed a review card; the original stayed on the review stage.

## Why

The review link is synced by `syncReviewLink`, and it was called from exactly two places: `SetProgress` and `SetInProgress`. Dragging a review card's progress to 100 passed the review; pressing **Mark as done** — which goes through `SetStage` — did not. The original kept the review stage, and nothing in its activity log said why.

On the live board: review card `…g28mdw` finished at 13:18:40, original `…gzs8oE` still reading `stage: review` with progress 85.

## The rule now

A review card's **stage** drives its original exactly as its progress does:

- marking it done → the original leaves the review stage, and a `review-passed` event on the original names the reviewer;
- dropping it back below 100 (the Reopen action) → the original returns to review;
- clearing the stage of a card already at 100 changes nothing — a card at 100 is complete whatever its stage says, so the review stays passed.

The frontend already re-lists the original when a review card's stage changes, so it converges with no client change.

## Testing

- `TestReviewDoneByStagePassesTheOriginal` — done via the stage menu passes the review and records the event with the reviewer's login.
- `TestReopeningAReviewCardReturnsTheOriginal` — pins both halves: clearing the stage of a 100% card does NOT reopen it, Reopen does.
- A row in `docs/design/behavior-matrix.md`.

The two cards from the report have been put back into the right state by hand on the live board.