### PR TITLE
fix(plan): the × on column cards, a debt that can be dragged, and the week grouping kept taking

### DIFF
--- a/pkg/boardservice/mirrors_test.go
+++ b/pkg/boardservice/mirrors_test.go
@@ -463,6 +463,42 @@ func TestThePlanRemoveWritesNothingForAColumnCardWithNoBand(t *testing.T) {
 	}
 }
 
+// Grouping takes a card's BAND — the parent takes its place in the plan —
+// but not the WEEK of a card that stands in a COLUMN: there the week is the
+// row the Project board draws it in, and clearing it took the card's stripe
+// away and left its row to be re-derived from dates the client is not shown.
+func TestGroupingKeepsTheWeekOfACardInAColumn(t *testing.T) {
+	f := mirrorBoard([]board.Card{
+		{ItemID: "p", Title: "parent", Team: "platform"},
+		{ItemID: "slot", Title: "a card in a column", Team: "platform",
+			Project: "engineering", Epic: "Cozystack", Plan: board.PlanFri,
+			Week: "2026-08-31", StartDate: "2026-08-31", Day: "2026-09-04"},
+		{ItemID: "plain", Title: "a plan card", Team: "platform",
+			Plan: board.PlanFri, Week: "2026-08-31"},
+	})
+	svc := New(f)
+	if err := svc.SetParent(ctx, "acme", "slot", "p"); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := f.LoadBoard(ctx, "acme")
+	c, _ := findCard(b, "slot")
+	if c.Plan != board.PlanNone {
+		t.Fatalf("the band goes to the parent: %+v", c)
+	}
+	if c.Week != "2026-08-31" {
+		t.Fatalf("the week stays — it is the row the card is drawn in: %+v", c)
+	}
+	// A card with no column has no row of its own: both go.
+	if err := svc.SetParent(ctx, "acme", "plain", "p"); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = f.LoadBoard(ctx, "acme")
+	c, _ = findCard(b, "plain")
+	if c.Plan != board.PlanNone || c.Week != "" {
+		t.Fatalf("a plan card hands over both: %+v", c)
+	}
+}
+
 // Renames follow the mirrors. The rename loops match cards through InEpic,
 // which now sees mirrors — rewriting the card's HOME fields for a mirror
 // match would corrupt it, and not rewriting the mirror would strand it

--- a/pkg/boardservice/subtasks.go
+++ b/pkg/boardservice/subtasks.go
@@ -97,8 +97,16 @@ func (s *Service) setParentOf(ctx context.Context, b board.Board, card board.Car
 		if err := s.backend.SetPlan(ctx, b, card, board.PlanNone); err != nil {
 			return err
 		}
-		if err := s.backend.SetWeek(ctx, b, card, ""); err != nil {
-			return err
+		// The BAND goes; the WEEK stays for a card that stands in a COLUMN.
+		// There the week is the row the Project board draws it in — its span
+		// speaks for it, not stored plan membership — and clearing it took
+		// the card's stripe away and left the row to be re-derived from
+		// dates the client cannot see. The plan's × makes the same
+		// distinction (a slot keeps its week).
+		if !hasColumn(card) {
+			if err := s.backend.SetWeek(ctx, b, card, ""); err != nil {
+				return err
+			}
 		}
 	}
 	// A subtask keeps the ONE column it carries — G14 blesses that, and the

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -513,6 +513,17 @@ export function TeamBoard({
 
   // Move a plan card between the two bands (changes its Wed/Fri deadline).
   const handleSetPlan = (card: CardModel, plan: "wed" | "fri") => {
+    // A DEBT dropped into a band of the CURRENT week is a person saying
+    // "take this into this week, due then". Its own band belongs to the
+    // week it missed, and the panel draws it by the debt rule (always the
+    // by-Wednesday band) whatever that band says — so writing the band
+    // alone moved nothing anyone could see, and an overdue card could not
+    // be dragged anywhere at all. It comes into the week first, by its
+    // dates when it is a slot (whose week IS its start), then takes the
+    // band.
+    if (owedIn(card) !== "" && owedIn(card) < currentWeek) {
+      handleSetWeek(card, currentWeek);
+    }
     const prev: Partial<CardModel> = { plan: card.plan, parent: card.parent, week: card.week };
     // A band on a SUBTASK takes it out of the group (G58): the server pulls
     // it out and plans it in the current week, so the row must stop being

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -1153,7 +1153,14 @@ export function TeamBoard({
       return;
     }
     const prev: Partial<CardModel> = { parent: card.parent, plan: card.plan, week: card.week };
-    patchCard(card.itemId, { parent: parentId, plan: undefined, week: undefined });
+    // The band goes to the parent; a COLUMN card keeps its week — that is
+    // the row the Project board draws it in, not plan membership (mirrors
+    // boardservice.SetParent).
+    patchCard(card.itemId, {
+      parent: parentId,
+      plan: undefined,
+      ...(card.epic ? {} : { week: undefined }),
+    });
     autoExpanded.current = null; // the drop keeps the target unfolded
     setExpandedSubs((cur) => new Set(cur).add(parentId));
     void provider

--- a/web/src/weekly.test.ts
+++ b/web/src/weekly.test.ts
@@ -63,8 +63,10 @@ describe("planRemoveOffered", () => {
 
   it("is offered where the band is the only thing holding the card", () => {
     expect(planRemoveOffered({ plan: "fri", week: "2026-08-03" })).toBe(true);
-    // An epic without both boundaries is not a slot: its band is stored.
-    expect(planRemoveOffered({ epic: "Cozystack", week: "2026-08-03", plan: "wed" })).toBe(true);
+    // A card in a COLUMN is not that card, whatever band it carries: the
+    // column is where it lives, and the plan has nothing of its own to
+    // take away from it.
+    expect(planRemoveOffered({ epic: "Cozystack", week: "2026-08-03", plan: "wed" })).toBe(false);
   });
 });
 
@@ -119,14 +121,18 @@ describe("who gets an × on the weekly panel", () => {
     // A leftover WEEK is a record of its own: grouping clears the band and
     // the week may outlive it, and clearing it is the whole gesture there.
     expect(planRemoveOffered({ week: "2026-08-24" })).toBe(true);
-    // …but a COLUMN card's week is the row it is drawn in, not plan
-    // membership: the server writes nothing for it, band or no band, so
-    // the × would do nothing. (A subtask keeps its column on grouping and
-    // its week can outlive the band, which is how this shape arises.)
+    // …but never a card in a COLUMN: that is where it lives, and the plan
+    // has nothing of its own to take away.
     expect(planRemoveOffered({ epic: "Cozystack", week: "2026-08-24" })).toBe(false);
   });
 
-  it("offers none to a slot, whose span is its plan", () => {
+  // A card filed under a project column is not the plan's to empty — band
+  // or no band, span or no span. The column is where it lives.
+  it("offers none to a card that stands in a column", () => {
     expect(planRemoveOffered({ epic: "E", week: "2026-08-24", day: "2026-08-28" })).toBe(false);
+    expect(
+      planRemoveOffered({ epic: "E", week: "2026-08-24", day: "2026-08-28", plan: "fri" }),
+    ).toBe(false);
+    expect(planRemoveOffered({ epic: "E", week: "2026-08-24", plan: "fri" })).toBe(false);
   });
 });

--- a/web/src/weekly.ts
+++ b/web/src/weekly.ts
@@ -28,15 +28,19 @@ export function isSlot(c: Banded): boolean {
  *  nothing to empty for them (it returns without a write), so an × there
  *  would be the inert one this rule exists to prevent. */
 export function planRemoveOffered(c: Banded): boolean {
-  if (isSlot(c)) {
+  // A card filed under a project COLUMN is not the plan's to empty. The
+  // column is where it lives and why the panel shows it at all — taking a
+  // band away would leave the card exactly where it is, and a card that
+  // has no plan membership to lose should not be offered a gesture that
+  // reads like losing one.
+  if (c.epic) {
     return false;
   }
-  // Mirrors what the server's plan × actually writes (Remove from="plan"):
-  // a BAND is always something to empty, and a bare WEEK only on a card
-  // outside every column — on a column card the week is the row it is
-  // drawn in, not plan membership, so there is nothing to take away and
-  // the × would be the inert one this rule exists to prevent.
-  return !!c.plan || (!c.epic && !!c.week);
+  // Everything else: a BAND is something to empty, and so is a bare WEEK
+  // (grouping can clear the band and leave the week behind). A card with
+  // neither — the nested subtask rows of an expanded parent — has nothing
+  // in the plan's records, and the server's × writes nothing for it.
+  return !!c.plan || !!c.week;
 }
 
 /** slotBand derives the weekly-plan band a band-less slot occupies on `week`'s


### PR DESCRIPTION
Three more from use, right after the last deploy.

**No × on a card that stands in a column.** The column is where the card lives and why the panel shows it — taking a band away leaves it exactly where it was. Band or no band, span or no span.

**An overdue card could not be dragged into a band.** The panel draws a debt in the by-Wednesday band whatever band it carries (its own belongs to the week it missed), so writing the band alone moved nothing anyone could see. A debt dropped into a band of the current week now comes into that week first — by its dates when it is a slot, whose week IS its start — and then takes the band.

**Grouping kept taking a slot's week.** The band goes to the parent, but a column card's week is the row the Project board draws it in, not plan membership: clearing it left the row to be re-derived from dates the client had not been shown, so the card lost its stripe until a full reload.