### PR TITLE
fix(web): a view switch keeps the logs it already fetched

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { clientId, fetchConfig, fetchHealth, type AppConfig } from "./api/client";
 import { apiProvider } from "./providers/api/apiProvider";
 import { guardSignedOut } from "./session";
+import { mergeCardLists } from "./cardmerge";
 import {
   resourceToCard,
   sprintStateFrom,
@@ -85,19 +86,6 @@ function readFilter(): string[] | null {
 
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
-
-// mergeCardLists flattens a view's lists (e.g. the Team grid + its weekly
-// plan), deduping by item id; board order within each list is preserved.
-function mergeCardLists(lists: CardModel[][]): CardModel[] {
-  const seen = new Set<string>();
-  return lists.flat().filter((c) => {
-    if (seen.has(c.itemId)) {
-      return false;
-    }
-    seen.add(c.itemId);
-    return true;
-  });
-}
 
 export function App() {
   const [config, setConfig] = useState<AppConfig | null>(null);
@@ -608,7 +596,11 @@ export function App() {
         // Board watch frame keeps it current afterwards.
         provider.listProcesses().catch(() => [] as ProcessInfo[]),
       ]);
-      setBoard({ ...loaded, cards: mergeCardLists(lists), processes });
+      setBoard((cur) => ({
+        ...loaded,
+        cards: mergeCardLists(lists, cur?.cards),
+        processes,
+      }));
     } catch (err: unknown) {
       setError(errMessage(err));
     } finally {
@@ -632,7 +624,12 @@ export function App() {
         if (cancelled) {
           return;
         }
-        setBoard((cur) => (cur ? { ...cur, cards: mergeCardLists(lists) } : cur));
+        // The listing is the row view; the notes, events and bodies already
+        // fetched are kept, so switching views costs one request, not one
+        // per card all over again.
+        setBoard((cur) =>
+          cur ? { ...cur, cards: mergeCardLists(lists, cur.cards) } : cur,
+        );
       })
       .catch((err: unknown) => {
         if (!cancelled) {

--- a/web/src/cardmerge.test.ts
+++ b/web/src/cardmerge.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeCardLists } from "./cardmerge";
+import type { Card } from "./providers/types";
+
+const card = (itemId: string, extra: Partial<Card> = {}): Card => ({
+  itemId,
+  title: itemId,
+  assignees: [],
+  ...extra,
+});
+
+describe("mergeCardLists", () => {
+  it("flattens the lists in order, deduping by item id", () => {
+    const got = mergeCardLists([[card("a"), card("b")], [card("b"), card("c")]]);
+    expect(got.map((c) => c.itemId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("is empty for no lists", () => {
+    expect(mergeCardLists([])).toEqual([]);
+    expect(mergeCardLists([[], []])).toEqual([]);
+  });
+
+  // A listing is the board's row view: it carries no notes, no events and no
+  // description. Replacing the board's cards with it threw away what had
+  // already been fetched, so every view switch re-fetched a log per card —
+  // a request each, seconds of git work — and the board settled visibly late.
+  // What the fresh row does not carry, the card keeps.
+  it("keeps the loaded notes, events and body of a card the listing brings back", () => {
+    const loaded = card("a", {
+      notes: [{ id: "n1", body: "note", createdAt: "2026-08-28T09:00:00Z", source: "comment" }],
+      events: [{ id: "e1", kind: "progress", at: "2026-08-28T09:00:00Z" }],
+      description: "the body",
+      progress: 40,
+    });
+    const [fresh] = mergeCardLists([[card("a", { progress: 70 })]], [loaded]);
+    expect(fresh.progress).toBe(70); // the listing is the truth about the row
+    expect(fresh.notes).toEqual(loaded.notes);
+    expect(fresh.events).toEqual(loaded.events);
+    expect(fresh.description).toBe("the body");
+  });
+
+  it("does not invent them for a card that was never loaded", () => {
+    const [fresh] = mergeCardLists([[card("new")]], [card("other", { notes: [] })]);
+    expect(fresh.notes).toBeUndefined();
+    expect(fresh.events).toBeUndefined();
+    expect(fresh.description).toBeUndefined();
+  });
+
+  // A listing that DOES carry a body (a full fetch, a card echoed by a
+  // mutation) is the fresher answer and wins.
+  it("takes the listing's own body when it has one", () => {
+    const [fresh] = mergeCardLists(
+      [[card("a", { description: "new body" })]],
+      [card("a", { description: "old body" })],
+    );
+    expect(fresh.description).toBe("new body");
+  });
+
+  it("works without a previous board", () => {
+    expect(mergeCardLists([[card("a")]]).map((c) => c.itemId)).toEqual(["a"]);
+  });
+});

--- a/web/src/cardmerge.ts
+++ b/web/src/cardmerge.ts
@@ -1,0 +1,50 @@
+// Merging a view's fresh listings into the board's cards.
+//
+// A listing is the board's ROW view: title, team, zone, dates, progress — no
+// notes, no events, no description. Those arrive from the card's own
+// subresources and are expensive on a git board (a log walks history). So a
+// fresh listing is the truth about the row and nothing more: what it does not
+// carry, the card keeps.
+
+import type { Card } from "./providers/types";
+
+/** mergeCardLists flattens a view's lists (e.g. the Team grid + its weekly
+ *  plan), deduping by item id; board order within each list is preserved.
+ *  `loaded` is the board's current cards, if any: a card coming back in the
+ *  listing keeps the notes, events and body already fetched for it, so
+ *  switching views does not throw away — and then re-fetch — a log per card. */
+export function mergeCardLists(
+  lists: Card[][],
+  loaded: readonly Card[] = [],
+): Card[] {
+  const known = new Map(loaded.map((c) => [c.itemId, c]));
+  const seen = new Set<string>();
+  const out: Card[] = [];
+  for (const fresh of lists.flat()) {
+    if (seen.has(fresh.itemId)) {
+      continue;
+    }
+    seen.add(fresh.itemId);
+    out.push(withLoaded(fresh, known.get(fresh.itemId)));
+  }
+  return out;
+}
+
+/** withLoaded fills the fields a listing never carries from the card the
+ *  board already had. The listing wins wherever it says anything at all. */
+function withLoaded(fresh: Card, prev: Card | undefined): Card {
+  if (!prev) {
+    return fresh;
+  }
+  const merged = { ...fresh };
+  if (merged.notes === undefined) {
+    merged.notes = prev.notes;
+  }
+  if (merged.events === undefined) {
+    merged.events = prev.events;
+  }
+  if (merged.description === undefined) {
+    merged.description = prev.description;
+  }
+  return merged;
+}


### PR DESCRIPTION
Reported live after the migration: switching between Me and Team went from instant to a spinner and a board that visibly settles afterwards.

Measured on prod: one view switch fires the listing **plus ~20 parallel `GET /api/v1/cards/{uid}/log`**, each about a second of git history walking; the plain listing then queues behind that storm and takes 1.4-1.8s itself. The same card ids are fetched again on every switch.

Why: the view-load effect replaced the board's cards with the fresh listing, and a listing is the board's **row** view — no notes, no events, no description. Everything already fetched was dropped, so the notes machinery saw `notes === undefined` again and re-fetched a log per card. On the Projects v2 backend this was cheap (the events were part of the item payload); on a git board each log walks history.

Now a card the listing brings back keeps the notes, events and body the board already had — the listing stays the truth about the row itself. The first visit to a view pays for its logs; every later switch costs one request.

The merge is a pure function with its own tests (`web/src/cardmerge.ts`, 6 cases: order and dedup, keeping what the row lacks, not inventing it for cards never loaded, a full listing's own body winning, no previous board).

`npm run typecheck`, `npm test` (194), `npm run build` — green.