### PR TITLE
ci(image): publish the container image from a release tag

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,61 @@
+name: Image
+
+# The public image. A release tag publishes it; the manual run republishes an
+# existing tag (or any commit) without minting a new version.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to publish (e.g. v0.29.4)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    name: build & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Name the version
+        id: v
+        run: |
+          version="${{ inputs.ref || github.ref_name }}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # `latest` is what a deployment tracks, so only a release tag moves
+          # it — never a one-off build of some commit.
+          if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "latest=,ghcr.io/${{ github.repository }}:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "latest=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The Dockerfile cross-compiles from the build arch (the SPA once, the Go
+      # binary per target), so both architectures cost one build, no emulation.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ steps.v.outputs.version }}
+          tags: ghcr.io/${{ github.repository }}:${{ steps.v.outputs.version }}${{ steps.v.outputs.latest }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.v.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -66,6 +66,8 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
+The compose file builds from this checkout. To run a **published** image instead — every release tag is built for `linux/amd64` and `linux/arm64` and pushed to `ghcr.io/aenix-io/aeman` — drop the `build:` block and name the image: `image: ghcr.io/aenix-io/aeman:latest` (or a version, `:v0.29.4`). Upgrading is then `docker compose pull && docker compose up -d`.
+
 `AEMAN_REPOS` names the board's repositories as `name=url`, comma-separated, the primary first — HTTPS clone URLs on the forge, e.g. `aeman-db=https://github.com/acme/aeman-db.git` or `aeman-db=https://gitlab.com/acme/aeman-db.git`. `AEMAN_GIT_TOKEN` is the server's own credential for them (fetch, push, and the membership checks behind the assignee pickers); it is required in this mode. An **empty** repository becomes a board first, on either forge: `aeman init --repo <url>` — from this directory, `docker compose run --rm aeman init --repo https://gitlab.com/acme/aeman-db.git`. `serve` refuses an unborn remote and names that command.
 
 `AEMAN_GIT_TOKEN` is the server's own credential for all of them. A board whose repositories live in **two organisations** gives each its own instead: `AEMAN_GIT_TOKEN_<NAME>`, named after the domain (upper-cased, anything but a letter or a digit an underscore — `founders` → `AEMAN_GIT_TOKEN_FOUNDERS`). This is what lets each token stay narrow: a fine-grained GitHub token belongs to one organisation, so one token cannot cover repositories in two, and a classic token that could is wider than either repository needs. Pass the variables you use through the compose file's `environment` block.


### PR DESCRIPTION
The image was built by hand and carried to the server; nothing built the public one.

A release tag (`v*`) now builds it for `linux/amd64` and `linux/arm64` and pushes it to `ghcr.io/aenix-io/aeman`. `latest` follows release tags only, never a one-off build, since that is what a deployment tracks. A manual run (`workflow_dispatch`) republishes an existing tag or any commit — how a tag pushed before this workflow existed gets its image.

The Dockerfile already cross-compiles (the SPA once, the Go binary per target), so both architectures cost one build with no emulation. `docs/deploy.md` now points at the published image as an alternative to building from the checkout.