### PR TITLE
feat(project): zoom the board, size columns one at a time, and make room for the next card

### DIFF
--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -16,6 +16,7 @@ import { ZoomControl } from "./ZoomControl";
 import {
   MIN_COL_PX,
   type Zoom,
+  anchoredScroll,
   clampZoom,
   columnFactor,
   wheelZoom,
@@ -398,6 +399,20 @@ export function ProjectBoard({
     setResizing(null);
   };
 
+  // Where the scroller must land after the next zoom-driven re-layout, so the
+  // point under the cursor stays under it.
+  const pendingScroll = useRef<{ left: number; top: number } | null>(null);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const want = pendingScroll.current;
+    if (!el || !want) {
+      return;
+    }
+    pendingScroll.current = null;
+    el.scrollLeft = want.left;
+    el.scrollTop = want.top;
+  }, [zoom]);
+
   // Ctrl/Cmd + wheel zooms the board. Both axes move by the same step from
   // wherever they are, so the two sliders keep their offset; the browser's
   // own page zoom is what the modifier would otherwise do, hence preventing
@@ -412,7 +427,18 @@ export function ProjectBoard({
         return;
       }
       e.preventDefault();
-      setZoom(wheelZoom(zoomRef.current, e.deltaY));
+      const was = zoomRef.current;
+      const next = wheelZoom(was, e.deltaY);
+      // Zoom around the cursor: work out where the board must be scrolled to
+      // leave the point under the pointer where it is, and apply it AFTER the
+      // grid has been re-laid — a scroll set against the old size is clamped
+      // to it, which is what makes a naive version drift.
+      const box = el.getBoundingClientRect();
+      pendingScroll.current = {
+        left: anchoredScroll(el.scrollLeft, e.clientX - box.left, 54, next.x / was.x),
+        top: anchoredScroll(el.scrollTop, e.clientY - box.top, HEADER_PX, next.y / was.y),
+      };
+      setZoom(next);
     };
     // Not passive: the whole point is to take the gesture from the browser.
     el.addEventListener("wheel", onWheel, { passive: false });

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -128,8 +128,11 @@ const LS_COLF = "aeman.projectColFactors";
 const LS_ZOOM = "aeman.projectZoom";
 
 /** The cell the board is drawn from before any zoom or per-column width. */
-/** How far a card steps aside to uncover the strip a new one starts from. */
+/** How far a card steps aside to uncover the strip a new one starts from,
+ *  and how long the pointer must rest there first — long enough that merely
+ *  crossing the card on the way somewhere else never moves it. */
 const NUDGE_PX = 13;
+const NUDGE_DELAY_MS = 500;
 const BASE_COL = 140;
 const BASE_ROW = 28;
 
@@ -250,6 +253,13 @@ export function ProjectBoard({
   // buttons at either end — planning is not confined to a fixed horizon.
   // The card currently stepped aside to leave room for a new one beside it.
   const [nudged, setNudged] = useState<string | null>(null);
+  const nudgeTimer = useRef<number | null>(null);
+  const cancelNudgeTimer = () => {
+    if (nudgeTimer.current !== null) {
+      window.clearTimeout(nudgeTimer.current);
+      nudgeTimer.current = null;
+    }
+  };
   const [padBack, setPadBack] = useState(0);
   const [padFwd, setPadFwd] = useState(0);
 
@@ -1608,7 +1618,12 @@ export function ProjectBoard({
               }`}
               style={{ gridRow: row + 2, gridColumn: col + 2 }}
               onPointerDown={(ev) => beginDrag(e, row, ev)}
-              onPointerLeave={() => setNudged(null)}
+              onPointerLeave={() => {
+                if (!drag) {
+                  cancelNudgeTimer();
+                  setNudged(null);
+                }
+              }}
               onPointerCancel={() => setDrag(null)}
             />
           )),
@@ -1730,7 +1745,19 @@ export function ProjectBoard({
                 }
                 const r = (ev.currentTarget as HTMLElement).getBoundingClientRect();
                 const inStrip = ev.clientX > r.right - NUDGE_PX * 2;
-                setNudged(inStrip ? card.itemId : (cur) => (cur === card.itemId ? null : cur));
+                if (!inStrip) {
+                  cancelNudgeTimer();
+                  setNudged((cur) => (cur === card.itemId ? null : cur));
+                  return;
+                }
+                // Rest there first: a pointer merely crossing the card on its
+                // way somewhere else must not shove it.
+                if (nudged !== card.itemId && nudgeTimer.current === null) {
+                  nudgeTimer.current = window.setTimeout(() => {
+                    nudgeTimer.current = null;
+                    setNudged(card.itemId);
+                  }, NUDGE_DELAY_MS);
+                }
               }}
               // Stepping aside puts the pointer in the gap that just opened —
               // which the browser reports as leaving the card. Undoing the
@@ -1738,6 +1765,13 @@ export function ProjectBoard({
               // and flicker forever; so a pointer inside the strip is not a
               // pointer that left.
               onPointerLeave={(ev) => {
+                // A drag started in the strip holds the card aside until it
+                // ends: the pointer travels far from the card by design, and
+                // closing the gap mid-pull yanks the ground out from under it.
+                if (drag) {
+                  return;
+                }
+                cancelNudgeTimer();
                 const r = (ev.currentTarget as HTMLElement).getBoundingClientRect();
                 const intoTheGap =
                   ev.clientX >= r.right &&
@@ -1760,9 +1794,14 @@ export function ProjectBoard({
                 // of hiding each other. The width holds while the card is
                 // being dragged too: widening it on press made the first click
                 // of a double-click visibly inflate the card.
+                // Cards sharing a column carry an EXPLICIT width, and a
+                // margin cannot shrink that — the step aside has to come out
+                // of the width itself, or a card with neighbours never moves.
                 ...(lanes > 1
                   ? {
-                      width: `calc(${(100 / lanes) * laneWidth}% - 2px)`,
+                      width: `calc(${(100 / lanes) * laneWidth}% - 2px${
+                        nudged === card.itemId ? ` - ${NUDGE_PX}px` : ""
+                      })`,
                       marginLeft: `${(100 / lanes) * lane}%`,
                     }
                   : {}),

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -128,6 +128,8 @@ const LS_COLF = "aeman.projectColFactors";
 const LS_ZOOM = "aeman.projectZoom";
 
 /** The cell the board is drawn from before any zoom or per-column width. */
+/** How far a card steps aside to uncover the strip a new one starts from. */
+const NUDGE_PX = 13;
 const BASE_COL = 140;
 const BASE_ROW = 28;
 
@@ -246,6 +248,8 @@ export function ProjectBoard({
   // card), through the latest card plus a quarter of runway to plan into.
   // How far the window reaches beyond the default, in weeks, grown by the
   // buttons at either end — planning is not confined to a fixed horizon.
+  // The card currently stepped aside to leave room for a new one beside it.
+  const [nudged, setNudged] = useState<string | null>(null);
   const [padBack, setPadBack] = useState(0);
   const [padFwd, setPadFwd] = useState(0);
 
@@ -1604,6 +1608,7 @@ export function ProjectBoard({
               }`}
               style={{ gridRow: row + 2, gridColumn: col + 2 }}
               onPointerDown={(ev) => beginDrag(e, row, ev)}
+              onPointerLeave={() => setNudged(null)}
               onPointerCancel={() => setDrag(null)}
             />
           )),
@@ -1713,7 +1718,36 @@ export function ProjectBoard({
               key={card.itemId}
               className={`project-slot ${slotTone(card, today)}${
                 move?.card.itemId === card.itemId ? " project-slot-moving" : ""
-              }`}
+              }${nudged === card.itemId ? " project-slot-nudged" : ""}`}
+              // A card that fills its column leaves nowhere to start the next
+              // one. Hovering its right edge steps it aside just enough to
+              // uncover the cell beneath, which is already the drag surface —
+              // so a new card is pulled out beside an existing one without
+              // moving anything or opening a menu.
+              onPointerMove={(ev) => {
+                if (move || drag) {
+                  return;
+                }
+                const r = (ev.currentTarget as HTMLElement).getBoundingClientRect();
+                const inStrip = ev.clientX > r.right - NUDGE_PX * 2;
+                setNudged(inStrip ? card.itemId : (cur) => (cur === card.itemId ? null : cur));
+              }}
+              // Stepping aside puts the pointer in the gap that just opened —
+              // which the browser reports as leaving the card. Undoing the
+              // nudge there would close the gap under the pointer, reopen it,
+              // and flicker forever; so a pointer inside the strip is not a
+              // pointer that left.
+              onPointerLeave={(ev) => {
+                const r = (ev.currentTarget as HTMLElement).getBoundingClientRect();
+                const intoTheGap =
+                  ev.clientX >= r.right &&
+                  ev.clientX <= r.right + NUDGE_PX + 2 &&
+                  ev.clientY >= r.top &&
+                  ev.clientY <= r.bottom;
+                if (!intoTheGap) {
+                  setNudged((cur) => (cur === card.itemId ? null : cur));
+                }
+              }}
               style={{
                 // While dragged, the slot itself sits where it would land —
                 // the preview IS the card. row/span/col come from the packing,

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -12,6 +12,14 @@ import { Dropdown } from "./Dropdown";
 import { ProjectPicker } from "./ProjectPicker";
 import { STAGES } from "../stages";
 import { TeamChips } from "./TeamChips";
+import { ZoomControl } from "./ZoomControl";
+import {
+  MIN_COL_PX,
+  type Zoom,
+  clampZoom,
+  columnFactor,
+  wheelZoom,
+} from "../projectZoom";
 
 interface ProjectBoardProps {
   board: Board;
@@ -54,10 +62,6 @@ function isoWeekNo(monday: string): number {
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-/** One grid row's height in px, and how many weeks each "more" press adds.
- *  ROW_PX must match .project-cell in styles.css — it is what keeps the view
- *  still when rows are prepended. */
-const ROW_PX = 28;
 /** How far the pointer must travel before a press on a card becomes a drag. */
 const DRAG_SLOP = 4;
 const HEADER_PX = 26;
@@ -114,32 +118,25 @@ function colKey(project: string, epic: string): string {
   return `${project}\u0000${epic}`;
 }
 
-/** LS_COLW remembers how wide you dragged the columns — this browser's view
- *  of the board rather than the board's own state, so it stays local. (The
- *  project chips' selection lives in projectFilter.ts, shared with the
- *  Process tab.) */
-const LS_COLW = "aeman.projectColWidth";
 const LS_PROGRESS = "aeman.projectProgressOpen";
+/** Per-column widths, kept as a RATIO to the shared width and keyed by the
+ *  column itself, so a column carries its size from one project selection to
+ *  the next — and the board's zoom scales it along with everything else. */
+const LS_COLF = "aeman.projectColFactors";
+/** The board's own zoom, one entry per axis. */
+const LS_ZOOM = "aeman.projectZoom";
 
-/** The narrowest a column may be dragged: below this a title is unreadable. */
-const MIN_COL = 70;
+/** The cell the board is drawn from before any zoom or per-column width. */
+const BASE_COL = 140;
+const BASE_ROW = 28;
 
-/** Column widths, one per selection of projects: a plan of 21 columns and one
- *  of a single column want different widths, and a width that followed you
- *  between them would be wrong in one of the two. */
-function readColWidths(): Record<string, number> {
+function readColFactors(): Record<string, number> {
   try {
-    const raw = localStorage.getItem(LS_COLW);
-    const v: unknown = raw ? JSON.parse(raw) : null;
-    // The pre-selection format was one number for the whole board: keep it as
-    // the all-projects width rather than dropping what someone dragged.
-    if (typeof v === "number") {
-      return v >= MIN_COL ? { "*": v } : {};
-    }
+    const v: unknown = JSON.parse(localStorage.getItem(LS_COLF) ?? "null");
     if (v && typeof v === "object") {
       return Object.fromEntries(
         Object.entries(v as Record<string, unknown>).filter(
-          ([, w]) => typeof w === "number" && w >= MIN_COL,
+          ([, f]) => typeof f === "number" && f > 0 && f < 20,
         ),
       ) as Record<string, number>;
     }
@@ -148,6 +145,23 @@ function readColWidths(): Record<string, number> {
   }
   return {};
 }
+
+function readZoom(): Zoom {
+  try {
+    const v: unknown = JSON.parse(localStorage.getItem(LS_ZOOM) ?? "null");
+    if (v && typeof v === "object") {
+      const z = v as { x?: unknown; y?: unknown };
+      return {
+        x: clampZoom(typeof z.x === "number" ? z.x : 1),
+        y: clampZoom(typeof z.y === "number" ? z.y : 1),
+      };
+    }
+  } catch {
+    // ditto
+  }
+  return { x: 1, y: 1 };
+}
+
 
 /** The Project board: weeks as rows and one project's epics as columns, cards
  *  as slots that may span several weeks (dates start..end). Dragging down an
@@ -238,9 +252,47 @@ export function ProjectBoard({
   // the right default. One width governs every column of the selection,
   // because a plan reads as a grid and columns of assorted widths stop being
   // comparable; a different selection carries its own width.
-  const [colWidths, setColWidths] = useState<Record<string, number>>(readColWidths);
-  const widthsRef = useRef(colWidths);
-  const [resizing, setResizing] = useState<{ x: number; from: number } | null>(null);
+  // How much bigger the board draws its cells, and which columns keep a width
+  // of their own (a ratio to the shared width, so zoom scales it too).
+  const [zoom, setZoomState] = useState<Zoom>(readZoom);
+  const zoomRef = useRef(zoom);
+  const [colFactors, setColFactorsState] = useState<Record<string, number>>(readColFactors);
+  const factorsRef = useRef(colFactors);
+  const [resizing, setResizing] = useState<{
+    key: string;
+    x: number;
+    from: number;
+  } | null>(null);
+
+  const setZoom = (z: Zoom) => {
+    zoomRef.current = z;
+    setZoomState(z);
+    localStorage.setItem(LS_ZOOM, JSON.stringify(z));
+  };
+  // The width a column has when it has no width of its own: what the columns
+  // would share at zoom 1, scaled by the zoom. Measured from the board rather
+  // than assumed, so zooming starts from what is actually on screen instead of
+  // jumping to a constant the first time it is touched.
+  const [boardW, setBoardW] = useState(0);
+  const sharedCol = useMemo(() => {
+    const room = Math.max(0, boardW - 54 - 34);
+    const fill = epics.length > 0 ? room / epics.length : BASE_COL;
+    return Math.max(MIN_COL_PX, Math.max(BASE_COL, fill) * zoom.x);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardW, epics.length, zoom.x]);
+  const rowH = Math.max(12, Math.round(BASE_ROW * zoom.y));
+
+  const setColFactor = (key: string, f: number | null) => {
+    const next = { ...factorsRef.current };
+    if (f === null) {
+      delete next[key];
+    } else {
+      next[key] = f;
+    }
+    factorsRef.current = next;
+    setColFactorsState(next);
+    localStorage.setItem(LS_COLF, JSON.stringify(next));
+  };
 
   // Dragging a column header sideways reorders the columns. A column can
   // always be moved among the columns of ITS OWN project — that order is what
@@ -317,38 +369,26 @@ export function ProjectBoard({
       });
   };
 
-  // Which selection the width belongs to: the chips in view, or every project.
-  const widthKey = filter ? [...filter].sort().join("\u0000") : "*";
-  const colWidth = colWidths[widthKey] ?? null;
-
-  const setColWidth = (w: number | null) => {
-    const next = { ...widthsRef.current };
-    if (w === null) {
-      delete next[widthKey];
-    } else {
-      next[widthKey] = w;
-    }
-    widthsRef.current = next;
-    setColWidths(next);
-  };
-
-  const persistWidths = () =>
-    localStorage.setItem(LS_COLW, JSON.stringify(widthsRef.current));
-
-  const beginResize = (e: React.PointerEvent) => {
+  // Dragging an edge resizes THAT column and nothing else: its width is
+  // remembered as a ratio to the width the others share, so it survives a
+  // zoom and a change of project selection. Dragged back to within a hair of
+  // the others it gives the ratio up and rejoins them — a column should not
+  // stay subtly different from a width nobody can see is different.
+  const beginResize = (key: string) => (e: React.PointerEvent) => {
     e.preventDefault();
     e.stopPropagation();
     const head = (e.currentTarget as HTMLElement).closest(".project-epic-head");
-    const from = colWidth ?? (head ? head.getBoundingClientRect().width : 140);
+    const from = head ? head.getBoundingClientRect().width : sharedCol;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    setResizing({ x: e.clientX, from });
+    setResizing({ key, x: e.clientX, from });
   };
 
   const moveResize = (e: React.PointerEvent) => {
     if (!resizing) {
       return;
     }
-    setColWidth(Math.max(MIN_COL, Math.round(resizing.from + (e.clientX - resizing.x))));
+    const width = Math.max(MIN_COL_PX, Math.round(resizing.from + (e.clientX - resizing.x)));
+    setColFactor(resizing.key, columnFactor(width, sharedCol));
   };
 
   const endResize = () => {
@@ -356,8 +396,29 @@ export function ProjectBoard({
       return;
     }
     setResizing(null);
-    persistWidths();
   };
+
+  // Ctrl/Cmd + wheel zooms the board. Both axes move by the same step from
+  // wherever they are, so the two sliders keep their offset; the browser's
+  // own page zoom is what the modifier would otherwise do, hence preventing
+  // the default.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) {
+        return;
+      }
+      e.preventDefault();
+      setZoom(wheelZoom(zoomRef.current, e.deltaY));
+    };
+    // Not passive: the whole point is to take the gesture from the browser.
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const weeks = useMemo(() => {
     let first = addDays(thisMonday, -14 - 7 * padBack);
@@ -386,7 +447,7 @@ export function ProjectBoard({
     setPadBack(padBack + WEEK_STEP);
     if (scroller) {
       requestAnimationFrame(() => {
-        scroller.scrollTop += WEEK_STEP * ROW_PX;
+        scroller.scrollTop += WEEK_STEP * rowH;
       });
     }
   };
@@ -877,6 +938,8 @@ export function ProjectBoard({
         height: b.height,
         gridTop: g.top - b.top + board.scrollTop,
       });
+      // The room the columns divide between them, for the zoom's base width.
+      setBoardW(b.width);
     };
     measure();
     const ro = new ResizeObserver(measure);
@@ -886,7 +949,7 @@ export function ProjectBoard({
       ro.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [weeks.length, epics.length, colWidth, padBack, padFwd]);
+  }, [weeks.length, epics.length, sharedCol, padBack, padFwd]);
 
 
   const beginLineDrag = (
@@ -1194,24 +1257,27 @@ export function ProjectBoard({
   // very first week — someone arriving had to scroll past a spent quarter to
   // find out where the team is. Once per project shown: after that the scroll
   // is the reader's, and pressing "earlier weeks" must not yank it back.
+  // Which selection is on screen — the identity the open-on-today scroll
+  // remembers, so switching projects opens on today again.
+  const selectionKey = filter ? [...filter].sort().join("\u0000") : "*";
   const scrolledFor = useRef<string | null>(null);
   useLayoutEffect(() => {
     const scroller = scrollRef.current;
-    if (!scroller || !boardBox || todayRow < 0 || scrolledFor.current === widthKey) {
+    if (!scroller || !boardBox || todayRow < 0 || scrolledFor.current === selectionKey) {
       return;
     }
-    const top = Math.max(0, boardBox.gridTop + HEADER_PX + (todayRow - 2) * ROW_PX);
+    const top = Math.max(0, boardBox.gridTop + HEADER_PX + (todayRow - 2) * rowH);
     // After the paint: switching project rebuilds the grid, and a scroll set
     // before it has its new height is clamped to the old one. The mark is set
     // in the callback, not here — this effect re-runs as the new board is
     // measured, and a mark set up front would cancel the pending frame and
     // then refuse to schedule another, which is why switching never moved.
     const frame = requestAnimationFrame(() => {
-      scrolledFor.current = widthKey;
+      scrolledFor.current = selectionKey;
       scroller.scrollTop = top;
     });
     return () => cancelAnimationFrame(frame);
-  }, [boardBox, todayRow, widthKey, weeks.length]);
+  }, [boardBox, todayRow, selectionKey, weeks.length]);
 
   // The projects the week menu can act on: those in view, or the whole roster
   // when nothing is filtered. The no-project bucket is included in both cases
@@ -1260,6 +1326,7 @@ export function ProjectBoard({
           onManage={onManageProjects}
           noneChip={looseEpics ? "No project" : undefined}
         />
+        {!empty && <ZoomControl zoom={zoom} onChange={setZoom} />}
       </div>
       {empty && (
         <div className="project-empty">
@@ -1323,14 +1390,39 @@ export function ProjectBoard({
           // they all take the width that was chosen.
           // 54px is what "17 Aug" needs and no more — the ISO number that
           // used to share this column is gone.
-          gridTemplateColumns: `54px repeat(${epics.length}, ${
-            colWidth === null ? "minmax(140px, 1fr)" : `${colWidth}px`
-          }) 34px`,
-          gridTemplateRows: `26px repeat(${weeks.length}, 28px)`,
+          // Every column is sized explicitly: a column with a width of its
+          // own takes its ratio of the shared width, the rest take the shared
+          // width itself. Text is never scaled — only the room around it.
+          gridTemplateColumns: `54px ${epics
+            .map((e) => {
+              const f = colFactors[colKey(e.project, e.name)];
+              return `${Math.round(sharedCol * (f ?? 1))}px`;
+            })
+            .join(" ")} 34px`,
+          gridTemplateRows: `26px repeat(${weeks.length}, ${rowH}px)`,
         }}
       >
         {/* header row */}
-        <div className="project-corner" />
+        <div className="project-corner">
+          {epics.some((e) => colFactors[colKey(e.project, e.name)] !== undefined) && (
+            <button
+              type="button"
+              className="project-cols-reset"
+              title="Give the columns on this board the same width again (columns not shown keep theirs)"
+              onClick={() => {
+                const next = { ...factorsRef.current };
+                for (const e of epics) {
+                  delete next[colKey(e.project, e.name)];
+                }
+                factorsRef.current = next;
+                setColFactorsState(next);
+                localStorage.setItem(LS_COLF, JSON.stringify(next));
+              }}
+            >
+              ⇥⇤
+            </button>
+          )}
+        </div>
         {epics.map((e) => {
           const k = colKey(e.project, e.name);
           if (renaming === k) {
@@ -1400,21 +1492,20 @@ export function ProjectBoard({
               >
                 ×
               </button>
-              {/* The border between two headers is the grip: dragging it sets
-                  the width of every column at once, double-click gives the
-                  room back to be shared evenly. */}
+              {/* The border is THIS column's grip: dragging it widens this
+                  column alone and remembers the size as a ratio to the rest,
+                  so it survives a zoom and a change of selection. Dragged
+                  back near the others it lets the ratio go. */}
               <span
                 className="project-col-resize"
-                title="Drag to set every column's width · double-click to fit"
-                onPointerDown={beginResize}
+                title="Drag to size this column · double-click to match the rest"
+                onPointerDown={beginResize(k)}
                 onPointerMove={moveResize}
                 onPointerUp={endResize}
                 onPointerCancel={() => setResizing(null)}
                 onDoubleClick={(ev) => {
-                  // Back to sharing the room evenly — for this selection only.
                   ev.stopPropagation();
-                  setColWidth(null);
-                  persistWidths();
+                  setColFactor(k, null);
                 }}
               />
             </div>

--- a/web/src/components/ZoomControl.tsx
+++ b/web/src/components/ZoomControl.tsx
@@ -1,0 +1,48 @@
+import { MAX_ZOOM, MIN_ZOOM, type Zoom } from "../projectZoom";
+
+interface ZoomControlProps {
+  zoom: Zoom;
+  onChange: (z: Zoom) => void;
+}
+
+/** ZoomControl is the board's scale, as two thin sliders stacked around a
+ *  reading of the current size: the top one widens the columns, the bottom one
+ *  heightens the rows, and the button between puts both back to 100%. The same
+ *  scale answers Ctrl/Cmd + wheel over the board, which moves both at once. */
+export function ZoomControl({ zoom, onChange }: ZoomControlProps) {
+  const at100 = Math.abs(zoom.x - 1) < 0.005 && Math.abs(zoom.y - 1) < 0.005;
+  const slider = (
+    axis: "x" | "y",
+    label: string,
+  ) => (
+    <input
+      type="range"
+      className="zoom-slider"
+      min={MIN_ZOOM}
+      max={MAX_ZOOM}
+      step={0.05}
+      value={zoom[axis]}
+      aria-label={label}
+      title={`${label} — ${Math.round(zoom[axis] * 100)}%`}
+      onChange={(e) => onChange({ ...zoom, [axis]: Number(e.target.value) })}
+    />
+  );
+
+  return (
+    <div className="zoom-control" title="Ctrl/Cmd + scroll over the board zooms both">
+      <div className="zoom-sliders">
+        {slider("x", "Column width")}
+        {slider("y", "Row height")}
+      </div>
+      <button
+        type="button"
+        className="zoom-reset"
+        onClick={() => onChange({ x: 1, y: 1 })}
+        disabled={at100}
+        title="Back to 100%"
+      >
+        {Math.round(((zoom.x + zoom.y) / 2) * 100)}%
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/ZoomControl.tsx
+++ b/web/src/components/ZoomControl.tsx
@@ -5,19 +5,16 @@ interface ZoomControlProps {
   onChange: (z: Zoom) => void;
 }
 
-/** ZoomControl is the board's scale, as two thin sliders stacked around a
- *  reading of the current size: the top one widens the columns, the bottom one
- *  heightens the rows, and the button between puts both back to 100%. The same
- *  scale answers Ctrl/Cmd + wheel over the board, which moves both at once. */
+/** ZoomControl is the board's scale: one line with a handle on either side of
+ *  it — above for column width, below for row height — each pointing at the
+ *  line it rides. The reading beside them puts both back to 100%. Ctrl/Cmd +
+ *  wheel over the board moves both at once, around the cursor. */
 export function ZoomControl({ zoom, onChange }: ZoomControlProps) {
   const at100 = Math.abs(zoom.x - 1) < 0.005 && Math.abs(zoom.y - 1) < 0.005;
-  const slider = (
-    axis: "x" | "y",
-    label: string,
-  ) => (
+  const slider = (axis: "x" | "y", label: string) => (
     <input
       type="range"
-      className="zoom-slider"
+      className={`zoom-slider zoom-slider-${axis}`}
       min={MIN_ZOOM}
       max={MAX_ZOOM}
       step={0.05}
@@ -29,8 +26,9 @@ export function ZoomControl({ zoom, onChange }: ZoomControlProps) {
   );
 
   return (
-    <div className="zoom-control" title="Ctrl/Cmd + scroll over the board zooms both">
-      <div className="zoom-sliders">
+    <div className="zoom-control" title="Ctrl/Cmd + scroll over the board zooms around the cursor">
+      <div className="zoom-track">
+        <div className="zoom-line" />
         {slider("x", "Column width")}
         {slider("y", "Row height")}
       </div>

--- a/web/src/projectZoom.test.ts
+++ b/web/src/projectZoom.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ZOOM,
+  MIN_ZOOM,
+  SNAP,
+  clampZoom,
+  columnFactor,
+  wheelZoom,
+} from "./projectZoom";
+
+describe("clampZoom", () => {
+  it("keeps a plain value", () => expect(clampZoom(1.4)).toBeCloseTo(1.4));
+  it("stops at the ends", () => {
+    expect(clampZoom(99)).toBe(MAX_ZOOM);
+    expect(clampZoom(0.01)).toBe(MIN_ZOOM);
+  });
+});
+
+describe("wheelZoom", () => {
+  // Ctrl/Cmd+wheel moves BOTH axes by the same step from where they are, so
+  // the two sliders keep their relative offset instead of collapsing together.
+  it("moves both axes by the same step", () => {
+    const z = wheelZoom({ x: 1, y: 1.5 }, -100);
+    expect(z.x - 1).toBeCloseTo(z.y - 1.5, 5);
+  });
+  it("scrolling up zooms in, down zooms out", () => {
+    expect(wheelZoom({ x: 1, y: 1 }, -100).x).toBeGreaterThan(1);
+    expect(wheelZoom({ x: 1, y: 1 }, 100).x).toBeLessThan(1);
+  });
+  it("an axis already at the end does not drag the other past its own", () => {
+    const z = wheelZoom({ x: MAX_ZOOM, y: 1 }, -100);
+    expect(z.x).toBe(MAX_ZOOM);
+    expect(z.y).toBeGreaterThan(1);
+  });
+});
+
+describe("columnFactor", () => {
+  // A dragged column remembers its size RELATIVE to the others, so zooming
+  // keeps the relation and switching projects keeps the column.
+  it("is the dragged width over the shared width", () => {
+    expect(columnFactor(280, 140)).toBeCloseTo(2);
+  });
+  it("snaps back to the default near the others' width", () => {
+    expect(columnFactor(144, 140)).toBeNull();
+    expect(columnFactor(140 * (1 + SNAP / 2), 140)).toBeNull();
+  });
+  it("keeps a width that is clearly its own", () => {
+    expect(columnFactor(140 * 1.5, 140)).toBeCloseTo(1.5);
+  });
+  it("never returns a factor below the floor", () => {
+    const f = columnFactor(10, 140);
+    expect(f).not.toBeNull();
+    expect(140 * (f as number)).toBeGreaterThanOrEqual(60);
+  });
+});

--- a/web/src/projectZoom.test.ts
+++ b/web/src/projectZoom.test.ts
@@ -6,6 +6,7 @@ import {
   clampZoom,
   columnFactor,
   wheelZoom,
+  anchoredScroll,
 } from "./projectZoom";
 
 describe("clampZoom", () => {
@@ -51,5 +52,36 @@ describe("columnFactor", () => {
     const f = columnFactor(10, 140);
     expect(f).not.toBeNull();
     expect(140 * (f as number)).toBeGreaterThanOrEqual(60);
+  });
+});
+
+// Zooming around the cursor: the point of the board under the pointer must
+// still be under it afterwards, or the board slides out from under the hand.
+// Only the cells scale — the date column on the left and the header row on
+// top keep their size — so the fixed part is subtracted before scaling and
+// added back after.
+describe("anchoredScroll", () => {
+  it("keeps the point under the cursor still", () => {
+    // 200px into the content, gutter 54, scaled 2x: that point moves to
+    // 54 + (200-54)*2 = 346, so the scroll must grow by the same 146.
+    expect(anchoredScroll(0, 200, 54, 2)).toBeCloseTo(146);
+  });
+
+  it("does not move when the zoom does not change", () => {
+    expect(anchoredScroll(120, 300, 54, 1)).toBeCloseTo(120);
+  });
+
+  it("leaves a cursor over the gutter alone", () => {
+    expect(anchoredScroll(0, 30, 54, 2)).toBe(0);
+  });
+
+  it("never scrolls to a negative offset", () => {
+    expect(anchoredScroll(0, 60, 54, 0.5)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("works from a board already scrolled", () => {
+    // content point = 500 + 100 = 600; scaled: 54 + (600-54)*1.5 = 873;
+    // the cursor stays 100 from the edge, so the scroll is 773.
+    expect(anchoredScroll(500, 100, 54, 1.5)).toBeCloseTo(773);
   });
 });

--- a/web/src/projectZoom.ts
+++ b/web/src/projectZoom.ts
@@ -1,0 +1,47 @@
+/** The Project board's zoom: how much bigger its cells are drawn than the
+ *  board's own idea of a cell. Text is never scaled — only the room around it,
+ *  so a dense quarter can be spread out to be read and squeezed back to be
+ *  seen whole. */
+export interface Zoom {
+  /** Column width multiplier. */
+  x: number;
+  /** Row height multiplier. */
+  y: number;
+}
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 3;
+/** How close to the shared width a dragged column must come before it gives
+ *  up its own width and rejoins the others. */
+export const SNAP = 0.08;
+/** The narrowest a column may be dragged, in pixels. */
+export const MIN_COL_PX = 60;
+/** One wheel notch, as a share of the current scale. */
+const WHEEL_STEP = 0.0015;
+
+export function clampZoom(v: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, v));
+}
+
+/** wheelZoom moves BOTH axes by the same step from where they are — the two
+ *  sliders keep whatever offset they have instead of snapping together. An
+ *  axis that has hit its end simply stops there; it does not hold the other
+ *  back, or a board zoomed wide could never be made taller. */
+export function wheelZoom(z: Zoom, deltaY: number): Zoom {
+  const step = -deltaY * WHEEL_STEP;
+  return { x: clampZoom(z.x + step), y: clampZoom(z.y + step) };
+}
+
+/** columnFactor turns a dragged width into what the column remembers: its size
+ *  relative to the width the other columns share. null means "no width of its
+ *  own" — either it was dragged back to within SNAP of the others, or it never
+ *  left. Kept as a RATIO, not pixels, so zooming keeps the relation and a
+ *  column carries its size from one project selection to the next. */
+export function columnFactor(widthPx: number, sharedPx: number): number | null {
+  if (sharedPx <= 0) {
+    return null;
+  }
+  const floor = MIN_COL_PX / sharedPx;
+  const factor = Math.max(floor, widthPx / sharedPx);
+  return Math.abs(factor - 1) < SNAP ? null : factor;
+}

--- a/web/src/projectZoom.ts
+++ b/web/src/projectZoom.ts
@@ -45,3 +45,30 @@ export function columnFactor(widthPx: number, sharedPx: number): number | null {
   const factor = Math.max(floor, widthPx / sharedPx);
   return Math.abs(factor - 1) < SNAP ? null : factor;
 }
+
+/** anchoredScroll keeps the point under the cursor where it is while the board
+ *  scales around it.
+ *
+ *  Only the cells scale: the date column on the left and the header row on top
+ *  keep their size whatever the zoom, so `fixed` is subtracted before scaling
+ *  and added back after. A cursor over that fixed part has nothing to anchor —
+ *  the scroll stays put.
+ *
+ *  @param scroll  the scroller's current offset
+ *  @param cursor  the cursor's distance from the scroller's own edge
+ *  @param fixed   the gutter that does not scale (54px column, 26px header)
+ *  @param k       the scale change — new zoom over old
+ */
+export function anchoredScroll(
+  scroll: number,
+  cursor: number,
+  fixed: number,
+  k: number,
+): number {
+  const point = scroll + cursor;
+  if (point <= fixed) {
+    return scroll;
+  }
+  const scaled = fixed + (point - fixed) * k;
+  return Math.max(0, scaled - cursor);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4258,50 +4258,106 @@ button.card-age {
 /* ---- Project board zoom ------------------------------------------------ */
 
 /* The scale sits at the right end of the board's toolbar, beside the project
-   chips: two thin sliders and the reading between them. */
+   chips: one line, with a handle on either side of it. */
 .zoom-control {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   margin-left: auto;
 }
 
-.zoom-sliders {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+/* Both sliders ride the SAME line: the track is drawn once, here, and each
+   input contributes only its handle. */
+.zoom-track {
+  position: relative;
+  width: 92px;
+  height: 22px;
+}
+
+.zoom-line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  margin-top: -1px;
+  border-radius: 1px;
+  background: var(--line);
 }
 
 .zoom-slider {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 11px;
+  margin: 0;
+  padding: 0;
   -webkit-appearance: none;
   appearance: none;
-  width: 86px;
-  height: 3px;
-  border-radius: 2px;
-  background: var(--line);
+  background: none;
   cursor: ew-resize;
 }
 
+/* Column width above the line, row height below it. */
+.zoom-slider-x {
+  top: 0;
+}
+
+.zoom-slider-y {
+  bottom: 0;
+}
+
+.zoom-slider::-webkit-slider-runnable-track,
+.zoom-slider::-moz-range-track {
+  height: 11px;
+  background: none;
+  border: 0;
+}
+
+/* A pentagon with its point at the line it belongs to: the top handle points
+   down, the bottom one up, so which slider is which is read from the shape
+   rather than from a label. */
 .zoom-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--ink-3, var(--muted));
+  width: 11px;
+  height: 11px;
+  background: var(--muted);
+  border: 0;
   cursor: ew-resize;
 }
 
 .zoom-slider::-moz-range-thumb {
-  width: 9px;
-  height: 9px;
+  width: 11px;
+  height: 11px;
+  background: var(--muted);
   border: 0;
-  border-radius: 50%;
-  background: var(--ink-3, var(--muted));
   cursor: ew-resize;
 }
 
-.zoom-slider:hover::-webkit-slider-thumb {
+.zoom-slider-x::-webkit-slider-thumb {
+  clip-path: polygon(0 0, 100% 0, 100% 55%, 50% 100%, 0 55%);
+}
+
+.zoom-slider-x::-moz-range-thumb {
+  clip-path: polygon(0 0, 100% 0, 100% 55%, 50% 100%, 0 55%);
+}
+
+.zoom-slider-y::-webkit-slider-thumb {
+  clip-path: polygon(50% 0, 100% 45%, 100% 100%, 0 100%, 0 45%);
+}
+
+.zoom-slider-y::-moz-range-thumb {
+  clip-path: polygon(50% 0, 100% 45%, 100% 100%, 0 100%, 0 45%);
+}
+
+.zoom-slider:hover::-webkit-slider-thumb,
+.zoom-slider:focus-visible::-webkit-slider-thumb {
+  background: var(--accent);
+}
+
+.zoom-slider:hover::-moz-range-thumb,
+.zoom-slider:focus-visible::-moz-range-thumb {
   background: var(--accent);
 }
 
@@ -4337,7 +4393,6 @@ button.card-age {
 
 .project-cols-reset {
   padding: 0 3px;
-  font-size: 10px;
   line-height: 1;
   color: var(--ink-3, var(--muted));
   background: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4254,3 +4254,100 @@ button.card-age {
 .sprint-choice-btn-danger:hover {
   border-color: var(--danger);
 }
+
+/* ---- Project board zoom ------------------------------------------------ */
+
+/* The scale sits at the right end of the board's toolbar, beside the project
+   chips: two thin sliders and the reading between them. */
+.zoom-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.zoom-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.zoom-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 86px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--line);
+  cursor: ew-resize;
+}
+
+.zoom-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ink-3, var(--muted));
+  cursor: ew-resize;
+}
+
+.zoom-slider::-moz-range-thumb {
+  width: 9px;
+  height: 9px;
+  border: 0;
+  border-radius: 50%;
+  background: var(--ink-3, var(--muted));
+  cursor: ew-resize;
+}
+
+.zoom-slider:hover::-webkit-slider-thumb {
+  background: var(--accent);
+}
+
+.zoom-reset {
+  min-width: 40px;
+  padding: 2px 4px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.zoom-reset:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: var(--line);
+}
+
+.zoom-reset:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+/* The corner above the date column: a quiet way to give every column on the
+   board the same width back. Only there when something has a width of its own. */
+.project-corner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-cols-reset {
+  padding: 0 3px;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--ink-3, var(--muted));
+  background: none;
+  border: 0;
+  border-radius: 3px;
+  cursor: pointer;
+  opacity: 0.45;
+}
+
+.project-cols-reset:hover {
+  opacity: 1;
+  color: var(--accent);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4406,3 +4406,11 @@ button.card-age {
   opacity: 1;
   color: var(--accent);
 }
+
+/* A card hovered near its right edge steps aside, uncovering the strip of
+   cell a new card is pulled out from. Small and quick: it is an invitation,
+   not an animation. */
+.project-slot-nudged {
+  margin-right: 13px;
+  transition: margin-right 90ms ease-out;
+}


### PR DESCRIPTION
Four changes to the Project board, all driven end to end in a browser against a live board.

## Zoom

Ctrl/Cmd + wheel scales the board on both axes, **around the pointer** — the point under the cursor stays under it. Only the cells scale, so the fixed date column and header row are held out of the arithmetic, and the scroll is applied after the grid has been re-laid (set against the old size it would be clamped to it, which is the usual way this drifts).

Beside the project chips there is now one line with a handle on either side of it: column width above pointing down, row height below pointing up — each a pentagon aimed at the line it rides, so which slider is which is read from the shape. The reading between them puts both back to 100%. The wheel moves both axes by the same step from wherever they are, so the two handles keep their offset instead of collapsing together.

Text is never scaled — only the room around it. That is the point: a dense quarter can be spread out to be read, or squeezed to be seen whole.

## A width per column, not per selection

Dragging an edge used to set the width of **every** column at once, keyed by which project chips were showing — so a width was lost the moment the selection changed. It now sizes that column alone and remembers the size as a **ratio** to the width the others share: the ratio survives a zoom, and it is keyed by the column itself, so it carries from one selection to the next. Dragged back to within a hair of the others the column gives the ratio up and rejoins them.

A quiet button in the corner above the dates gives every column **on this board** the shared width back; columns not currently shown keep theirs.

## Room for the next card

A card that fills its column left nowhere to press: the surface that pulls a new card out is the cell underneath. Resting the pointer at a card's right edge for half a second steps it aside thirteen pixels, uncovering exactly enough cell to press and pull. Three traps, all found in use and fixed:

- it must not move on the way past — hence the delay;
- stepping aside puts the pointer in the gap, which the browser reports as leaving the card: undoing it there closes the gap under the pointer, which reopens it — a flicker with no way out;
- a drag started in the strip travels far from the card by design, and every cell it crossed was closing the gap behind it, so a drag in progress holds it open;
- and a card sharing its column carries an **explicit** width, which a margin cannot shrink — the step has to come out of the width itself, or it does nothing exactly where it is needed most.

## Testing

`web/src/projectZoom.test.ts` — 14 cases over the pure logic: clamping, the wheel's equal step and its behaviour at the ends, the width ratio and its snap, and the cursor anchor (including a pointer over the fixed gutter and an already-scrolled board). Verified in headless Chrome: the wheel scales both axes with the font untouched; the sliders move independently; widening one column leaves its neighbours alone and the ratio survives a zoom and a change of chips; releasing near the shared width snaps it back; the step aside waits, holds through a drag that creates a card, and works in a shared column.

## Note

Old per-selection widths are not migrated: the model changed from “one width per set of chips” to “a ratio per column”, and there is no faithful translation. Columns start out equal.