### PR TITLE
feat(ui): the board says when it is waiting on an answer

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,11 @@ import { nameConflict } from "./names";
 import { AppearanceMenu } from "./components/AppearanceMenu";
 import { applyAppearance, persistAppearance, readAppearance, type Appearance } from "./theme";
 
+// waitingAfterMs is how long a request may take before the board says it is
+// waiting. Below it nothing is shown: the answer arrives before the eye
+// would settle on the indicator anyway.
+const waitingAfterMs = 300;
+
 // SNAPSHOT_FROZEN is what a write attempt on a past day says. The day is
 // over: its board is a picture, and today's board is one click away.
 const SNAPSHOT_FROZEN =
@@ -220,14 +225,28 @@ export function App() {
   // The forge (GitHub / GitLab) spells the sign-in and token copy; before the
   // config answers, and on an older server, that is GitHub.
   const forge = useMemo(() => forgeCopy(config), [config]);
-  // Count of in-flight data loads (initial load + per-view card fetches);
-  // any of them showing keeps the top progress bar visible.
+  // Count of in-flight data loads (initial load + per-view card fetches, plus
+  // the slow actions the boards wrap in trackLoad); any of them showing is
+  // what the waiting mark beside the view switch reports.
   const [pendingLoads, setPendingLoads] = useState(0);
   const loading = pendingLoads > 0;
+  // waiting is `loading` that has LASTED: a request answered in a blink shows
+  // nothing at all. The old bar across the top appeared for every fetch,
+  // however short, and a flash at the edge of the screen reads as something
+  // being wrong rather than as work in progress.
+  const [waiting, setWaiting] = useState(false);
+  useEffect(() => {
+    if (!loading) {
+      setWaiting(false);
+      return;
+    }
+    const t = window.setTimeout(() => setWaiting(true), waitingAfterMs);
+    return () => window.clearTimeout(t);
+  }, [loading]);
   const beginLoad = useCallback(() => setPendingLoads((n) => n + 1), []);
   const endLoad = useCallback(() => setPendingLoads((n) => n - 1), []);
   // Boards wrap their slow server calls (carry over etc.) with this so the
-  // progress bar covers the operation itself, not just the refetch after it.
+  // waiting mark covers the operation itself, not just the refetch after it.
   const trackLoad = useCallback(
     <T,>(p: Promise<T>): Promise<T> => {
       beginLoad();
@@ -1301,6 +1320,22 @@ export function App() {
           </span>
         )}
 
+        {pendingSync === 0 && waiting && (
+          <span className="load-badge" title="Loading…" role="status" aria-label="Loading">
+            <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true">
+              <circle
+                cx="12"
+                cy="12"
+                r="9"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeDasharray="14 42"
+              />
+            </svg>
+          </span>
+        )}
         {pendingSync > 0 && (
           <span
             className="sync-badge"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -608,6 +608,32 @@ select {
   }
 }
 
+/* The browser waiting on an answer — the same corner as the sync badge and
+   deliberately not the same thing: no pill, no count, a thin ring that turns.
+   The sync badge says the SERVER owes writes; this says this tab asked and is
+   still listening. */
+.load-badge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  margin-bottom: 4px;
+  padding: 0 4px;
+  color: var(--muted);
+  opacity: 0.75;
+}
+
+.load-badge svg {
+  animation: load-badge-spin 0.9s linear infinite;
+}
+
+@keyframes load-badge-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.load-badge + .segmented,
 .sync-badge + .segmented {
   margin-left: 8px;
 }


### PR DESCRIPTION
The loading bar went because it flashed across the top of the page on every fetch, however short, and a blink at the edge of the screen reads as an alarm rather than as work in progress. But a board that is genuinely fetching — a day flipped far back, a carry-over, a cold load — should say so.

It now says so where the sync badge sits, and deliberately not in the same shape:

- the **sync badge** counts what the SERVER still owes — a pill with the turning arrows and a number of unsynced writes;
- the **waiting ring** is a thin turning ring with no count, saying only that this tab asked and is still listening.

The two never show at once: unsynced writes are the more interesting fact.

And the ring waits 300 ms before it appears, so a request that answers at once shows nothing at all — which is exactly what made the old bar noise. It covers the initial load, every view and day change, and the slow actions the boards wrap (carry over and the like).