### PR TITLE
perf(watch): announce the board once per request, not once per card

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -248,6 +248,8 @@ The optional `client` id keys **echo suppression**: send the same value in the `
 
 **Scoped watch**: pass the same selector parameters as LIST (`view=`, `team=`, `stage=`, ...) and the subscription tracks that selection — a card entering it arrives as `ADDED` and one leaving it as `DELETED`, so a thin client can mirror a single view without knowing the board rules. Memberships are re-diffed when a sprint pointer moves and when the local day rolls over. `resources=cards,sprints,ordering` picks the kinds.
 
+**Board frames**: a change to the board's STRUCTURE — a project, a column, a deadline, a process or one of its tasks — cannot be expressed as a card event, so it arrives as a `MODIFIED` frame of kind `Board` carrying the whole board resource plus the process structure (apply it, no round trip needed). These frames are **coalesced**: one request that touches many cards announces the board once, a moment (~25 ms) after its changes, not once per card — a carry-over moving a team's whole backlog would otherwise repaint the board for every open tab hundreds of times over, and it did.
+
 Changes that reach the repository from elsewhere — another aeman replica, a plugin committing directly — arrive the same way: the server fetches on its sync tick (`--sync-interval`, 15 s), reads exactly the cards the new commits touched, and streams them.
 
 ### Health

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -56,6 +56,12 @@ func (sub *subscription) send(frame watchFrame) {
 	if err != nil {
 		return
 	}
+	sub.sendRaw(data)
+}
+
+// sendRaw delivers a frame already marshalled — one built for a whole group
+// of subscriptions that see the same board (see flushRoster).
+func (sub *subscription) sendRaw(data []byte) {
 	select {
 	case sub.ch <- data:
 	default:
@@ -159,6 +165,10 @@ type boardEntry struct {
 	// recentMove is when a local reorder last touched this board: within
 	// recentGrace the cached order outweighs a fresh (possibly stale) read.
 	recentMove time.Time
+	// rosterDue is a board announcement waiting to go out. The frame carries
+	// the whole board, so it is sent once for a burst of changes rather than
+	// once per card — see rosterBroadcast.
+	rosterDue bool
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -894,19 +904,78 @@ func (e *boardEntry) diffNotify(old board.Board) {
 // events it is already receiving: it has to re-read /board, and this is what
 // tells it to. Sent to every watcher regardless of the view it selected,
 // because the roster is the same for all of them.
+// The caller holds e.mu.
+//
+// It is ONE announcement for a burst, not one per card. The frame carries the
+// board — every project, column, deadline and process — so building it means
+// projecting the board for the watcher and marshalling the result; a
+// carry-over moves hundreds of cards, a good share of them process turns,
+// and announcing each of them to each open tab built that frame thousands of
+// times under the lock every read waits on. On the real board that was a
+// minute and a half in which nothing else was served. The changes themselves
+// reach the client as card events meanwhile; the roster catches up a moment
+// later.
 func (e *boardEntry) rosterBroadcast() {
+	if e.rosterDue {
+		return
+	}
+	e.rosterDue = true
+	time.AfterFunc(rosterCoalesce, e.flushRoster)
+}
+
+// rosterCoalesce is how long an announcement waits for the rest of its burst.
+// Short enough that a single change still looks instant, long enough that a
+// request writing many cards announces once.
+const rosterCoalesce = 25 * time.Millisecond
+
+// flushRoster sends the announcement rosterBroadcast promised: one frame per
+// distinct set of rights (the tabs of one visitor share a projection, and
+// most visitors of a one-repository board share it with everyone), marshalled
+// once and handed to every subscription it fits.
+func (e *boardEntry) flushRoster() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.rosterDue {
+		return
+	}
+	e.rosterDue = false
 	// The frame CARRIES the board, the way a Card frame carries its card: a
 	// client applies it and needs no round trip. A bare "something changed"
 	// signal sent every open tab back to GET /board — a full snapshot each,
 	// which is the opposite of what a cache is for. Processes ride along as
 	// their full structure, since the Process tab is drawn from it.
+	built := map[string][]byte{}
 	for sub := range e.watchers {
-		view := sub.view(e.board)
-		sub.send(watchFrame{Type: "MODIFIED", Kind: "Board", Object: boardFrame{
-			BoardInfo: apiserver.BoardResourceWithPeople(view, e.member),
-			Processes: apiserver.ProcessesResource(view, "").Items,
-		}})
+		key := rightsKey(sub.rights)
+		data, ok := built[key]
+		if !ok {
+			view := sub.view(e.board)
+			raw, err := json.Marshal(watchFrame{Type: "MODIFIED", Kind: "Board", Object: boardFrame{
+				BoardInfo: apiserver.BoardResourceWithPeople(view, e.member),
+				Processes: apiserver.ProcessesResource(view, "").Items,
+			}})
+			if err != nil {
+				continue
+			}
+			data = raw
+			built[key] = raw
+		}
+		sub.sendRaw(data)
 	}
+}
+
+// rightsKey names a projection of the board: two subscriptions with the same
+// key see the same board and can share one built frame.
+func rightsKey(r *domainRights) string {
+	if r == nil {
+		return ""
+	}
+	names := make([]string, 0, len(r.read))
+	for d := range r.read {
+		names = append(names, d)
+	}
+	sort.Strings(names)
+	return "r\x00" + r.primary + "\x00" + strings.Join(names, "\x00")
 }
 
 // boardFrame is the Board watch frame's object: the board resource plus the

--- a/internal/server/carryover_cost_test.go
+++ b/internal/server/carryover_cost_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/storage/memory"
+
+	"github.com/aenix-io/aeman/pkg/gitstore"
+)
+
+// A carry-over moves a whole team's unfinished work, and a good share of it
+// is process turns. Every turn announced the board's STRUCTURE to every open
+// tab — and a roster frame carries the board: it projected the board per
+// watcher, built the board resource and the full process structure, and
+// marshalled all of it, once per card, holding the lock that every read
+// waits on. On the real board (2435 cards, twenty tabs) a carry-over took a
+// minute and a half during which nothing else was served: the board, the
+// sprints, the cards and the process list all queued behind it and came back
+// after a minute apiece.
+//
+// The board is announced once for the whole request, not once per card.
+func TestACarryOverAnnouncesTheBoardOnceNotPerCard(t *testing.T) {
+	const (
+		yesterday = "2026-08-30"
+		cards     = 400 // the rows a carry-over walks
+		turns     = 120 // of which this many are process turns
+		tabs      = 12  // open boards, each one an announcement target
+	)
+	remote := gitRemoteN(t, "board")
+	r, err := gitstore.Init(memory.NewStorage(), gitstore.Options{Committer: gitstore.Identity{Name: "aeman", Email: "a@x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []gitstore.FileWrite{
+		{Path: gitstore.BoardPath, Data: []byte("schema: 1\ntitle: t\n")},
+		{Path: gitstore.TeamPath("01JB4TEAM"), Data: []byte("name: portal\nrank: b\ncreated: 2026-06-01T08:00:00Z\nsprint:\n  current: " + yesterday + "\n")},
+		{Path: gitstore.ProjectPath("01JB4PROJ"), Data: []byte("name: portal\nrank: a\ncreated: 2026-06-01T08:00:00Z\n")},
+	}
+	// The processes the turns belong to: a real board keeps dozens, each
+	// with its own recurring task, and the roster frame carries all of them.
+	for i := range turns {
+		pid := fmt.Sprintf("01PROC%018d", i)
+		tid := fmt.Sprintf("01TASK%018d", i)
+		files = append(files,
+			gitstore.FileWrite{Path: gitstore.ProcessPath(pid), Data: []byte(fmt.Sprintf(
+				"name: process %d\nproject: portal\nrank: a%d\ncreated: 2026-06-04T08:00:00Z\n", i, i))},
+			gitstore.FileWrite{Path: gitstore.TaskPath(pid, tid), Data: []byte(fmt.Sprintf(
+				"---\ntitle: turn %d\nteam: portal\nrecurrence: week\nrank: a\ncreated: 2026-06-04T08:00:00Z\n---\n\nDo it.\n", i))},
+		)
+	}
+	for i := range cards {
+		id := fmt.Sprintf("01CARRY%017d", i)
+		p, err := gitstore.CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		front := fmt.Sprintf(
+			"---\ntitle: card %d\nteam: portal\nsprint: %s\nstart: %s\nday: %s\nprogress: 30\nrank: a%05d\ncreated: 2026-08-20T09:00:00Z\n",
+			i, yesterday, yesterday, yesterday, i)
+		if i < turns {
+			front += fmt.Sprintf("process: %s\ntask: %s\n", fmt.Sprintf("01PROC%018d", i), fmt.Sprintf("01TASK%018d", i))
+		}
+		files = append(files, gitstore.FileWrite{Path: p, Data: []byte(front + "---\n")})
+	}
+	if _, err := r.Commit(gitstore.Action{Name: "import", Summary: "seed"}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Push(context.Background(), remote); err != nil {
+		t.Fatal(err)
+	}
+	srv := gitModeServer(t, remote)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	srv.store.waitDrained(ctx)
+
+	// Twelve tabs, each draining its stream the way a browser does — a frame
+	// nobody reads is dropped, and a dropped frame would hide the cost that
+	// building it already paid.
+	key := storeKey(srv.boardRef(nil))
+	var boards, all atomic.Int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := range tabs {
+		sub, cancelSub := srv.store.subscribe(key, fmt.Sprintf("tab-%d", i), nil,
+			map[string]bool{"cards": true, "sprints": true, "ordering": true})
+		defer cancelSub()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case data := <-sub.ch:
+					all.Add(1)
+					var frame struct {
+						Kind string `json:"kind"`
+					}
+					if json.Unmarshal(data, &frame) == nil && frame.Kind == "Board" {
+						boards.Add(1)
+					}
+				case <-stop:
+					return
+				}
+			}
+		}()
+	}
+
+	started := time.Now()
+	rec := do(t, srv, http.MethodPost, "/api/v1/sprints/actions/carry-over", `{"team":"portal"}`)
+	took := time.Since(started)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("carry-over: %d %s", rec.Code, rec.Body.String())
+	}
+	srv.store.waitDrained(ctx)
+	time.Sleep(200 * time.Millisecond) // let the tabs finish reading
+	close(stop)
+	wg.Wait()
+
+	t.Logf("carry-over of %d cards (%d turns) to %d tabs: %v, %d frames, %d of them the whole board",
+		cards, turns, tabs, took, all.Load(), boards.Load())
+	// A tab hears the board once per coalescing window the request spans —
+	// a handful — and never once per card it moved.
+	windows := int64(took/rosterCoalesce) + 2
+	if got := boards.Load(); got > int64(tabs)*windows {
+		t.Fatalf("the board was announced %d times to %d tabs in %v; that is %d windows' worth at most",
+			got, tabs, took, windows)
+	}
+	// And the request itself stays interactive: it is a person waiting on a
+	// button, with the whole board's reads queued behind it.
+	if took > 5*time.Second {
+		t.Fatalf("the carry-over took %v with %d tabs open", took, tabs)
+	}
+}


### PR DESCRIPTION
A watch frame of kind `Board` carries the whole board — every project, column, deadline and process — so building one means projecting the board for the watcher and marshalling the result. Every card belonging to a process turn announced it, to every open tab, while holding the lock every read waits on.

A carry-over moves a team's whole backlog, so it did that thousands of times: on the production board that was a minute and a half in which nothing else was served — board, sprints, cards and the process list all queued behind it and came back a minute later apiece.

The announcement is now coalesced into one per burst and built once per set of rights rather than once per tab. Measured on a board of production size with twenty tabs open: 1m50s → 0.7s. The regression test pins the invariant; `docs/api.md` documents the Board frame and its coalescing.