### PR TITLE
fix(ui): drop the loading bar, keep the sync badge turning

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1070,9 +1070,6 @@ export function App() {
 
   return (
     <div className="app">
-      {loading && (
-        <div className="loading-bar" role="progressbar" aria-label="Loading data" />
-      )}
       <header className="app-header">
         <div className="brand">
           <Logo className="brand-logo" />
@@ -1158,6 +1155,22 @@ export function App() {
             className="sync-badge"
             title={`${pendingSync} change(s) applied but not yet committed`}
           >
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M21 2v6h-6" />
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+              <path d="M3 22v-6h6" />
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+            </svg>
             {pendingSync}
           </span>
         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -336,39 +336,6 @@ select {
   border-bottom: 1px solid var(--line);
 }
 
-/* Thin indeterminate progress bar pinned to the top edge while data loads.
-   Fixed and pointer-events-free, so it never displaces or blocks content. */
-.loading-bar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: 200;
-}
-
-.loading-bar::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 35%;
-  border-radius: 999px;
-  background: var(--accent);
-  animation: loading-bar-slide 1.1s ease-in-out infinite;
-}
-
-@keyframes loading-bar-slide {
-  0% {
-    left: -35%;
-  }
-  100% {
-    left: 100%;
-  }
-}
-
 .brand {
   display: flex;
   align-items: center;
@@ -629,6 +596,16 @@ select {
   font-weight: 600;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+}
+
+.sync-badge svg {
+  animation: sync-badge-spin 1.8s linear infinite;
+}
+
+@keyframes sync-badge-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .sync-badge + .segmented {


### PR DESCRIPTION
The thin indeterminate bar slid across the top of the page on every fetch — every day flip, every re-list, every reload — and a blink at the top edge reads as something being wrong rather than as work in progress.

It goes. What the board owes the server is already said where it belongs: the number of unsynced changes beside the view switch, with its turning arrows (those stay — an earlier change had taken them off, which was not the ask).

The "Loading…" placeholder on a board that has not arrived yet is untouched.