### PR TITLE
perf(watch): decide a scoped view's membership once per burst

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -248,6 +248,8 @@ The optional `client` id keys **echo suppression**: send the same value in the `
 
 **Scoped watch**: pass the same selector parameters as LIST (`view=`, `team=`, `stage=`, ...) and the subscription tracks that selection — a card entering it arrives as `ADDED` and one leaving it as `DELETED`, so a thin client can mirror a single view without knowing the board rules. Memberships are re-diffed when a sprint pointer moves and when the local day rolls over. `resources=cards,sprints,ordering` picks the kinds.
 
+Deciding what a scoped view holds means building that view, so it is decided **once for a burst of changes** rather than once per card: a request that moves a team's whole backlog is answered with one frame per card a moment (~25 ms, stretched on a board where the fan-out is expensive) after its writes. Unscoped subscriptions still receive each change as it lands.
+
 **Board frames**: a change to the board's STRUCTURE — a project, a column, a deadline, a process or one of its tasks — cannot be expressed as a card event, so it arrives as a `MODIFIED` frame of kind `Board` carrying the whole board resource plus the process structure (apply it, no round trip needed). These frames are **coalesced**: one request that touches many cards announces the board once, a moment (~25 ms) after its changes, not once per card — a carry-over moving a team's whole backlog would otherwise repaint the board for every open tab hundreds of times over, and it did.
 
 Changes that reach the repository from elsewhere — another aeman replica, a plugin committing directly — arrive the same way: the server fetches on its sync tick (`--sync-interval`, 15 s), reads exactly the cards the new commits touched, and streams them.

--- a/internal/server/boardstore.go
+++ b/internal/server/boardstore.go
@@ -169,6 +169,16 @@ type boardEntry struct {
 	// the whole board, so it is sent once for a burst of changes rather than
 	// once per card — see rosterBroadcast.
 	rosterDue bool
+	// fanoutCost is how long the last fan-out took — what paces the next
+	// one (see fanoutDelay).
+	fanoutCost time.Duration
+	// membersDue is a scoped subscription's membership waiting to be
+	// re-decided, and moved holds the cards the burst touched with the
+	// client that touched each (for echo suppression). Deciding a view's
+	// membership means building the view, so it happens once for the burst —
+	// see cardChanged and flushMembers.
+	membersDue bool
+	moved      map[string]string
 }
 
 // recentGrace is how long a local mutation outweighs a full reload.
@@ -391,36 +401,91 @@ func (e *boardEntry) cardChanged(origin string, c board.Card, verb string) {
 	if c.Task != "" {
 		e.rosterBroadcast()
 	}
-	res := apiserver.CardResource(e.board, c)
+	// Built on demand: on a board whose tabs are all scoped — the ordinary
+	// case — a burst of changes must not pay for a resource nobody is sent.
+	var res apiserver.Card
+	built := false
+	scoped := false
 	for sub := range e.watchers {
 		if !sub.resources["cards"] || !sub.rights.canRead(c.Domain) {
 			continue
 		}
-		suppressed := origin != "" && sub.clientID == origin
 		if sub.sel == nil {
-			if !suppressed {
+			if !mine(origin, sub.clientID) {
+				if !built {
+					res, built = apiserver.CardResource(e.board, c), true
+				}
 				sub.send(watchFrame{Type: verb, Kind: "Card", Object: res})
 			}
 			continue
 		}
-		was := sub.members[c.ItemID]
-		now := verb != "DELETED" && sub.sel.Matches(e.board, c)
-		if now {
-			sub.members[c.ItemID] = true
-		} else {
-			delete(sub.members, c.ItemID)
-		}
-		if suppressed {
+		// What a scoped subscription is told depends on whether this change
+		// moved the card INTO or OUT OF its view — a question about the
+		// whole view. Asking it here (build the view, look for one uid) is
+		// what made a carry-over cost a full board scan per card per tab; it
+		// is answered once for the burst, in flushMembers.
+		scoped = true
+	}
+	if !scoped {
+		return
+	}
+	if e.moved == nil {
+		e.moved = map[string]string{}
+	}
+	e.moved[c.ItemID] = origin
+	if !e.membersDue {
+		e.membersDue = true
+		time.AfterFunc(e.fanoutDelay(), e.flushMembers)
+	}
+}
+
+// flushMembers re-decides what each scoped subscription holds, once for the
+// burst: the view is built one time per subscription and diffed against what
+// it held, so a card that entered arrives as ADDED and one that left as
+// DELETED. The caller holds nothing.
+func (e *boardEntry) flushMembers() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.membersDue {
+		return
+	}
+	e.membersDue = false
+	started := time.Now()
+	defer func() { e.noteFanout(time.Since(started)) }()
+	moved := e.moved
+	e.moved = nil
+	for sub := range e.watchers {
+		if sub.sel == nil || !sub.resources["cards"] {
 			continue
 		}
-		switch {
-		case now && !was:
-			sub.send(watchFrame{Type: "ADDED", Kind: "Card", Object: res})
-		case was && !now:
-			sub.send(watchFrame{Type: "DELETED", Kind: "Card", Object: res})
-		case was && now:
-			sub.send(watchFrame{Type: "MODIFIED", Kind: "Card", Object: res})
+		now := map[string]bool{}
+		for _, c := range apiserver.FilterCards(sub.view(e.board), *sub.sel) {
+			now[c.ItemID] = true
+			changed, touched := moved[c.ItemID]
+			if mine(changed, sub.clientID) {
+				continue
+			}
+			switch {
+			case !sub.members[c.ItemID]:
+				sub.send(watchFrame{Type: "ADDED", Kind: "Card", Object: apiserver.CardResource(e.board, c)})
+			case touched:
+				sub.send(watchFrame{Type: "MODIFIED", Kind: "Card", Object: apiserver.CardResource(e.board, c)})
+			}
 		}
+		for id := range sub.members {
+			if now[id] || mine(moved[id], sub.clientID) {
+				continue
+			}
+			obj := apiserver.Card{Kind: "Card", Metadata: apiserver.CardMetadata{UID: id}}
+			for _, c := range e.board.Cards {
+				if c.ItemID == id {
+					obj = apiserver.CardResource(e.board, c)
+					break
+				}
+			}
+			sub.send(watchFrame{Type: "DELETED", Kind: "Card", Object: obj})
+		}
+		sub.members = now
 	}
 }
 
@@ -920,13 +985,41 @@ func (e *boardEntry) rosterBroadcast() {
 		return
 	}
 	e.rosterDue = true
-	time.AfterFunc(rosterCoalesce, e.flushRoster)
+	time.AfterFunc(e.fanoutDelay(), e.flushRoster)
 }
 
-// rosterCoalesce is how long an announcement waits for the rest of its burst.
+// fanoutWindow is how long a fan-out waits for the rest of its burst —
+// the board announcement and the scoped views' membership both ride it.
 // Short enough that a single change still looks instant, long enough that a
-// request writing many cards announces once.
-const rosterCoalesce = 25 * time.Millisecond
+// request writing many cards is answered once.
+const fanoutWindow = 25 * time.Millisecond
+
+// fanoutCeiling bounds how far the window may stretch on a board where a
+// fan-out is genuinely expensive: past a second the boards would feel stale.
+const fanoutCeiling = time.Second
+
+// mine reports that a frame would be echoed back to the client that caused
+// it. An unattributed change (origin "") belongs to nobody and is echoed to
+// everyone — including a subscription that gave no client id.
+func mine(origin, clientID string) bool { return origin != "" && origin == clientID }
+
+// fanoutDelay is how long the next fan-out waits. It follows what the last
+// one COST: a fan-out builds a view per open board, so on a big board with
+// many tabs it is not free, and firing it every 25 ms through a long burst
+// would spend the server on repainting instead of writing. Waiting four
+// times the cost keeps it under a fifth of the machine, whatever the board's
+// size — and on the ordinary board, where a fan-out is a fraction of a
+// millisecond, the window stays the plain 25 ms.
+func (e *boardEntry) fanoutDelay() time.Duration {
+	d := 4 * e.fanoutCost
+	if d < fanoutWindow {
+		return fanoutWindow
+	}
+	if d > fanoutCeiling {
+		return fanoutCeiling
+	}
+	return d
+}
 
 // flushRoster sends the announcement rosterBroadcast promised: one frame per
 // distinct set of rights (the tabs of one visitor share a projection, and
@@ -939,6 +1032,8 @@ func (e *boardEntry) flushRoster() {
 		return
 	}
 	e.rosterDue = false
+	started := time.Now()
+	defer func() { e.noteFanout(time.Since(started)) }()
 	// The frame CARRIES the board, the way a Card frame carries its card: a
 	// client applies it and needs no round trip. A bare "something changed"
 	// signal sent every open tab back to GET /board — a full snapshot each,
@@ -962,6 +1057,12 @@ func (e *boardEntry) flushRoster() {
 		}
 		sub.sendRaw(data)
 	}
+}
+
+// noteFanout records what a fan-out cost, smoothed so one slow run does not
+// stretch the window for long. The caller holds e.mu.
+func (e *boardEntry) noteFanout(d time.Duration) {
+	e.fanoutCost = (e.fanoutCost + d) / 2
 }
 
 // rightsKey names a projection of the board: two subscriptions with the same

--- a/internal/server/boardstore_test.go
+++ b/internal/server/boardstore_test.go
@@ -40,6 +40,26 @@ func readFrame(t *testing.T, sub *subscription) frame {
 	}
 }
 
+// settled waits for the coalesced fan-out to run: what a scoped view holds
+// is decided once for a burst of changes (flushMembers), so a test that made
+// one change waits for that decision the way a browser does.
+func settled(t *testing.T, e *boardEntry) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		e.mu.Lock()
+		due := e.membersDue
+		e.mu.Unlock()
+		if !due {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the membership fan-out never ran")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func noFrame(t *testing.T, sub *subscription) {
 	t.Helper()
 	select {
@@ -138,6 +158,7 @@ func TestScopedWatchMembership(t *testing.T) {
 	e.upsertCard(c2)
 	e.cardChanged("", c2, "MODIFIED")
 	e.mu.Unlock()
+	settled(t, e)
 	if f := readFrame(t, sub); f.Type != "ADDED" || frameUID(t, f) != "c2" {
 		t.Fatalf("frame = %+v", f)
 	}
@@ -149,6 +170,7 @@ func TestScopedWatchMembership(t *testing.T) {
 	e.upsertCard(c1)
 	e.cardChanged("", c1, "MODIFIED")
 	e.mu.Unlock()
+	settled(t, e)
 	if f := readFrame(t, sub); f.Type != "MODIFIED" || frameUID(t, f) != "c1" {
 		t.Fatalf("frame = %+v", f)
 	}
@@ -159,6 +181,7 @@ func TestScopedWatchMembership(t *testing.T) {
 	e.upsertCard(c1)
 	e.cardChanged("", c1, "MODIFIED")
 	e.mu.Unlock()
+	settled(t, e)
 	if f := readFrame(t, sub); f.Type != "DELETED" || frameUID(t, f) != "c1" {
 		t.Fatalf("frame = %+v", f)
 	}
@@ -180,6 +203,7 @@ func TestScopedWatchOriginMembershipTracked(t *testing.T) {
 	e.upsertCard(c2)
 	e.cardChanged("me", c2, "MODIFIED")
 	e.mu.Unlock()
+	settled(t, e)
 	noFrame(t, sub)
 	if !sub.members["c2"] {
 		t.Fatal("origin membership must be tracked")
@@ -191,6 +215,7 @@ func TestScopedWatchOriginMembershipTracked(t *testing.T) {
 	e.upsertCard(c2)
 	e.cardChanged("", c2, "MODIFIED")
 	e.mu.Unlock()
+	settled(t, e)
 	if f := readFrame(t, sub); f.Type != "MODIFIED" {
 		t.Fatalf("frame = %+v", f)
 	}

--- a/internal/server/carryover_cost_test.go
+++ b/internal/server/carryover_cost_test.go
@@ -126,7 +126,7 @@ func TestACarryOverAnnouncesTheBoardOnceNotPerCard(t *testing.T) {
 		cards, turns, tabs, took, all.Load(), boards.Load())
 	// A tab hears the board once per coalescing window the request spans —
 	// a handful — and never once per card it moved.
-	windows := int64(took/rosterCoalesce) + 2
+	windows := int64(took/fanoutWindow) + 2
 	if got := boards.Load(); got > int64(tabs)*windows {
 		t.Fatalf("the board was announced %d times to %d tabs in %v; that is %d windows' worth at most",
 			got, tabs, took, windows)

--- a/internal/server/carryover_scope_test.go
+++ b/internal/server/carryover_scope_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/storage/memory"
+
+	"github.com/aenix-io/aeman/pkg/apiserver"
+	"github.com/aenix-io/aeman/pkg/gitstore"
+)
+
+// Every open board is a SCOPED watch — a team grid, somebody's Me view, the
+// weekly plan — and a scoped subscription has to know whether a changed card
+// entered or left its view. Asking that question card by card meant building
+// the whole view again for every card and every tab: FilterCards over the
+// entire board, sorted and projected, to look up one uid. A carry-over moves
+// hundreds of cards, so a morning's twenty tabs turned one button into
+// thousands of full board views, under the lock every read waits on — three
+// and a half minutes on the real board, with the memory churn to match.
+//
+// Membership is decided ONCE for the burst. What that buys is measured here
+// as a RATIO rather than a stopwatch: opening more boards must not make a
+// carry-over cost more, and the machine the test runs on cancels out.
+func TestACarryOverDoesNotCostMoreForEveryOpenBoard(t *testing.T) {
+	lone, frames := carryWithTabs(t, "lone", 1)
+	if frames < 1 {
+		t.Fatalf("the one tab heard nothing (%d frames); the comparison would be empty", frames)
+	}
+	many, frames := carryWithTabs(t, "many", 12)
+	t.Logf("carry-over with 1 tab: %v; with 12 tabs: %v (%.1fx), %d frames",
+		lone, many, float64(many)/float64(max(lone, 1)), frames)
+	// A tab costs one view per coalescing window, not one per card: twelve
+	// of them may cost more than one, but not an order of magnitude more.
+	if many > 3*lone+250*time.Millisecond {
+		t.Fatalf("a carry-over took %v with one tab and %v with twelve; the cost follows the tabs", lone, many)
+	}
+}
+
+// carryWithTabs seeds a board of unfinished work, opens n scoped watches on
+// it — the views a team actually keeps open — and returns how long the
+// carry-over took and how many frames the tabs were told.
+func carryWithTabs(t *testing.T, name string, tabs int) (time.Duration, int64) {
+	t.Helper()
+	const (
+		yesterday = "2026-08-30"
+		cards     = 400
+	)
+	remote := gitRemoteN(t, name)
+	r, err := gitstore.Init(memory.NewStorage(), gitstore.Options{Committer: gitstore.Identity{Name: "aeman", Email: "a@x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []gitstore.FileWrite{
+		{Path: gitstore.BoardPath, Data: []byte("schema: 1\ntitle: t\n")},
+		{Path: gitstore.TeamPath("01JB4TEAM"), Data: []byte("name: portal\nrank: b\ncreated: 2026-06-01T08:00:00Z\nsprint:\n  current: " + yesterday + "\n")},
+	}
+	for i := range cards {
+		id := fmt.Sprintf("01CARRY%017d", i)
+		p, err := gitstore.CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, gitstore.FileWrite{Path: p, Data: []byte(fmt.Sprintf(
+			"---\ntitle: card %d\nteam: portal\nassignees:\n  - kvaps\nsprint: %s\nstart: %s\nday: %s\nprogress: 30\nrank: a%05d\ncreated: 2026-08-20T09:00:00Z\n---\n",
+			i, yesterday, yesterday, yesterday, i))})
+	}
+	if _, err := r.Commit(gitstore.Action{Name: "import", Summary: "seed"}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Push(context.Background(), remote); err != nil {
+		t.Fatal(err)
+	}
+	srv := gitModeServer(t, remote)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	srv.store.waitDrained(ctx)
+
+	// The views a team keeps open on a planning morning: the grid, the plan
+	// and people's own boards — every one of them scoped.
+	key := storeKey(srv.boardRef(nil))
+	sels := []apiserver.Selector{
+		{View: "team", Team: "portal"},
+		{View: "me", User: "kvaps"},
+		{View: "weekly", Team: "portal"},
+	}
+	var frames atomic.Int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := range tabs {
+		sel := sels[i%len(sels)]
+		sub, cancelSub := srv.store.subscribe(key, fmt.Sprintf("tab-%d", i), &sel,
+			map[string]bool{"cards": true, "sprints": true})
+		defer cancelSub()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-sub.ch:
+					frames.Add(1)
+				case <-stop:
+					return
+				}
+			}
+		}()
+	}
+
+	started := time.Now()
+	rec := do(t, srv, http.MethodPost, "/api/v1/sprints/actions/carry-over", `{"team":"portal"}`)
+	took := time.Since(started)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("carry-over: %d %s", rec.Code, rec.Body.String())
+	}
+	srv.store.waitDrained(ctx)
+	time.Sleep(200 * time.Millisecond) // let the tabs finish reading
+	close(stop)
+	wg.Wait()
+	return took, frames.Load()
+}

--- a/internal/server/idlecost_test.go
+++ b/internal/server/idlecost_test.go
@@ -315,8 +315,25 @@ func TestAPersonNobodyHasAskedAboutIsAskedAbout(t *testing.T) {
 	if calls.Load() != 2 {
 		t.Fatalf("%d listings, want 2 — the second for the login never seen", calls.Load())
 	}
-	// …and once the forge has answered, the answer stands.
-	if got, err := fa.readers(ctx, "shared", []string{"kvaps", "lex"}); err != nil || len(got) != 2 {
-		t.Fatalf("the settled answer: %v, %v", got, err)
+	// …and once the forge has ANSWERED, the answer stands. The listing call
+	// is counted when it is made, and the answer is recorded when it comes
+	// back: in between, the login is one the server has asked about and has
+	// no answer for, which is deliberately not offered — so settle first.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := fa.readers(ctx, "shared", []string{"kvaps", "lex"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the settled answer: %v", got)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("%d listings; settling must not have asked again", n)
 	}
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1158,22 +1158,6 @@ export function App() {
             className="sync-badge"
             title={`${pendingSync} change(s) applied but not yet committed`}
           >
-            <svg
-              width="11"
-              height="11"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M21 2v6h-6" />
-              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-              <path d="M3 22v-6h6" />
-              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-            </svg>
             {pendingSync}
           </span>
         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -631,16 +631,6 @@ select {
   font-variant-numeric: tabular-nums;
 }
 
-.sync-badge svg {
-  animation: sync-badge-spin 1.8s linear infinite;
-}
-
-@keyframes sync-badge-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .sync-badge + .segmented {
   margin-left: 8px;
 }


### PR DESCRIPTION
A scoped subscription — a team grid, a Me board, the weekly plan — has to know whether a changed card entered or left its view. It asked that card by card: `FilterCards` built the whole view again, sorted and projected, to look for one uid.

A carry-over moves hundreds of cards, so a morning's twenty open tabs turned one button into thousands of full board views, under the lock every read waits on. On the production board that was three and a half minutes with the whole board queued behind it, the CPU pinned and memory climbing towards an OOM.

The question is now answered once for a burst of changes: one view per subscription, diffed against what it held, emitting the same ADDED / MODIFIED / DELETED frames. The window follows what a fan-out actually costs, so a bigger board paces itself rather than spending the machine on repainting. Unscoped subscriptions are unchanged — they still hear each change as it lands.

Measured on a board of 400 cards: one tab 446ms → 19ms, twelve tabs 3.6s → 27ms. The regression test states it as a ratio (opening more boards must not make a carry-over cost more), so it holds on any machine.

Also in here: the sync badge in the toolbar is just the number now, without the spinning arrows; and a flaky test from the previous change (it read the forge's answer before it had landed) waits properly.