### PR TITLE
fix(project): a card's own controls are not the strip, and a menu closes on any press

### DIFF
--- a/web/src/components/Dropdown.tsx
+++ b/web/src/components/Dropdown.tsx
@@ -79,6 +79,11 @@ export function Dropdown({ open, anchorRef, onClose, className, children }: Drop
     // preventDefault() on the pointer event, and that suppresses the
     // compatibility mouse events entirely — so a menu opened over the board
     // would never hear the press that was meant to dismiss it.
+    //
+    // And in the CAPTURE phase, because the same drag handlers call
+    // stopPropagation(): a press on a board cell never reached a listener
+    // waiting on the document, so clicking away from an open menu left it
+    // open. Capture runs on the way DOWN, where nothing can stop it.
     const onDown = (e: PointerEvent) => {
       const t = e.target as Node;
       if (menuRef.current?.contains(t) || anchorRef.current?.contains(t)) {
@@ -88,11 +93,11 @@ export function Dropdown({ open, anchorRef, onClose, className, children }: Drop
     };
     window.addEventListener("scroll", reposition, true);
     window.addEventListener("resize", reposition);
-    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("pointerdown", onDown, true);
     return () => {
       window.removeEventListener("scroll", reposition, true);
       window.removeEventListener("resize", reposition);
-      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("pointerdown", onDown, true);
     };
   }, [open, place, onClose, anchorRef]);
 

--- a/web/src/components/ProjectBoard.tsx
+++ b/web/src/components/ProjectBoard.tsx
@@ -1743,6 +1743,19 @@ export function ProjectBoard({
                 if (move || drag) {
                   return;
                 }
+                // The card's own controls live at that same right edge — the
+                // team badge, the delete button. Stepping aside under a
+                // pointer that came to press one of them shrinks the card out
+                // from under the click.
+                if (
+                  (ev.target as HTMLElement).closest(
+                    "button, .project-slot-team, .project-slot-actions",
+                  )
+                ) {
+                  cancelNudgeTimer();
+                  setNudged((cur) => (cur === card.itemId ? null : cur));
+                  return;
+                }
                 const r = (ev.currentTarget as HTMLElement).getBoundingClientRect();
                 const inStrip = ev.clientX > r.right - NUDGE_PX * 2;
                 if (!inStrip) {


### PR DESCRIPTION
Two regressions from the step-aside, both reported from use.

## Reaching for the avatar shrank the card

The team badge and the delete button sit at the card's right edge — the same edge that opens the strip for the next card. Moving the pointer onto the avatar armed the nudge, and the card shrank away from under the click. A pointer over the card's own controls no longer arms it, and cancels a nudge already pending.

## An open menu would not close when you pressed the board

The dismissal listened for `pointerdown` on the document. The board's own drag handlers call `stopPropagation()`, so a press on a cell never reached it and the menu stayed open — exactly where "click somewhere else" is the natural way to dismiss it. The listener now runs in the **capture** phase, on the way down, where nothing can stop it. Presses inside the menu or on its anchor are still ignored, as before.

## Testing

Driven in headless Chrome: hovering the team badge for 900ms leaves the card its size; opening the team menu and then pressing a board cell closes it.