### PR TITLE
fix(config): the OAuth-mode credential check counts the domains, not the default

### DIFF
--- a/cmd/aeman/forge.go
+++ b/cmd/aeman/forge.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aenix-io/aeman/internal/forge"
 	"github.com/aenix-io/aeman/internal/ghcli"
 	"github.com/aenix-io/aeman/internal/glabcli"
+	"github.com/aenix-io/aeman/internal/server"
 )
 
 // cliFor is the forge's command-line tool — gh for GitHub, glab for GitLab
@@ -85,6 +86,21 @@ func oauthPair(f forge.Forge, env func(string) string) (id, secret string, err e
 		return env("AEMAN_GITLAB_CLIENT_ID"), env("AEMAN_GITLAB_CLIENT_SECRET"), nil
 	}
 	return "", "", nil
+}
+
+// missingTokens names the board's repositories that have no credential —
+// each with the variable that would give it one. In the OAuth mode the
+// server needs one per repository: it pushes them and asks the forge who
+// may read them with its own. Empty when every repository is covered,
+// whether by its own token or by the shared one.
+func missingTokens(cfg *server.GitConfig) []string {
+	var out []string
+	for _, r := range cfg.Repos {
+		if r.Token == "" {
+			out = append(out, r.Name+" ("+tokenEnvFor(r.Name)+")")
+		}
+	}
+	return out
 }
 
 // osEnv is os.Getenv with the surrounding whitespace dropped.

--- a/cmd/aeman/forge_test.go
+++ b/cmd/aeman/forge_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aenix-io/aeman/internal/forge"
+	"github.com/aenix-io/aeman/internal/server"
 )
 
 // The board's forge is read off the primary repository's host, and the flag
@@ -89,6 +90,31 @@ func TestResolveForgeTokenPrefersTheEnvironmentThenTheCLI(t *testing.T) {
 	broken := &fakeCLI{err: errors.New("glab: not logged in")}
 	if _, err := resolveForgeToken(ctx, gl, broken, env(nil)); !errors.Is(err, broken.err) {
 		t.Fatalf("cli error must surface: %v", err)
+	}
+}
+
+// In the OAuth mode the server needs a credential for EVERY repository of
+// the board — it pushes them and asks the forge who may read them with its
+// own — but a board whose domains each carry their own needs no shared one.
+// The error names the domains that lack one and the variables that would
+// give them one.
+func TestMissingTokensNamesTheDomainsWithoutACredential(t *testing.T) {
+	all := &server.GitConfig{Repos: []server.RepoSpec{
+		{Name: "aeman-db", Token: "a"}, {Name: "founders", Token: "b"},
+	}}
+	if got := missingTokens(all); len(got) != 0 {
+		t.Fatalf("every domain has a token; missing = %v", got)
+	}
+	some := &server.GitConfig{Repos: []server.RepoSpec{
+		{Name: "aeman-db", Token: "a"}, {Name: "founders"}, {Name: "odd.name"},
+	}}
+	got := missingTokens(some)
+	if len(got) != 2 || got[0] != "founders (AEMAN_GIT_TOKEN_FOUNDERS)" || got[1] != "odd.name (AEMAN_GIT_TOKEN_ODD_NAME)" {
+		t.Fatalf("missing = %v; want the two domains with the variables that would fill them", got)
+	}
+	none := &server.GitConfig{Repos: []server.RepoSpec{{Name: "aeman-db"}}}
+	if got := missingTokens(none); len(got) != 1 {
+		t.Fatalf("missing = %v", got)
 	}
 }
 

--- a/cmd/aeman/main.go
+++ b/cmd/aeman/main.go
@@ -139,8 +139,9 @@ func runServe(args []string) error {
 		if baseURL == "" {
 			return fmt.Errorf("AEMAN_BASE_URL is required when %s OAuth is configured", gitCfg.Forge.Label())
 		}
-		if gitCfg.Token == "" {
-			return fmt.Errorf("AEMAN_GIT_TOKEN is required in OAuth mode: the server pushes the board's repositories and asks %s who may read them with its own credential", gitCfg.Forge.Label())
+		if missing := missingTokens(gitCfg); len(missing) > 0 {
+			return fmt.Errorf("no credential for %s: in the OAuth mode the server pushes every repository of the board and asks %s who may read it with its own token — set AEMAN_GIT_TOKEN, or a token per repository",
+				strings.Join(missing, ", "), gitCfg.Forge.Label())
 		}
 		auth = &server.OAuthConfig{
 			ClientID:     id,


### PR DESCRIPTION
The check asked whether `AEMAN_GIT_TOKEN` was set — which per-repository credentials (#129) made legitimately empty. A board whose every domain carries its own token refused to start in the OAuth mode ("AEMAN_GIT_TOKEN is required"), which is exactly the configuration #129 was for. Caught on the first deploy of a two-organisation board.

It now asks whether every repository has a credential — its own or the shared one — and the error names the domains that do not, each with the variable that would fill it. Test: `TestMissingTokensNamesTheDomainsWithoutACredential`.

`make lint`, `go test ./...` — green.