### PR TITLE
fix(board): a subtask left behind in an earlier sprint still shows

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -75,6 +75,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 
 | R+ | A review card's own STAGE drives its original exactly as its progress does: marking the review card done passes the review (the original leaves the review stage, a review-passed event names the reviewer), and lowering it below 100 — Reopen — sends the original back on review. Clearing the stage of a card at 100 changes nothing: it is complete whatever the stage says. Only the progress paths synced this, so "mark as done" on a review card left the original stuck on review with nothing in its log | boardservice.SetStage → syncReviewLink | ✅ TestReviewDoneByStagePassesTheOriginal / TestReopeningAReviewCardReturnsTheOriginal |
 
+| S+ | A subtask left BEHIND in an earlier sprint still renders under its parent: a completed subtask stays in the sprint it was finished in while the parent carries on, and the parent's progress bar is derived from exactly those children. Hiding them (the old `activeSprint > sprintStart` rule) left a card handed to someone else reading 90% with no expand arrow and subtasks its new owner could see named in the log but could not open. Only a subtask whose day has not arrived — deferred ahead, or a sprint that had not started on the viewed day — stays hidden | web/src/subtasks.ts (shared by MeBoard and TeamBoard) | ✅ subtasks.test.ts |
+
 ## Card object mapping
 
 | # | Rule | Test |

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -27,6 +27,7 @@ import type {
 } from "../providers/types";
 import { ZONES, ZONE_ORDER } from "../zones";
 import { todayIso, localDateIso, addDays } from "../date";
+import { subtaskShows } from "../subtasks";
 import { activeSprint, currentSprint } from "../sprint";
 import { avatarUrlFor, displayName, type GhUser } from "../users";
 import { Card } from "./Card";
@@ -365,24 +366,10 @@ export function MeBoard({
 
   // Subtasks grouped by parent. The Me board's team-focus filter applies to
   // subtask rows the same way it applies to cards.
-  // Mirrors the server's subtaskOnDay: a subtask keeps its own day
-  // visibility even though it rides its parent — deferred to the future it
-  // hides until its day, and one left behind in an earlier sprint stays on
-  // that sprint's days. Without this an acked defer (addCard) would put the
-  // row right back under the parent on today's board.
-  const subtaskOnDay = (c: CardModel): boolean => {
-    const today = todayIso();
-    if (c.startDate && c.startDate > today && selectedDate < c.startDate) {
-      return false;
-    }
-    if (c.sprintStart) {
-      const as = activeSprint(board, c.team ?? null, selectedDate);
-      if (as && as > c.sprintStart) {
-        return false;
-      }
-    }
-    return true;
-  };
+  // The shared rule (subtasks.ts): a subtask keeps its own day visibility
+  // even though it rides its parent.
+  const subtaskOnDay = (c: CardModel): boolean =>
+    subtaskShows(c, { today: todayIso(), day: selectedDate });
 
   const childrenOf = useMemo(() => {
     const m = new Map<string, CardModel[]>();

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -36,6 +36,7 @@ import { SprintChoiceDialog } from "./SprintChoiceDialog";
 import { SortableBoard, type BoardGroup, type DropResult } from "./SortableBoard";
 import { globalOrderFromGroups, afterIdFor } from "./dndOrder";
 import { isSlot, slotBand } from "../weekly";
+import { subtaskShows } from "../subtasks";
 
 interface TeamBoardProps {
   board: Board;
@@ -687,19 +688,9 @@ export function TeamBoard({
   // hides until its day, and one left behind in an earlier sprint stays on
   // that sprint's days. Without this an acked defer (addCard) would put the
   // row right back under the parent on today's board.
-  const subtaskOnDay = (c: CardModel): boolean => {
-    const today = todayIso();
-    if (c.startDate && c.startDate > today && selectedDate < c.startDate) {
-      return false;
-    }
-    if (c.sprintStart) {
-      const as = activeSprint(board, c.team ?? null, selectedDate);
-      if (as && as > c.sprintStart) {
-        return false;
-      }
-    }
-    return true;
-  };
+  // The shared rule (subtasks.ts) — the same one the Me board applies.
+  const subtaskOnDay = (c: CardModel): boolean =>
+    subtaskShows(c, { today: todayIso(), day: selectedDate });
 
   const childrenOf = useMemo(() => {
     const m = new Map<string, CardModel[]>();

--- a/web/src/subtasks.test.ts
+++ b/web/src/subtasks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { subtaskShows } from "./subtasks";
+
+const base = { team: "portal", parent: "p1" };
+
+describe("subtaskShows", () => {
+  it("shows a subtask of the day's own sprint", () => {
+    expect(subtaskShows({ ...base, sprintStart: "2026-08-26" },
+      { today: "2026-08-26", day: "2026-08-26" })).toBe(true);
+  });
+
+  it("hides one deferred to a later day until that day arrives", () => {
+    const c = { ...base, startDate: "2026-08-28", sprintStart: "2026-08-26" };
+    expect(subtaskShows(c, { today: "2026-08-26", day: "2026-08-26" })).toBe(false);
+    expect(subtaskShows(c, { today: "2026-08-26", day: "2026-08-28" })).toBe(true);
+  });
+
+  // The bug: a subtask FINISHED in an earlier sprint stays in that sprint by
+  // design, while its parent carries on. Hiding it left the parent with no
+  // children and no expand arrow — on a progress bar derived from exactly
+  // those children. The person who inherited the card saw 90% and no way to
+  // learn why.
+  it("shows a subtask left behind in an earlier sprint — the parent's bar is made of it", () => {
+    expect(subtaskShows({ ...base, sprintStart: "2026-08-25", progress: 100 },
+      { today: "2026-08-26", day: "2026-08-26" })).toBe(true);
+  });
+
+  it("shows an OPEN subtask left behind too — it is still the group's work", () => {
+    expect(subtaskShows({ ...base, sprintStart: "2026-08-25", progress: 40 },
+      { today: "2026-08-26", day: "2026-08-26" })).toBe(true);
+  });
+
+  // Rolling the board back to an earlier day keeps the old behaviour: a
+  // subtask that had not joined a sprint yet does not appear before its time.
+  it("hides a subtask whose sprint had not started on the viewed day", () => {
+    expect(subtaskShows({ ...base, sprintStart: "2026-08-26" },
+      { today: "2026-08-26", day: "2026-08-25" })).toBe(false);
+  });
+
+  it("shows one with no sprint of its own", () => {
+    expect(subtaskShows({ ...base }, { today: "2026-08-26", day: "2026-08-26" })).toBe(true);
+  });
+});

--- a/web/src/subtasks.ts
+++ b/web/src/subtasks.ts
@@ -1,0 +1,38 @@
+/** The slice of a card the subtask-visibility rule reads. */
+export interface SubtaskLike {
+  team?: string;
+  parent?: string;
+  startDate?: string;
+  sprintStart?: string;
+  progress?: number;
+}
+
+export interface DayContext {
+  today: string;
+  day: string;
+}
+
+/** subtaskShows decides whether a subtask row belongs under its parent on the
+ *  viewed day.
+ *
+ *  A subtask deferred to a later day stays hidden until that day — scheduling
+ *  work ahead is exactly the act of taking it off today's board.
+ *
+ *  A subtask whose sprint had not STARTED by the viewed day is not there yet
+ *  either: rolling the board back must not show work that had not begun.
+ *
+ *  But a subtask left BEHIND in an earlier sprint does show. It stays in the
+ *  sprint it was finished in by design, while its parent carries on — and the
+ *  parent's progress bar is derived from exactly these children. Hiding them
+ *  left an inherited card reading 90% with no expand arrow and no way to learn
+ *  why: the log named subtasks their new owner could not open.
+ */
+export function subtaskShows(c: SubtaskLike, ctx: DayContext): boolean {
+  if (c.startDate && c.startDate > ctx.today && ctx.day < c.startDate) {
+    return false;
+  }
+  if (c.sprintStart && ctx.day < c.sprintStart) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Closes the card «Баг aeman: у Егора не отобразились подзадачи после переноса ему чужой карточки».

## The report

A parent card with several subtasks was moved from one engineer to another. The person handing it over saw the whole family move; the new owner saw only the parent — no expand arrow, and the subtasks the log named could not be opened.

## What actually happened

The server was innocent: `view=me` for the new owner delivers the parent **and** both subtasks (checked against the live board). The client dropped them.

Both boards carried their own copy of a rule that hid a subtask whose sprint had fallen behind the day's active sprint. That is exactly the state a completed subtask ends up in: it stays in the sprint it was finished in — by design, so the day it was done still shows it — while the parent is carried on to the next sprint. From then on the parent renders with **none** of the children its progress bar is derived from. The inherited card read 90% with nothing to open.

The timeline on the reported family: carry-over moved the parent to the new sprint at 07:35 and left the two finished subtasks on the old one; the reassignment followed at 07:45.

## The rule now

Hide only what has not arrived — a subtask deferred to a later day, or one whose sprint had not started on the viewed day. Anything left behind renders under its parent, which is where the group's story belongs. The two hand-kept copies are replaced by one tested module, `web/src/subtasks.ts`, used by both boards.

## Testing

- `web/src/subtasks.test.ts` — six cases pinning both directions: the day's own sprint, a deferred subtask before and after its day, a completed one left behind, an **open** one left behind, a sprint that had not started on the viewed day, and a subtask with no sprint at all.
- End-to-end in headless Chrome on a rebuilt version of the reported shape (parent on the current sprint, completed subtask left on an older one), driven as the new owner via view-as: **before** — parent visible, `arrow: false`; **after** — `arrow: true`, and expanding reveals the subtask.
- A row in `docs/design/behavior-matrix.md`.

## Note

The reported family also carries a separate defect found yesterday: its parent's sprint was silently pulled back by the smart × demote, which writes dates and sprint but logs no event. That is why the parent is currently sitting on 25 August rather than today. Not fixed here.