### PR TITLE
feat(board): a subtask's person always follows its parent

### DIFF
--- a/docs/dates.md
+++ b/docs/dates.md
@@ -178,6 +178,13 @@ today while the card stays in its sprint). A "**next sprint**" create has **no
   plan slot to the parent instead (the parent replaces it in the Weekly
   panel) — subtasks are never plan cards themselves, though an expanded
   weekly parent shows its subtask rows nested under it.
+- **A subtask's person always follows its parent**, the way its team does:
+  grouping hands the child over to the parent's assignee, a direct change on a
+  subtask snaps back to the parent's, and re-assigning a parent hands the whole
+  family over (unassigning it unassigns them all). A family that drifts apart
+  lands on two personal boards — the Me view admits a card when you own one of
+  its subtasks, so one stray child drags the parent and every sibling onto a
+  board they are not part of.
 - A subtask's team always follows its parent: changing the parent's team
   cascades to its subtasks (sprint pointer included), and a direct team change
   on a subtask snaps back to the parent's team.

--- a/docs/design/behavior-matrix.md
+++ b/docs/design/behavior-matrix.md
@@ -79,6 +79,8 @@ Legend: ✅ existing Go test · 🆕 new test written for the redesign ·
 
 | S2 | Ungrouping hands an OWNERLESS child the parent's person: a subtask usually has no assignee of its own (it rides the parent's), so a pull-out left it in Unassigned and off every personal board — from the person who pulled it, the card vanished. A patch that also names assignees wins, including an explicit empty one: assignees are applied AFTER the parent so a deliberate drop into Unassigned lands | boardservice.SetParent + handlePatchCard ordering | ✅ TestUngroupGivesTheParentsPerson / TestUngroupKeepsItsOwnPerson / TestPatchUngroupRespectsExplicitAssignees |
 
+| S3 | A subtask's PERSON always follows its parent, like its team: grouping hands the child to the parent's assignee, a direct change on a subtask snaps back, and re-assigning (or unassigning) a parent cascades to every subtask. Without it a split family lands on two personal boards, since the Me view admits a card when you own one of its subtasks — one stray child dragged the parent and all its siblings onto a stranger's board | boardservice.SetAssignee + SetParent, mirrored in TeamBoard | ✅ TestSubtaskOwnerFollowsTheParent |
+
 ## Card object mapping
 
 | # | Rule | Test |

--- a/pkg/boardservice/service.go
+++ b/pkg/boardservice/service.go
@@ -1808,6 +1808,20 @@ func (s *Service) SetAssignee(ctx context.Context, owner string, project int, it
 	if err != nil {
 		return err
 	}
+	// A subtask always belongs to its parent's PERSON, the way it always
+	// belongs to the parent's team: a direct change follows the parent
+	// instead of drifting away from it. A family that drifts apart lands on
+	// two personal boards — the Me view admits a card when you own one of its
+	// subtasks, so one stray child drags the parent and every sibling onto a
+	// board they are not part of.
+	if card.Parent != "" {
+		if p, ok := findCard(b, card.Parent); ok {
+			login = ""
+			if len(p.Assignees) > 0 {
+				login = p.Assignees[0]
+			}
+		}
+	}
 	if err := s.backend.SetAssignee(ctx, b, card, login); err != nil {
 		return err
 	}
@@ -1815,7 +1829,32 @@ func (s *Service) SetAssignee(ctx context.Context, owner string, project int, it
 	if len(card.Assignees) > 0 {
 		prev = card.Assignees[0]
 	}
-	s.logEvent(ctx, b, card, board.EventAssignee, prev, login)
+	if prev != login {
+		s.logEvent(ctx, b, card, board.EventAssignee, prev, login)
+	}
+	// Re-assigning a parent hands its whole family over.
+	return s.syncChildrenAssignee(ctx, b, card, login)
+}
+
+// syncChildrenAssignee puts every subtask on the person its parent is on. It
+// is a no-op for a card without subtasks.
+func (s *Service) syncChildrenAssignee(ctx context.Context, b board.Board, parent board.Card, login string) error {
+	if parent.Parent != "" {
+		return nil // a subtask has no subtasks of its own
+	}
+	for _, c := range board.Children(b, parent.ItemID) {
+		cur := ""
+		if len(c.Assignees) > 0 {
+			cur = c.Assignees[0]
+		}
+		if cur == login {
+			continue
+		}
+		if err := s.backend.SetAssignee(ctx, b, c, login); err != nil {
+			return err
+		}
+		s.logEvent(ctx, b, c, board.EventAssignee, cur, login)
+	}
 	return nil
 }
 

--- a/pkg/boardservice/subtasks.go
+++ b/pkg/boardservice/subtasks.go
@@ -94,6 +94,22 @@ func (s *Service) SetParent(ctx context.Context, owner string, project int, item
 			return err
 		}
 	}
+	// A subtask always belongs to its parent's PERSON: grouping hands the
+	// child over, so a family is never split across two personal boards.
+	pLogin := ""
+	if len(p.Assignees) > 0 {
+		pLogin = p.Assignees[0]
+	}
+	cLogin := ""
+	if len(card.Assignees) > 0 {
+		cLogin = card.Assignees[0]
+	}
+	if cLogin != pLogin {
+		if err := s.backend.SetAssignee(ctx, b, card, pLogin); err != nil {
+			return err
+		}
+		s.logEvent(ctx, b, card, board.EventAssignee, cLogin, pLogin)
+	}
 	// A subtask always belongs to its parent's team.
 	if card.Team != p.Team {
 		if err := s.backend.SetTeam(ctx, b, card, p.Team); err != nil {

--- a/pkg/boardservice/subtasks_test.go
+++ b/pkg/boardservice/subtasks_test.go
@@ -457,3 +457,78 @@ func TestUngroupKeepsItsOwnPerson(t *testing.T) {
 		t.Fatalf("assignees = %v, want its own person untouched", c.Assignees)
 	}
 }
+
+// A subtask always belongs to its parent's PERSON, the way it always belongs
+// to the parent's team. Three doors lead in, and all three must agree, or a
+// family drifts apart and someone else's card lands on your personal board:
+// the Me view admits a card when you own one of its subtasks, so a single
+// stray child drags the parent and all its siblings onto a board they are not
+// part of.
+func TestSubtaskOwnerFollowsTheParent(t *testing.T) {
+	t.Run("grouping hands the child the parent's person", func(t *testing.T) {
+		fake := newFake([]board.Card{
+			{ItemID: "p1", Title: "parent", Team: "portal", Assignees: []string{"IvanStukov"}},
+			{ItemID: "c1", Title: "child", Team: "portal", Assignees: []string{"krakazyabra"}},
+		}, nil)
+		svc := New(fake)
+		if err := svc.SetParent(t.Context(), "o", 1, "c1", "p1"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := fake.LoadBoard(t.Context(), "o", 1)
+		c, _ := findCard(b, "c1")
+		if len(c.Assignees) != 1 || c.Assignees[0] != "IvanStukov" {
+			t.Fatalf("assignees = %v, want the parent's person", c.Assignees)
+		}
+	})
+
+	t.Run("a direct change on a subtask follows the parent instead of drifting", func(t *testing.T) {
+		fake := newFake([]board.Card{
+			{ItemID: "p1", Title: "parent", Team: "portal", Assignees: []string{"IvanStukov"}},
+			{ItemID: "c1", Title: "child", Team: "portal", Parent: "p1", Assignees: []string{"IvanStukov"}},
+		}, nil)
+		svc := New(fake)
+		if err := svc.SetAssignee(t.Context(), "o", 1, "c1", "krakazyabra"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := fake.LoadBoard(t.Context(), "o", 1)
+		c, _ := findCard(b, "c1")
+		if len(c.Assignees) != 1 || c.Assignees[0] != "IvanStukov" {
+			t.Fatalf("assignees = %v, want it snapped back to the parent's person", c.Assignees)
+		}
+	})
+
+	t.Run("re-assigning the parent cascades to every subtask", func(t *testing.T) {
+		fake := newFake([]board.Card{
+			{ItemID: "p1", Title: "parent", Team: "portal", Assignees: []string{"IvanStukov"}},
+			{ItemID: "c1", Title: "one", Team: "portal", Parent: "p1", Assignees: []string{"IvanStukov"}},
+			{ItemID: "c2", Title: "two", Team: "portal", Parent: "p1", Assignees: []string{"IvanStukov"}},
+		}, nil)
+		svc := New(fake)
+		if err := svc.SetAssignee(t.Context(), "o", 1, "p1", "krakazyabra"); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := fake.LoadBoard(t.Context(), "o", 1)
+		for _, id := range []string{"p1", "c1", "c2"} {
+			c, _ := findCard(b, id)
+			if len(c.Assignees) != 1 || c.Assignees[0] != "krakazyabra" {
+				t.Fatalf("%s assignees = %v, want the whole family on krakazyabra", id, c.Assignees)
+			}
+		}
+	})
+
+	t.Run("unassigning the parent unassigns the family", func(t *testing.T) {
+		fake := newFake([]board.Card{
+			{ItemID: "p1", Title: "parent", Team: "portal", Assignees: []string{"IvanStukov"}},
+			{ItemID: "c1", Title: "one", Team: "portal", Parent: "p1", Assignees: []string{"IvanStukov"}},
+		}, nil)
+		svc := New(fake)
+		if err := svc.SetAssignee(t.Context(), "o", 1, "p1", ""); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := fake.LoadBoard(t.Context(), "o", 1)
+		c, _ := findCard(b, "c1")
+		if len(c.Assignees) != 0 {
+			t.Fatalf("child assignees = %v, want none", c.Assignees)
+		}
+	})
+}

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1658,13 +1658,33 @@ export function TeamBoard({
   };
 
   const handleSetAssignee = (card: CardModel, login: string | null) => {
+    // A subtask always belongs to its parent's person (mirrors the server): a
+    // direct change follows the parent, and re-assigning a parent hands the
+    // whole family over. A family split across two people lands on two
+    // personal boards.
+    const target = card.parent ? cardsById.get(card.parent) ?? card : card;
+    const next = card.parent
+      ? target.assignees.slice(0, 1)
+      : login
+        ? [login]
+        : [];
+    const family = card.parent
+      ? []
+      : board.cards.filter((c) => c.parent === card.itemId);
     const prev = card.assignees;
-    patchCard(card.itemId, { assignees: login ? [login] : [] });
+    const prevFamily = family.map((c) => ({ id: c.itemId, was: c.assignees }));
+    patchCard(card.itemId, { assignees: next });
+    for (const c of family) {
+      patchCard(c.itemId, { assignees: next });
+    }
     void provider
-      .patchCard(board, card.itemId, { assignees: login ? [login] : [] })
+      .patchCard(board, card.itemId, { assignees: next })
       .then(addCard)
       .catch((err: unknown) => {
         patchCard(card.itemId, { assignees: prev });
+        for (const f of prevFamily) {
+          patchCard(f.id, { assignees: f.was });
+        }
         onError(errMessage(err));
       });
   };


### PR DESCRIPTION
## The report

«Карточка у IvanStukov, а отображается у krakazyabra» — `PVTI_lADOCiHiS84BbkpzzgzMfWk`.

## Why it happened

The Me view admits a card when you own **one of its subtasks**. It has to: subtasks render only under their parent, so without the parent your subtask would have nowhere to appear. Then `withSubtasks` delivers the parent's whole family.

«Доработки документации» (IvanStukov) has eleven subtasks — ten his, one krakazyabra's. So the card and all ten foreign siblings landed on krakazyabra's personal board. Six such families exist on the live board, dragging **eighteen** foreign rows onto boards they are not part of.

## The rule

A subtask now belongs to its parent's **person** the way it already belongs to the parent's **team** — the same shape, the same three doors:

| door | behaviour |
|---|---|
| grouping a card under a parent | the child takes the parent's assignee |
| assigning a subtask directly | snaps back to the parent's person |
| re-assigning the parent | hands the whole family over; unassigning it unassigns them all |

A family can no longer split across two people, so it can no longer land on two boards. The Team board mirrors the rule optimistically, or the row jumps back when the server answers.

## Testing

- `TestSubtaskOwnerFollowsTheParent` — four cases, one per door plus the unassign cascade.
- Driven against a live board: grouping a `krakazyabra` child under an `IvanStukov` parent moved it to IvanStukov; a direct re-assign of the child snapped back; re-assigning the parent moved both.
- `docs/dates.md` gains the rule next to the team one; `docs/design/behavior-matrix.md` gains row S3.

## Note on existing data

Six families on the live board currently violate this rule. The rule does not rewrite them retroactively — they will normalize the next time anyone touches an assignee in the family. Say the word and I will normalize them in one pass instead.