### PR TITLE
fix(asof): reading a day costs the day, not the board on every commit

### DIFF
--- a/internal/server/asof_delete_test.go
+++ b/internal/server/asof_delete_test.go
@@ -54,21 +54,24 @@ func TestADeletedCardStandsOnTheDayItWasWorked(t *testing.T) {
 		}
 		return when
 	}
-	commit := func(iso, summary string, writes ...gitstore.FileWrite) {
+	// Every commit names the cards it touched, as the server's own do: that
+	// is what a day reads to find what it removed.
+	commit := func(iso, summary string, ids []string, writes ...gitstore.FileWrite) {
 		t.Helper()
-		if _, err := r.Commit(gitstore.Action{Name: "write", Summary: summary, At: at(iso)}, writes); err != nil {
+		if _, err := r.Commit(gitstore.Action{Name: "write", Actor: "kvaps", Cards: ids,
+			Summary: summary, At: at(iso)}, writes); err != nil {
 			t.Fatal(err)
 		}
 	}
-	commit("2026-08-24T08:00:00Z", "the sprint opens",
+	commit("2026-08-24T08:00:00Z", "the sprint opens", []string{gone, kept},
 		gitstore.FileWrite{Path: gitstore.BoardPath, Data: []byte("schema: 1\ntitle: t\n")},
 		team(day, prev),
 		card(gone, 40), card(kept, 40))
-	commit("2026-08-24T15:00:00Z", "done", card(gone, 100))
+	commit("2026-08-24T15:00:00Z", "done", []string{gone}, card(gone, 100))
 	// The × takes it off the board: the file goes (a write with no data).
-	commit("2026-08-24T15:05:00Z", "the × takes it off", gitstore.FileWrite{Path: path(gone)})
-	commit("2026-08-24T18:00:00Z", "still going", card(kept, 60))
-	commit("2026-08-31T09:00:00Z", "a new sprint", team("2026-08-31", day))
+	commit("2026-08-24T15:05:00Z", "the × takes it off", []string{gone}, gitstore.FileWrite{Path: path(gone)})
+	commit("2026-08-24T18:00:00Z", "still going", []string{kept}, card(kept, 60))
+	commit("2026-08-31T09:00:00Z", "a new sprint", nil, team("2026-08-31", day))
 	if err := r.Push(context.Background(), remote); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/gitstore/asof.go
+++ b/pkg/gitstore/asof.go
@@ -2,10 +2,10 @@ package gitstore
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/go-git/go-git/v5/utils/merkletrie"
 
 	"github.com/aenix-io/aeman/pkg/board"
 )
@@ -60,9 +60,15 @@ func LoadAsOf(r *Repo, at time.Time) (Snapshot, bool, error) {
 // A day is everything that stood on it. The × takes a card off the board and
 // the file goes, so a card worked and tidied away the same day is absent from
 // the tree the day ended with; reading only that tree loses exactly the work
-// the day is remembered for. Every card the day removed is read back from the
-// commit that removed it — its last state, done if that is how it went — and
-// a card removed and then made again is left to the tree, which has it.
+// the day is remembered for.
+//
+// What the day removed is read from what is already written down rather than
+// from comparing trees: every commit NAMES the cards it touched (the
+// Aeman-Cards trailer), and the two snapshots the day is bounded by say what
+// it began and ended with. Only the few cards that actually went are looked
+// up in a tree. The first version diffed every commit of the day against its
+// parent, which on a board of 2400 cards and three hundred commits a day cost
+// 75 seconds per request — the board hung on every past day.
 //
 // `from` is the previous day's last moment and `to` this one's. ok follows
 // LoadAsOf: false when the day is behind the clone's horizon.
@@ -75,107 +81,127 @@ func LoadAsOfDay(r *Repo, from, to time.Time) (Snapshot, bool, error) {
 	for _, c := range s.Cards {
 		held[c.ItemID] = true
 	}
-	gone, err := cardsRemovedBetween(r, from, to)
+	gone, err := cardsRemovedBetween(r, from, to, held)
 	if err != nil {
 		return Snapshot{}, false, err
 	}
-	for _, c := range gone {
-		if held[c.ItemID] {
-			continue
-		}
-		held[c.ItemID] = true
-		s.Cards = append(s.Cards, c)
-	}
+	s.Cards = append(s.Cards, gone...)
 	return s, true, nil
 }
 
-// cardsRemovedBetween reads every card whose file a commit in (from, to]
-// deleted, in the state that commit's parent held — walking the day newest
-// first, so a card deleted more than once is read as it went the last time.
-func cardsRemovedBetween(r *Repo, from, to time.Time) ([]board.Card, error) {
-	var out []board.Card
-	seen := map[string]bool{}
+// cardsRemovedBetween reads every card that stood on the day and is not on
+// its last tree — the ones the day removed — in the state each was in when it
+// went. `held` is what the day ended with.
+func cardsRemovedBetween(r *Repo, from, to time.Time, held map[string]bool) ([]board.Card, error) {
+	day, touched, err := commitsOfDay(r, from, to)
+	if err != nil {
+		return nil, err
+	}
+	// What the day BEGAN with: a writer that leaves no trailers still shows
+	// up here, as a card present at the start and absent at the end.
+	began, ok, err := LoadAsOf(r, from)
+	if err != nil {
+		return nil, err
+	}
+	start := map[string]board.Card{}
+	if ok {
+		for _, c := range began.Cards {
+			start[c.ItemID] = c
+		}
+	}
+
+	ids := make([]string, 0, len(touched))
+	for id := range touched {
+		if !held[id] {
+			ids = append(ids, id)
+		}
+	}
+	for id := range start {
+		if _, named := touched[id]; !held[id] && !named {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids) // a stable answer; the caller sorts by rank anyway
+
+	out := make([]board.Card, 0, len(ids))
+	for _, id := range ids {
+		c, found, err := lastStateInDay(id, day, touched[id])
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			// Never written during the day: it went with the day's first
+			// commit, and the state it went in is the one the day began with.
+			if was, ok := start[id]; ok {
+				out = append(out, was)
+			}
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// commitsOfDay is the day's commits, newest first, and the cards they name:
+// every commit says which cards it touched (the Aeman-Cards trailer), so the
+// ones that left are found without opening a single tree.
+func commitsOfDay(r *Repo, from, to time.Time) ([]*object.Commit, map[string]int, error) {
+	var day []*object.Commit
+	touched := map[string]int{}
 	h := r.Head()
 	for !h.IsZero() {
 		c, err := object.GetCommit(r.s, h)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !c.Committer.When.After(from) {
-			return out, nil // back at the day's start
-		}
-		if c.NumParents() == 0 {
-			return out, nil
-		}
-		parent, err := c.Parent(0)
-		if err != nil {
-			return nil, err
+			break // back at the day's start
 		}
 		if !c.Committer.When.After(to) {
-			removed, err := cardsRemovedBy(parent, c)
-			if err != nil {
-				return nil, err
-			}
-			for _, card := range removed {
-				if seen[card.ItemID] {
-					continue
+			for _, id := range ParseTrailers(c.Message).Cards {
+				if _, seen := touched[id]; !seen {
+					touched[id] = len(day)
 				}
-				seen[card.ItemID] = true
-				out = append(out, card)
 			}
+			day = append(day, c)
+		}
+		if c.NumParents() == 0 {
+			break
 		}
 		h = c.ParentHashes[0]
 	}
-	return out, nil
+	return day, touched, nil
 }
 
-// cardsRemovedBy is the cards a commit deleted, read from the tree it was
-// made on. Only card files count: a roster entry is not a card, and a
-// changed file is not a removed one.
-func cardsRemovedBy(parent, c *object.Commit) ([]board.Card, error) {
-	before, err := parent.Tree()
+// lastStateInDay reads a card's last state inside the day: the newest commit
+// of it whose tree still holds the file. The search starts at the commit that
+// last NAMED the card — which is the one that removed it, whose own tree no
+// longer has it and whose neighbour below does — so it opens a tree or two
+// rather than the day's worth.
+func lastStateInDay(id string, day []*object.Commit, at int) (board.Card, bool, error) {
+	p, err := CardPath(id)
 	if err != nil {
-		return nil, err
+		return board.Card{}, false, err
 	}
-	after, err := c.Tree()
-	if err != nil {
-		return nil, err
-	}
-	changes, err := object.DiffTree(before, after)
-	if err != nil {
-		return nil, err
-	}
-	var out []board.Card
-	for _, ch := range changes {
-		action, err := ch.Action()
+	for i := at; i < len(day); i++ {
+		f, err := day[i].File(p)
 		if err != nil {
-			return nil, err
-		}
-		if action != merkletrie.Delete {
-			continue
-		}
-		kind, parts := ParsePath(ch.From.Name)
-		if kind != PathCard {
-			continue
-		}
-		id := parts[0]
-		f, err := before.File(ch.From.Name)
-		if err != nil {
-			if errors.Is(err, object.ErrFileNotFound) {
+			if errors.Is(err, object.ErrFileNotFound) || errors.Is(err, object.ErrDirectoryNotFound) {
 				continue
 			}
-			return nil, err
+			return board.Card{}, false, err
 		}
 		data, err := f.Contents()
 		if err != nil {
-			return nil, err
+			return board.Card{}, false, err
 		}
 		card, err := DecodeCard(id, []byte(data))
 		if err != nil {
-			// A file the decoder cannot read is not a card anyone saw.
-			continue
+			// A file the decoder cannot read is not a card anyone saw; the
+			// day answers without it rather than failing over one bad file.
+			return board.Card{}, false, nil //nolint:nilerr // deliberate
 		}
-		out = append(out, card.Card)
+		return card.Card, true, nil
 	}
-	return out, nil
+	return board.Card{}, false, nil
 }

--- a/pkg/gitstore/asofday_cost_test.go
+++ b/pkg/gitstore/asofday_cost_test.go
@@ -1,0 +1,129 @@
+package gitstore
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+// counting is a storer that says how many objects were read through it.
+type counting struct {
+	*memory.Storage
+	reads int
+}
+
+func (c *counting) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	c.reads++
+	return c.Storage.EncodedObject(t, h)
+}
+
+var _ storer.EncodedObjectStorer = (*counting)(nil)
+
+// Reading a day must not cost the whole board, once per commit. The first
+// version of LoadAsOfDay diffed every commit of the day against its parent to
+// find what the day removed: on the production board — 2400 cards, some three
+// hundred commits a day — that walked millions of objects and took 75 seconds
+// per request, with the day's three requests (cards, board, sprints) each
+// paying it in parallel. The board hung on every past day until it was rolled
+// back.
+//
+// The answer comes from what the commits already say (their trailers name the
+// cards they touched) and from the two snapshots the day is bounded by, so the
+// tree is walked for the few cards that actually went — not for every card on
+// every commit. This pins that: the reads must stay far below "a tree per
+// commit", and the bound is generous enough to survive an honest refactor.
+func TestReadingADayDoesNotCostTheWholeBoardPerCommit(t *testing.T) {
+	store := &counting{Storage: memory.NewStorage()}
+	r, err := Init(store, Options{Committer: Identity{Name: "aeman", Email: "a@x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := func(iso string) time.Time {
+		when, err := time.Parse(time.RFC3339, iso)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return when
+	}
+	// A board of some size: 300 cards, spread across the shards.
+	const cards = 300
+	ids := make([]string, cards)
+	writes := make([]FileWrite, 0, cards+1)
+	writes = append(writes, FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t\n")})
+	for i := range cards {
+		id := fmt.Sprintf("01CARD%020d", i)
+		ids[i] = id
+		p, err := CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writes = append(writes, FileWrite{Path: p, Data: fmt.Appendf(nil,
+			"---\ntitle: card %d\nteam: portal\nstart: 2026-08-20\nday: 2026-08-20\nprogress: 10\nrank: a\ncreated: 2026-08-20T09:00:00Z\n---\n", i)})
+	}
+	if _, err := r.Commit(Action{Name: "import", Summary: "the board", At: at("2026-08-20T09:00:00Z")}, writes); err != nil {
+		t.Fatal(err)
+	}
+
+	// A day of ordinary work: one commit per action, as the server writes
+	// them, and one × among them.
+	const commits = 120
+	for i := range commits {
+		id := ids[i%cards]
+		p, err := CardPath(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		when := at("2026-08-21T09:00:00Z").Add(time.Duration(i) * time.Minute)
+		if _, err := r.Commit(Action{Name: "progress", Actor: "kvaps", Cards: []string{id},
+			Summary: "set progress", At: when}, []FileWrite{{Path: p, Data: fmt.Appendf(nil,
+			"---\ntitle: card %d\nteam: portal\nstart: 2026-08-20\nday: 2026-08-20\nprogress: %d\nrank: a\ncreated: 2026-08-20T09:00:00Z\n---\n",
+			i%cards, 20+i%70)}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The × takes one card off, mid-day.
+	gone := ids[7]
+	goneP, err := CardPath(gone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Commit(Action{Name: "delete", Actor: "kvaps", Cards: []string{gone},
+		Summary: "take it off the board", At: at("2026-08-21T15:00:00Z")}, []FileWrite{{Path: goneP}}); err != nil {
+		t.Fatal(err)
+	}
+	// And the next day happens, so the 21st is a day gone by.
+	if _, err := r.Commit(Action{Name: "progress", Actor: "kvaps", Cards: []string{ids[0]},
+		Summary: "next day", At: at("2026-08-22T09:00:00Z")}, []FileWrite{{Path: writes[1].Path, Data: writes[1].Data}}); err != nil {
+		t.Fatal(err)
+	}
+
+	store.reads = 0
+	s, ok, err := LoadAsOfDay(r, endOf(t, "2026-08-20"), endOf(t, "2026-08-21"))
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	reads := store.reads
+
+	// The day still answers: the card the × took off is on it.
+	found := false
+	for _, c := range s.Cards {
+		if c.ItemID == gone {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the day gives back what it removed")
+	}
+
+	// Two snapshots of a 300-card board plus a walk of 120 commits is a few
+	// thousand objects. A tree per commit is a hundred thousand.
+	const bound = 12000
+	if reads > bound {
+		t.Fatalf("reading one day read %d objects; more than %d means the cost grew with the board on every commit", reads, bound)
+	}
+	t.Logf("objects read for one day: %d", reads)
+}

--- a/pkg/gitstore/asofday_test.go
+++ b/pkg/gitstore/asofday_test.go
@@ -37,20 +37,23 @@ func TestADayGivesBackWhatItRemoved(t *testing.T) {
 		}
 		return when
 	}
-	commit := func(iso string, writes ...FileWrite) {
+	// Every commit NAMES the cards it touched, as the server's do: that is
+	// what the day reads to find what it removed.
+	commit := func(iso string, ids []string, writes ...FileWrite) {
 		t.Helper()
-		if _, err := r.Commit(Action{Name: "write", Summary: "w", At: at(iso)}, writes); err != nil {
+		if _, err := r.Commit(Action{Name: "write", Actor: "kvaps", Cards: ids,
+			Summary: "w", At: at(iso)}, writes); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// The day before: both cards stand.
-	commit("2026-08-20T09:00:00Z", card(gone, 30), card(kept, 30))
+	commit("2026-08-20T09:00:00Z", []string{gone, kept}, card(gone, 30), card(kept, 30))
 	// The day itself: one is finished, then taken off; the other works on.
-	commit("2026-08-21T14:00:00Z", card(gone, 100))
-	commit("2026-08-21T14:05:00Z", FileWrite{Path: path(gone)}) // the ×
-	commit("2026-08-21T18:00:00Z", card(kept, 60))
+	commit("2026-08-21T14:00:00Z", []string{gone}, card(gone, 100))
+	commit("2026-08-21T14:05:00Z", []string{gone}, FileWrite{Path: path(gone)}) // the ×
+	commit("2026-08-21T18:00:00Z", []string{kept}, card(kept, 60))
 	// And a later day, so the 21st is a day gone by.
-	commit("2026-08-22T10:00:00Z", card(kept, 90))
+	commit("2026-08-22T10:00:00Z", []string{kept}, card(kept, 90))
 
 	s, ok, err := LoadAsOfDay(r, endOf(t, "2026-08-20"), endOf(t, "2026-08-21"))
 	if err != nil {
@@ -85,7 +88,7 @@ func TestADayGivesBackWhatItRemoved(t *testing.T) {
 
 	// A card removed on a LATER day is simply there on this one — the tree
 	// of the day holds it and nothing needs giving back.
-	commit("2026-08-23T09:00:00Z", FileWrite{Path: path(kept)})
+	commit("2026-08-23T09:00:00Z", []string{kept}, FileWrite{Path: path(kept)})
 	s, ok, err = LoadAsOfDay(r, endOf(t, "2026-08-21"), endOf(t, "2026-08-22"))
 	if err != nil || !ok {
 		t.Fatalf("the 22nd: ok=%v err=%v", ok, err)
@@ -122,9 +125,10 @@ func TestADayGivesBackACardItBothMadeAndRemoved(t *testing.T) {
 		}
 		return when
 	}
-	write := func(iso string, w FileWrite) {
+	write := func(iso string, ids []string, w FileWrite) {
 		t.Helper()
-		if _, err := r.Commit(Action{Name: "write", Summary: "w", At: at(iso)}, []FileWrite{w}); err != nil {
+		if _, err := r.Commit(Action{Name: "write", Actor: "kvaps", Cards: ids,
+			Summary: "w", At: at(iso)}, []FileWrite{w}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -133,12 +137,12 @@ func TestADayGivesBackACardItBothMadeAndRemoved(t *testing.T) {
 			strconv.Itoa(progress) + "\nrank: a\ncreated: 2026-08-21T10:00:00Z\n---\n")
 	}
 	// The day before knows nothing of it.
-	write("2026-08-20T09:00:00Z", FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t\n")})
+	write("2026-08-20T09:00:00Z", nil, FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t\n")})
 	// Made, worked and taken off, all on the 21st.
-	write("2026-08-21T10:00:00Z", FileWrite{Path: p, Data: body(0)})
-	write("2026-08-21T16:00:00Z", FileWrite{Path: p, Data: body(100)})
-	write("2026-08-21T16:05:00Z", FileWrite{Path: p})
-	write("2026-08-22T09:00:00Z", FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t2\n")})
+	write("2026-08-21T10:00:00Z", []string{id}, FileWrite{Path: p, Data: body(0)})
+	write("2026-08-21T16:00:00Z", []string{id}, FileWrite{Path: p, Data: body(100)})
+	write("2026-08-21T16:05:00Z", []string{id}, FileWrite{Path: p})
+	write("2026-08-22T09:00:00Z", nil, FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t2\n")})
 
 	s, ok, err := LoadAsOfDay(r, endOf(t, "2026-08-20"), endOf(t, "2026-08-21"))
 	if err != nil || !ok {
@@ -167,4 +171,53 @@ func TestADayGivesBackACardItBothMadeAndRemoved(t *testing.T) {
 			t.Fatal("the card did not exist yet on the 20th")
 		}
 	}
+}
+
+// A tool writing the repository directly may leave no trailers — the layout
+// is public and nothing forces them (docs/design/plugin-impact.md). A card it
+// removes is still given back when the day BEGAN with it: the day is bounded
+// by two snapshots, and a card in the first and not in the second went during
+// it. What such a writer can hide is only a card it both made and removed
+// inside one day, which stood on no board anyone opened for long.
+func TestADayGivesBackWhatAToolRemovedWithoutSayingSo(t *testing.T) {
+	r := newRepo(t)
+	const id = "01CARD00000000000000000004"
+	p, err := CardPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := func(iso string) time.Time {
+		when, err := time.Parse(time.RFC3339, iso)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return when
+	}
+	// No Cards, no Actor: a bare commit, as another tool would make it.
+	bare := func(iso string, w FileWrite) {
+		t.Helper()
+		if _, err := r.Commit(Action{Name: "write", Summary: "by another tool", At: at(iso)},
+			[]FileWrite{w}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bare("2026-08-20T08:00:00Z", FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t\n")})
+	bare("2026-08-20T09:00:00Z", FileWrite{Path: p, Data: []byte(
+		"---\ntitle: a card\nteam: portal\nstart: 2026-08-20\nday: 2026-08-20\nprogress: 70\nrank: a\ncreated: 2026-08-20T09:00:00Z\n---\n")})
+	bare("2026-08-21T11:00:00Z", FileWrite{Path: p})
+	bare("2026-08-22T09:00:00Z", FileWrite{Path: BoardPath, Data: []byte("schema: 1\ntitle: t\n")})
+
+	s, ok, err := LoadAsOfDay(r, endOf(t, "2026-08-20"), endOf(t, "2026-08-21"))
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	for _, c := range s.Cards {
+		if c.ItemID == id {
+			if c.Progress != 70 {
+				t.Fatalf("the card stood at 70%% when it went, given back at %d%%", c.Progress)
+			}
+			return
+		}
+	}
+	t.Fatal("the day began with the card and ended without it: the day gives it back")
 }


### PR DESCRIPTION
A regression from #156, found in production within minutes of the deploy and rolled back: **every past day on the Me and Team boards hung**. The spinner never stopped because each of the day's three requests took over a minute — `/cards` 1m18s, `/board` 1m13s, `/sprints` 1m14s — and they run in parallel, so the cache none of them lived to fill saved nobody.

## What was wrong

To give a day back what it removed, `LoadAsOfDay` diffed **every commit of the day against its parent**. On the production board — 2400 cards, some three hundred commits a day — that walks millions of objects.

## What it does now

The answer is already written down:

- every commit **names the cards it touched** (the `Aeman-Cards` trailer), so the candidates come from reading messages the walk loads anyway;
- the two snapshots the day is **bounded by** say what it began and ended with, which catches a writer that leaves no trailers at all;
- a tree is opened only for the few cards that actually went, starting at the commit that last named one — its neighbour below holds the state the card went in.

Measured on the production board, the same day that hung: **1.3s cold, 0.01s from the cache.** On the test fixture, object reads went from 32850 to 1084.

The one thing a trailer-less writer can now hide is a card it both made and removed inside a single day; such a card stood on no board anyone opened for long, and `TestADayGivesBackWhatAToolRemovedWithoutSayingSo` pins what is still covered.

## Testing

The cost is a test now, which is what was missing: `TestReadingADayDoesNotCostTheWholeBoardPerCommit` counts objects read through a counting storer and fails if reading one day approaches a tree per commit. The day tests keep their fixtures honest — commits name their cards, as the server's own do. `make lint`, `go test ./...`, `npm test` and `tsc -b` are clean.
