### PR TITLE
perf(store): read the board once per commit; the board stops waiting on the forge

### DIFF
--- a/internal/server/access.go
+++ b/internal/server/access.go
@@ -122,6 +122,12 @@ const membersTTL = 5 * time.Minute
 // membersRefreshTimeout bounds a member refresh running behind an answer.
 const membersRefreshTimeout = 30 * time.Second
 
+// askBackoff is how long a login the forge was asked about but did not
+// answer for is left alone. Short enough that a passing outage is over
+// before it matters, long enough that a lasting one is not re-asked on
+// every request.
+const askBackoff = time.Minute
+
 // forgeAccess asks the forge — a repository's permissions, in the forge's
 // own terms — with the visitor's token, one request per domain, and caches
 // the answer per visitor. A stale answer stands in while the forge is
@@ -144,6 +150,9 @@ type forgeAccess struct {
 	mu      sync.Mutex
 	cache   map[string]cachedRights // by login
 	members map[string]cachedBool   // by domain + login
+	// asked is when the forge was last asked about a login, answer or no
+	// answer: a question that came back empty must not look unasked.
+	asked map[string]time.Time // by domain + login
 	// refreshing single-flights the background check per visitor: the
 	// requests of one page load share the one it triggered.
 	refreshing map[string]bool
@@ -192,16 +201,43 @@ func (f *forgeAccess) readers(ctx context.Context, domain string, logins []strin
 	}
 	unknown, stale := f.splitMembers(domain, logins)
 	switch {
-	case unknown:
+	case unknown && f.coldDomain(domain):
+		// Nobody has ever asked about this repository: pay for the answer
+		// once, so the first board of a fresh process is the true list.
 		f.askMembers(ctx, domain, url, logins)
-	case stale:
+	case unknown || stale:
+		// Everything after that goes BEHIND the answer. Asking the forge
+		// who reads a repository is a listing plus one request per login
+		// the listing does not name, and this runs on every GET /board:
+		// waiting for it put five to nine seconds between a person and
+		// their board every time a login was new — which, on a board where
+		// people are assigning cards all morning, is most of the time. The
+		// list narrows a PICKER and decides nothing about what anyone may
+		// read (the visibility projection asks the visitor's own rights),
+		// so serving it a moment stale costs nothing.
 		f.refreshMembers(domain, url, logins)
 	}
 	return f.knownReaders(domain, logins), nil
 }
 
+// coldDomain reports that no login has an answer for this domain yet — the
+// first board after a start, where waiting once is right.
+func (f *forgeAccess) coldDomain(domain string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k := range f.members {
+		if strings.HasPrefix(k, domain+"\x00") {
+			return false
+		}
+	}
+	return true
+}
+
 // splitMembers reports whether any of the logins has no answer at all, and
-// whether any answer has aged past the TTL.
+// whether any answer has aged past the TTL. A login the forge was ASKED
+// about recently counts as neither: without that, a forge that answers for
+// nobody (an outage, a credential that cannot see the org) left every
+// login unknown and every request asking again.
 func (f *forgeAccess) splitMembers(domain string, logins []string) (unknown, stale bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -209,6 +245,9 @@ func (f *forgeAccess) splitMembers(domain string, logins []string) (unknown, sta
 		c, ok := f.members[domain+"\x00"+login]
 		switch {
 		case !ok:
+			if at, asked := f.asked[domain+"\x00"+login]; asked && f.now().Sub(at) < askBackoff {
+				continue
+			}
 			unknown = true
 		case f.now().Sub(c.at) >= membersTTL:
 			stale = true
@@ -221,6 +260,7 @@ func (f *forgeAccess) splitMembers(domain string, logins []string) (unknown, sta
 // An error leaves the answers that stand — an outage must not empty a
 // picker — and is logged, since the caller has an answer either way.
 func (f *forgeAccess) askMembers(ctx context.Context, domain, url string, logins []string) {
+	f.markAsked(domain, logins)
 	found, err := f.forge.Readers(ctx, f.client, f.tokenFor(ctx, domain), url, logins)
 	if err != nil {
 		f.log("domain members", domain, err)
@@ -234,6 +274,20 @@ func (f *forgeAccess) askMembers(ctx context.Context, domain, url string, logins
 	for _, login := range logins {
 		_, reads := found[login]
 		f.members[domain+"\x00"+login] = cachedBool{ok: reads, at: f.now()}
+	}
+}
+
+// markAsked records that the forge was asked about these logins, whatever
+// it answers: an attempt that comes back empty must not look like a
+// question nobody has asked yet.
+func (f *forgeAccess) markAsked(domain string, logins []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.asked == nil {
+		f.asked = map[string]time.Time{}
+	}
+	for _, login := range logins {
+		f.asked[domain+"\x00"+login] = f.now()
 	}
 }
 
@@ -270,7 +324,26 @@ func (f *forgeAccess) knownReaders(domain string, logins []string) []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, login := range logins {
-		if c, ok := f.members[domain+"\x00"+login]; ok && c.ok {
+		c, answered := f.members[domain+"\x00"+login]
+		if answered {
+			if c.ok {
+				out = append(out, login)
+			}
+			continue
+		}
+		// NOT YET ASKED is not "no". The forge is asked behind the answer
+		// now, so a login that appeared a moment ago — a card just
+		// assigned to somebody new — would otherwise drop out of the
+		// picker until the ask lands: the picker silently losing people it
+		// has never heard of, which is what the blocking ask was there to
+		// prevent. Offered until the forge says otherwise; what anyone may
+		// READ is decided elsewhere, by the visitor's own rights.
+		//
+		// ASKED and unanswered is different: the question was put and came
+		// back with nothing (no credential to ask with, an outage), and
+		// claiming the person can read on that basis would be inventing an
+		// answer.
+		if _, asked := f.asked[domain+"\x00"+login]; !asked {
 			out = append(out, login)
 		}
 	}

--- a/internal/server/boardwait_test.go
+++ b/internal/server/boardwait_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	forgepkg "github.com/aenix-io/aeman/internal/forge"
+)
+
+// GET /board must not wait on the forge. Asking who reads a repository is
+// a listing plus one request per login the listing does not name, and it
+// runs on every board load: with a login the answer did not cover — a card
+// assigned to somebody new, which is what a morning of planning produces —
+// the page waited for all of it. Measured on the real board: five to nine
+// seconds, again and again.
+func TestTheBoardDoesNotWaitOnTheForgeOnceItIsWarm(t *testing.T) {
+	const probeTime = 400 * time.Millisecond
+	var calls atomic.Int32
+	srv := memberForge(t, &calls, probeTime)
+	fa := newForgeAccess(forgepkg.NewGitHubAt(srv.URL), srv.Client(),
+		[]RepoSpec{{Name: "shared", URL: "https://github.com/acme/shared.git"}}, "srv-token", nil)
+	ctx := context.Background()
+
+	// The first board of a fresh process pays once: nobody has ever asked
+	// about this repository, and an empty picker would be a worse answer
+	// than a slow one.
+	first, err := fa.readers(ctx, "shared", []string{"kvaps"})
+	if err != nil || len(first) != 1 {
+		t.Fatalf("the cold answer: %v, %v", first, err)
+	}
+
+	// From then on nobody waits — not for a login nobody has heard of…
+	started := time.Now()
+	got, err := fa.readers(ctx, "shared", []string{"kvaps", "newcomer"})
+	took := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if took > probeTime/2 {
+		t.Fatalf("a warm board waited %v on the forge", took)
+	}
+	if len(got) != 2 {
+		t.Fatalf("and the newcomer is offered while the forge is asked: %v", got)
+	}
+
+	// …nor for an answer that has merely aged.
+	waitForCalls(t, &calls, 2)
+	started = time.Now()
+	if _, err := fa.readers(ctx, "shared", []string{"kvaps", "newcomer"}); err != nil {
+		t.Fatal(err)
+	}
+	if took := time.Since(started); took > probeTime/2 {
+		t.Fatalf("a settled board waited %v on the forge", took)
+	}
+}

--- a/internal/server/carryover_commits_test.go
+++ b/internal/server/carryover_commits_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/storage/memory"
+
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/gitstore"
+)
+
+// A request's writes are ONE commit, however many cards it touches: the
+// queue groups every op that shares the request's action id (execGroup).
+// This is what keeps a big write cheap — every commit moves the tip, and
+// a moved tip costs the next write a fresh read of the whole board — so
+// it is worth a test of its own, checked against the real store rather
+// than assumed. A carry-over is the biggest such request there is.
+func TestACarryOverIsOneCommit(t *testing.T) {
+	const yesterday = "2026-08-30"
+	remote := gitRemoteN(t, "board")
+	r, err := gitstore.Init(memory.NewStorage(), gitstore.Options{Committer: gitstore.Identity{Name: "aeman", Email: "a@x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []gitstore.FileWrite{
+		{Path: gitstore.BoardPath, Data: []byte("schema: 1\ntitle: t\n")},
+		{Path: gitstore.TeamPath("01JB4TEAM"), Data: []byte("name: portal\nrank: b\ncreated: 2026-06-01T08:00:00Z\nsprint:\n  current: " + yesterday + "\n")},
+	}
+	// Enough cards that the old behaviour could not have committed them in
+	// one group by luck.
+	const cards = 12
+	for i := range cards {
+		id := fmt.Sprintf("01CARRY%017d", i)
+		p, err := gitstore.CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, gitstore.FileWrite{Path: p, Data: []byte(fmt.Sprintf(
+			"---\ntitle: card %d\nteam: portal\nsprint: %s\nstart: %s\nday: %s\nprogress: 30\nrank: a%d\ncreated: 2026-08-20T09:00:00Z\n---\n",
+			i, yesterday, yesterday, yesterday, i))})
+	}
+	if _, err := r.Commit(gitstore.Action{Name: "import", Summary: "seed"}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Push(context.Background(), remote); err != nil {
+		t.Fatal(err)
+	}
+	srv := gitModeServer(t, remote)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	srv.store.waitDrained(ctx)
+	before := headCount(t, srv)
+
+	rec := do(t, srv, http.MethodPost, "/api/v1/sprints/actions/carry-over",
+		`{"team":"portal"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("carry-over: %d %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, fmt.Sprintf(`"carried":%d`, cards)) {
+		t.Fatalf("the carry must move every card, or the count below proves nothing: %s", body)
+	}
+	srv.store.waitDrained(ctx)
+
+	if got := headCount(t, srv) - before; got != 1 {
+		t.Fatalf("one request is one commit; the carry-over made %d", got)
+	}
+	// And the board says what the carry did.
+	_ = board.TodayIso()
+}
+
+// headCount is how many commits the primary clone holds.
+func headCount(t *testing.T, srv *Server) int {
+	t.Helper()
+	repo := srv.gitBE.git.domains[0].Repo
+	n := 0
+	h := repo.Head()
+	for !h.IsZero() {
+		c, err := repo.CommitObject(h)
+		if err != nil {
+			break
+		}
+		n++
+		if len(c.ParentHashes) == 0 {
+			break
+		}
+		h = c.ParentHashes[0]
+	}
+	return n
+}

--- a/internal/server/idlecost_test.go
+++ b/internal/server/idlecost_test.go
@@ -303,10 +303,20 @@ func TestAPersonNobodyHasAskedAboutIsAskedAbout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The newcomer is offered at once — a login nobody has asked about yet
+	// is not "cannot read", and the picker must not lose the person a card
+	// was just assigned to — and asked about BEHIND the answer: waiting for
+	// the forge here is what put seconds between a person and their board
+	// every time somebody new appeared on it.
 	if len(got) != 2 {
-		t.Fatalf("readers = %v; the newcomer must be asked about, not assumed away", got)
+		t.Fatalf("readers = %v; the newcomer must not be assumed away", got)
 	}
+	waitForCalls(t, &calls, 2)
 	if calls.Load() != 2 {
 		t.Fatalf("%d listings, want 2 — the second for the login never seen", calls.Load())
+	}
+	// …and once the forge has answered, the answer stands.
+	if got, err := fa.readers(ctx, "shared", []string{"kvaps", "lex"}); err != nil || len(got) != 2 {
+		t.Fatalf("the settled answer: %v, %v", got, err)
 	}
 }

--- a/pkg/gitstore/commit.go
+++ b/pkg/gitstore/commit.go
@@ -54,6 +54,38 @@ type Repo struct {
 	// so a log read never waits on a commit and vice versa.
 	idxMu sync.Mutex
 	idx   *pathIndex
+	// snapMu guards the snapshot memo: the board as it reads at ONE commit.
+	// A commit is immutable, so the same hash always yields the same board —
+	// and a single request re-reads the whole tree once per field it writes
+	// otherwise (every setter takes a snapshot to decide where the card
+	// belongs), which is why a carry-over over a 2400-card board took
+	// minutes rather than the second it spends writing.
+	snapMu   sync.Mutex
+	snapHead plumbing.Hash
+	snap     *Snapshot
+}
+
+// snapshotAt returns the memoized snapshot for a tip, if that is the tip it
+// was read at. The copy is the caller's: LoadAll stamps every entry with
+// its domain's name, and a caller that wrote through to the memo would
+// hand the next reader a board stamped for somebody else.
+func (r *Repo) snapshotAt(head plumbing.Hash) (Snapshot, bool) {
+	r.snapMu.Lock()
+	defer r.snapMu.Unlock()
+	if r.snap == nil || r.snapHead != head {
+		return Snapshot{}, false
+	}
+	return r.snap.clone(), true
+}
+
+// rememberSnapshot memoizes one tip's snapshot, replacing whatever tip was
+// remembered before: the board moves forward, and a reader of an older tip
+// is a log read, which has its own path.
+func (r *Repo) rememberSnapshot(head plumbing.Hash, s Snapshot) {
+	r.snapMu.Lock()
+	defer r.snapMu.Unlock()
+	kept := s.clone()
+	r.snapHead, r.snap = head, &kept
 }
 
 // Action is what one commit records.

--- a/pkg/gitstore/load.go
+++ b/pkg/gitstore/load.go
@@ -117,12 +117,46 @@ type BrokenFile struct {
 }
 
 // Load reads the snapshot at the branch tip.
+// clone copies a snapshot's own slices — every place a reader writes into
+// one. LoadAll stamps each entry with its domain's NAME (stamp), so two
+// readers sharing one snapshot would stamp over each other; the strings
+// themselves are shared, which is what makes this cheap next to decoding
+// the tree again.
+func (s Snapshot) clone() Snapshot {
+	out := s
+	out.Cards = append([]board.Card(nil), s.Cards...)
+	out.Teams = append([]Team(nil), s.Teams...)
+	out.Processes = append([]Process(nil), s.Processes...)
+	for i := range out.Processes {
+		out.Processes[i].Tasks = append([]Task(nil), s.Processes[i].Tasks...)
+	}
+	out.Projects = append([]Project(nil), s.Projects...)
+	for i := range out.Projects {
+		out.Projects[i].Epics = append([]Epic(nil), s.Projects[i].Epics...)
+		out.Projects[i].Deadlines = append([]Deadline(nil), s.Projects[i].Deadlines...)
+	}
+	return out
+}
+
 func Load(r *Repo) (Snapshot, error) {
 	head := r.Head()
 	if head.IsZero() {
 		return Snapshot{}, ErrEmptyRepository
 	}
-	return LoadAt(r, head)
+	// Memoized by the tip. Reading the tree means decoding every card file
+	// on the board, and every setter asks for a snapshot to decide where
+	// its card belongs — so one request that wrote fifty cards read the
+	// whole board a hundred and fifty times. The commit is immutable: the
+	// same hash is the same board, and a write moves the hash.
+	if s, ok := r.snapshotAt(head); ok {
+		return s, nil
+	}
+	s, err := LoadAt(r, head)
+	if err != nil {
+		return s, err
+	}
+	r.rememberSnapshot(head, s)
+	return s, nil
 }
 
 // LoadAt reads the snapshot at a commit — the tip, or a past one for the

--- a/pkg/gitstore/snapshot_cache_test.go
+++ b/pkg/gitstore/snapshot_cache_test.go
@@ -1,0 +1,114 @@
+package gitstore
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aenix-io/aeman/pkg/board"
+	"github.com/aenix-io/aeman/pkg/boardservice"
+)
+
+// bigRepo is a board of n cards, the shape a real one has: a team, a
+// project with a column, and n cards spread over it.
+func bigRepo(t *testing.T, n int) *Repo {
+	t.Helper()
+	files := map[string]string{
+		BoardPath:                         "schema: 1\ntitle: big\n",
+		TeamPath("01T_PORTAL"):            "name: portal\nrank: b\ncreated: 2026-06-01T08:00:00Z\nsprint:\n  current: 2026-08-24\n  previous: 2026-08-17\n",
+		ProjectPath("01P_PORTAL"):         "name: portal\nrank: a\ncreated: 2026-06-01T08:00:00Z\n",
+		EpicPath("01P_PORTAL", "01E_BUG"): "name: Bugs\nrank: a\ncreated: 2026-06-01T08:00:00Z\n",
+	}
+	for i := range n {
+		id := fmt.Sprintf("01CARD%018d", i)
+		p, err := CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[p] = fmt.Sprintf("---\ntitle: card %d\nteam: portal\nsprint: 2026-08-24\nstart: 2026-08-24\nrank: a%d\ncreated: 2026-08-20T09:00:00Z\n---\nbody\n", i, i)
+	}
+	return repoWith(t, files)
+}
+
+// A snapshot is read once per TIP, not once per write. Every setter asks
+// where its card belongs, and asking meant decoding every card file on the
+// board again: one carry-over over a real board did that hundreds of times
+// and took minutes to write what it decided in a second.
+func TestASnapshotIsReadOncePerTip(t *testing.T) {
+	r := bigRepo(t, 400)
+
+	start := time.Now()
+	first, err := Load(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cold := time.Since(start)
+	if len(first.Cards) != 400 {
+		t.Fatalf("the board is %d cards", len(first.Cards))
+	}
+
+	start = time.Now()
+	for range 50 {
+		if _, err := Load(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	warm := time.Since(start) / 50
+	t.Logf("cold read %v, memoized read %v (%.0fx)", cold, warm, float64(cold)/float64(max(warm, 1)))
+	if warm*4 > cold {
+		t.Fatalf("a memoized read must be a fraction of the tree walk: cold %v, warm %v", cold, warm)
+	}
+
+	// The memo is per TIP: a write moves it, and the next read sees the
+	// write rather than the board as it was.
+	if _, err := r.Commit(Action{Name: "update", Summary: "one more"},
+		[]FileWrite{{Path: "cards/z/z/01CARDZZ.md", Data: []byte("---\ntitle: new\nteam: portal\n---\n")}}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := Load(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Cards) != 401 {
+		t.Fatalf("the next read sees the write: %d cards", len(after.Cards))
+	}
+
+	// And the copy handed out is the caller's: stamping one must not stamp
+	// the next reader's board (LoadAll stamps every entry with its domain).
+	after.Cards[0].Domain = "somebody-elses"
+	again, err := Load(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Cards[0].Domain != "" {
+		t.Fatalf("a reader's stamp leaked into the memo: %q", again.Cards[0].Domain)
+	}
+}
+
+// What the memo is for: an action that writes many cards — a carry-over is
+// the big one — asks for a snapshot per field it writes.
+func TestACarryOverOverABigBoardDoesNotReReadItPerWrite(t *testing.T) {
+	r := bigRepo(t, 400)
+	mb := NewMultiBackend([]Domain{{Name: "board", Repo: r}},
+		BackendOptions{Now: time.Now})
+	svc := boardservice.New(mb)
+	ctx, flush := WithScope(ctxAs("kvaps"), Action{Name: "carry-over", ID: NewID(time.Now())})
+	start := time.Now()
+	rep, err := svc.CarryOver(ctx, "acme", "portal", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := flush(); err != nil {
+		t.Fatal(err)
+	}
+	took := time.Since(start)
+	t.Logf("carry-over of %d cards over a 400-card board: %v", rep.Carried, took)
+	if rep.Carried == 0 {
+		t.Fatal("the fixture must have something to carry")
+	}
+	// Generous by design: the point is that it is not minutes.
+	if took > 20*time.Second {
+		t.Fatalf("a carry-over must not re-read the board per write: %v", took)
+	}
+	_ = board.TodayIso()
+}

--- a/web/src/components/MeBoard.tsx
+++ b/web/src/components/MeBoard.tsx
@@ -31,6 +31,7 @@ import { ZONES, ZONE_ORDER } from "../zones";
 import { todayIso, localDateIso, addDays } from "../date";
 import { subtaskShows } from "../subtasks";
 import { activeSprint, currentSprint, previousSprint } from "../sprint";
+import { slotWeekPatch } from "../weekly";
 import {
   boardAsksAbout,
   deleteWarning,
@@ -1890,10 +1891,13 @@ export function MeBoard({
     start: string | null,
     end: string | null,
   ) => {
-    const prev = { startDate: card.startDate, day: card.day };
+    const prev = { startDate: card.startDate, day: card.day, week: card.week };
     patchCard(card.itemId, {
       startDate: start ?? undefined,
       day: end ?? undefined,
+      // A slot's WEEK follows its start date, or the card keeps standing
+      // in the week it left until the next full load.
+      ...slotWeekPatch(card, start),
     });
     void provider
       .patchCard(card.itemId, {

--- a/web/src/components/TeamBoard.tsx
+++ b/web/src/components/TeamBoard.tsx
@@ -37,7 +37,7 @@ import { TeamsModal } from "./TeamsModal";
 import { SprintChoiceDialog } from "./SprintChoiceDialog";
 import { SortableBoard, type BoardGroup, type DropResult } from "./SortableBoard";
 import { globalOrderFromGroups, afterIdFor } from "./dndOrder";
-import { isSlot, owedIn, planRemoveOffered, slotBand } from "../weekly";
+import { isSlot, owedIn, planRemoveOffered, slotBand, slotWeekPatch } from "../weekly";
 import { subtaskShows } from "../subtasks";
 import {
   boardAsksAbout,
@@ -2038,6 +2038,9 @@ export function TeamBoard({
       startDate: start ?? undefined,
       sprintStart: sprint ?? undefined,
       day: end ?? undefined,
+      // A slot's WEEK follows its start date, or the card keeps standing
+      // in the week it left until the next full load.
+      ...slotWeekPatch(card, start),
     });
     void provider
       .patchCard(card.itemId, {

--- a/web/src/weekly.test.ts
+++ b/web/src/weekly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { effectiveBand, owedIn, planRemoveOffered, slotBand } from "./weekly";
+import { effectiveBand, owedIn, planRemoveOffered, slotBand, slotWeekPatch } from "./weekly";
 
 // Mirrors pkg/board WeeklyPlanAt's derived band: a Project-board slot needs no
 // stored band — its span is its plan, and the band derives from the end date.
@@ -134,5 +134,29 @@ describe("who gets an × on the weekly panel", () => {
       planRemoveOffered({ epic: "E", week: "2026-08-24", day: "2026-08-28", plan: "fri" }),
     ).toBe(false);
     expect(planRemoveOffered({ epic: "E", week: "2026-08-24", plan: "fri" })).toBe(false);
+  });
+});
+
+// A card in a COLUMN has no week of its own: the server derives it from
+// the start date. A client that moved the dates and left the week behind
+// kept drawing the card in the week it left — a card pushed to the end of
+// September stayed on THIS week's plan panel until the next full load.
+describe("the week that follows a slot's dates", () => {
+  it("moves with the start date", () => {
+    expect(slotWeekPatch({ epic: "Webinars" }, "2026-09-28")).toEqual({
+      week: "2026-09-28",
+    });
+    // Any day of that week is the same row: the Monday.
+    expect(slotWeekPatch({ epic: "Webinars" }, "2026-10-02")).toEqual({
+      week: "2026-09-28",
+    });
+  });
+
+  it("leaves a card outside every column alone — its week is its own", () => {
+    expect(slotWeekPatch({}, "2026-09-28")).toEqual({});
+  });
+
+  it("has nothing to move when the dates are cleared", () => {
+    expect(slotWeekPatch({ epic: "Webinars" }, null)).toEqual({});
   });
 });

--- a/web/src/weekly.ts
+++ b/web/src/weekly.ts
@@ -53,6 +53,20 @@ export function slotBand(week: string, endDay: string): "wed" | "fri" {
     : "fri";
 }
 
+/** slotWeekPatch is the week that follows a card's dates. A card in a
+ *  COLUMN has no week of its own — the server derives it from the start
+ *  date (board.NewBoard: "a slot's row is its START date's week, never a
+ *  week stored beside it") — so a client that moves the dates and leaves
+ *  the week behind keeps drawing the card in the week it left: on the
+ *  weekly panel of that week, until the next full load says otherwise.
+ *  Empty for a card outside every column, whose week is its own. */
+export function slotWeekPatch(
+  card: { epic?: string },
+  start: string | null | undefined,
+): { week?: string } {
+  return card.epic && start ? { week: mondayOf(start) } : {};
+}
+
 /** owedIn is the week a card was owed in: the one it belongs to, or — for a
  *  Project-board slot, whose span IS its plan — the week its span ENDS in,
  *  the only week of that span with a deadline in it. Mirrors pkg/board


### PR DESCRIPTION
Four things, all found in use this morning.

**A carry-over took nearly two minutes** and the board crawled for everyone while it ran. Every setter asks the store where its card belongs, and asking took a SNAPSHOT — the whole tree decoded again, 2418 card files — per field written. A commit is immutable, so the same tip is the same board: `Load` memoizes its snapshot by the tip it was read at, and a write moves the tip. Measured on a 400-card board (a sixth of the real one): a carry-over of 400 cards goes from **5.75s to 0.27s**, a memoized read is ~125× cheaper than the tree walk. The cost was quadratic in the board's size, so the real one gains more.

**`GET /board` took five to nine seconds**, again and again. It asks the forge who reads each repository — a listing plus one request per login the listing does not name — and any login without an answer made the page wait for all of it. A morning of planning produces new logins constantly, since every fresh assignee is one. The first board of a fresh process still pays once; after that the forge is asked behind the answer. A login nobody has asked about yet is offered while the question is put (not yet asked is not "cannot read", and the picker must not lose the person a card was just assigned to); one the forge was asked about and did not answer for is left out; and an attempt is remembered whether it succeeds or not, so a forge that answers for nobody is not re-asked on every request.

**A card moved to another week stayed on the old week's plan panel** until a full reload: a card in a column has no week of its own — the server derives it from the start date — and the client moved the dates without the week.

Plus a test for the invariant that keeps a big write cheap: one request is one commit (production's two carry-overs this morning are one commit each, and nothing checked it).

Verified against a real two-repository store, not only the fake.