### PR TITLE
fix(board): pulling a subtask out no longer leaves it ownerless

### DIFF
--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -77,6 +77,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 
 | S+ | A subtask left BEHIND in an earlier sprint still renders under its parent: a completed subtask stays in the sprint it was finished in while the parent carries on, and the parent's progress bar is derived from exactly those children. Hiding them (the old `activeSprint > sprintStart` rule) left a card handed to someone else reading 90% with no expand arrow and subtasks its new owner could see named in the log but could not open. Only a subtask whose day has not arrived — deferred ahead, or a sprint that had not started on the viewed day — stays hidden | web/src/subtasks.ts (shared by MeBoard and TeamBoard) | ✅ subtasks.test.ts |
 
+| S2 | Ungrouping hands an OWNERLESS child the parent's person: a subtask usually has no assignee of its own (it rides the parent's), so a pull-out left it in Unassigned and off every personal board — from the person who pulled it, the card vanished. A patch that also names assignees wins, including an explicit empty one: assignees are applied AFTER the parent so a deliberate drop into Unassigned lands | boardservice.SetParent + handlePatchCard ordering | ✅ TestUngroupGivesTheParentsPerson / TestUngroupKeepsItsOwnPerson / TestPatchUngroupRespectsExplicitAssignees |
+
 ## Card object mapping
 
 | # | Rule | Test |

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -551,16 +551,6 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if p.Assignees != nil {
-		login := ""
-		if len(*p.Assignees) > 0 {
-			login = (*p.Assignees)[0]
-		}
-		if err := svc.SetAssignee(ctx, owner, project, uid, login); err != nil {
-			s.apiError(w, r, err)
-			return
-		}
-	}
 	if p.Stage != nil {
 		stage, ok := parseStage(w, *p.Stage)
 		if !ok {
@@ -595,6 +585,20 @@ func (s *Server) handlePatchCard(w http.ResponseWriter, r *http.Request) {
 	}
 	if p.Parent != nil {
 		if err := svc.SetParent(ctx, owner, project, uid, *p.Parent); err != nil {
+			s.apiError(w, r, err)
+			return
+		}
+	}
+	// Assignees are applied AFTER the parent on purpose. Ungrouping hands an
+	// ownerless child the parent's person so it does not fall off every
+	// board; a patch that also names assignees means the caller decided who
+	// owns it — including "nobody" — and that decision must land last.
+	if p.Assignees != nil {
+		login := ""
+		if len(*p.Assignees) > 0 {
+			login = (*p.Assignees)[0]
+		}
+		if err := svc.SetAssignee(ctx, owner, project, uid, login); err != nil {
 			s.apiError(w, r, err)
 			return
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -637,3 +637,46 @@ func TestAPIBadCredentialsAnswers401(t *testing.T) {
 		t.Fatalf("the answer must name the cause, got %s", rec.Body.String())
 	}
 }
+
+// A patch that ungroups a card AND names its assignees must land the caller's
+// decision, not the parent-handover default: dropping a subtask into the
+// Unassigned column means nobody owns it. The handover only fills the gap
+// when the patch says nothing about assignees.
+func TestPatchUngroupRespectsExplicitAssignees(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"ungroup alone inherits the parent's person", `{"parent":""}`, "androndo"},
+		{"ungroup into Unassigned stays unowned", `{"parent":"","assignees":[]}`, ""},
+		{"ungroup onto a person takes that person", `{"parent":"","assignees":["kitsunoff"]}`, "kitsunoff"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := boardservicetest.New([]board.Card{
+				{ItemID: "p1", Title: "parent", Team: "portal", Assignees: []string{"androndo"}},
+				{ItemID: "c1", Title: "child", Team: "portal", Parent: "p1"},
+			}, nil)
+			srv := apiServer(t, Options{}, fake)
+			rec := do(t, srv, http.MethodPatch, "/api/v1/cards/c1?owner=acme&board=1", tc.body)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+			}
+			b, _ := fake.LoadBoard(t.Context(), "acme", 1)
+			var got string
+			for _, c := range b.Cards {
+				if c.ItemID == "c1" {
+					if c.Parent != "" {
+						t.Fatalf("still grouped")
+					}
+					if len(c.Assignees) > 0 {
+						got = c.Assignees[0]
+					}
+				}
+			}
+			if got != tc.want {
+				t.Fatalf("assignee = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/boardservice/subtasks.go
+++ b/pkg/boardservice/subtasks.go
@@ -39,6 +39,19 @@ func (s *Service) SetParent(ctx context.Context, owner string, project int, item
 		if err := s.backend.SetParent(ctx, b, card, ""); err != nil {
 			return err
 		}
+		// A subtask usually has no assignee of its own — it rides the
+		// parent's — so a pull-out left it ownerless: gone from every
+		// personal board and sitting in Unassigned, which from the person
+		// who pulled it looks exactly like the card vanishing.
+		// deleteWithCascade hands a released child the parent's person for
+		// this same reason.
+		if op, ok := findCard(b, card.Parent); ok &&
+			len(card.Assignees) == 0 && len(op.Assignees) > 0 {
+			if err := s.backend.SetAssignee(ctx, b, card, op.Assignees[0]); err != nil {
+				return err
+			}
+			s.logEvent(ctx, b, card, board.EventAssignee, "", op.Assignees[0])
+		}
 		// The log keeps titles, not item ids — that is what a human (or an
 		// agent reading list_log) can act on. Both sides record the change.
 		if op, ok := findCard(b, card.Parent); ok {

--- a/pkg/boardservice/subtasks_test.go
+++ b/pkg/boardservice/subtasks_test.go
@@ -413,3 +413,47 @@ func TestGroupPlanCardUnderASlot(t *testing.T) {
 		t.Fatalf("the slot was rewritten: band %q week %q", parent.Plan, parent.Week)
 	}
 }
+
+// Pulling a subtask out of its parent must not make it ownerless. A subtask
+// usually has no assignee of its own — it rides the parent's — so ungrouping
+// dropped it into Unassigned and off every personal board: from the person
+// who pulled it, the card simply vanished. deleteWithCascade already hands a
+// released child the parent's person for exactly this reason; the plain
+// ungroup now does the same.
+func TestUngroupGivesTheParentsPerson(t *testing.T) {
+	fake := newFake([]board.Card{
+		{ItemID: "p1", Title: "the parent", Team: "portal", Assignees: []string{"androndo"}},
+		{ItemID: "c1", Title: "smoke test", Team: "portal", Parent: "p1"},
+	}, nil)
+	svc := New(fake)
+	ctx := t.Context()
+	if err := svc.SetParent(ctx, "o", 1, "c1", ""); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(ctx, "o", 1)
+	c, _ := findCard(b, "c1")
+	if c.Parent != "" {
+		t.Fatalf("still grouped under %q", c.Parent)
+	}
+	if len(c.Assignees) != 1 || c.Assignees[0] != "androndo" {
+		t.Fatalf("assignees = %v, want the parent's person so the card stays on a board", c.Assignees)
+	}
+}
+
+// A subtask that has its OWN assignee keeps them: the pull-out must not hand
+// someone else's work to the parent's owner.
+func TestUngroupKeepsItsOwnPerson(t *testing.T) {
+	fake := newFake([]board.Card{
+		{ItemID: "p1", Title: "the parent", Team: "portal", Assignees: []string{"androndo"}},
+		{ItemID: "c1", Title: "smoke test", Team: "portal", Parent: "p1", Assignees: []string{"kitsunoff"}},
+	}, nil)
+	svc := New(fake)
+	if err := svc.SetParent(t.Context(), "o", 1, "c1", ""); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := fake.LoadBoard(t.Context(), "o", 1)
+	c, _ := findCard(b, "c1")
+	if len(c.Assignees) != 1 || c.Assignees[0] != "kitsunoff" {
+		t.Fatalf("assignees = %v, want its own person untouched", c.Assignees)
+	}
+}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -905,7 +905,14 @@ export function MeBoard({
     // the parent's slot); mirror both locally while the delete round-trips.
     const freed = board.cards.filter((c) => c.parent === card.itemId);
     for (const c of freed) {
-      patchCard(c.itemId, { parent: undefined });
+      patchCard(c.itemId, {
+        parent: undefined,
+        // An ownerless child takes the parent's person — the server does
+        // this so the card lands in a cell instead of falling off the board.
+        ...(c.assignees.length === 0 && card.assignees.length > 0
+          ? { assignees: card.assignees.slice(0, 1) }
+          : {}),
+      });
     }
     if (freed.length > 0) {
       const freedIds = new Set(freed.map((c) => c.itemId));


### PR DESCRIPTION
## The report

"I just pulled the Смоук-тест child out of its parent and it disappeared from the board."

## Why

A subtask usually has no assignee of its own — it rides the parent's. The reported card has no assignee event in its entire history, from creation on 6 August to the pull-out at 16:41 today. Once ungrouped it was ownerless, which means:

- gone from **every** personal board (a Me board is built from cards assigned to you), and
- sitting in the Team board's Unassigned column, far from where its parent stood.

From the person who pulled it out, that is indistinguishable from the card being deleted.

## The rule now

Ungrouping hands an ownerless child the parent's person. `deleteWithCascade` has always done exactly this when releasing subtasks — same reason, same comment: the freed card should surface in the cell the parent stood in, not in Unassigned. The plain ungroup simply never learned it.

**An explicit decision still wins.** Assignees are now applied *after* the parent in a patch, so:

| what the caller sends | result |
|---|---|
| `{"parent":""}` | inherits the parent's person |
| `{"parent":"","assignees":[]}` | stays unowned — a deliberate drop into Unassigned |
| `{"parent":"","assignees":["kitsunoff"]}` | takes that person |

The handover only fills a gap the caller left.

## Testing

- `TestUngroupGivesTheParentsPerson`, `TestUngroupKeepsItsOwnPerson` — the service rule and its limit (a child with its own assignee is untouched).
- `TestPatchUngroupRespectsExplicitAssignees` — the three intents above, through the HTTP layer, which is where the ordering matters.
- The reported card was given its owner back on the live board and is on the day flow again.
- A row in `docs/design/behavior-matrix.md`.