### PR TITLE
perf(asof): a past day costs its own day, not the whole history

### DIFF
--- a/internal/server/asofcache.go
+++ b/internal/server/asofcache.go
@@ -34,10 +34,47 @@ type asOfCache struct {
 	// deepened is when the history was last pulled for a day it did not
 	// reach, by that day's boundary.
 	deepened map[string]time.Time
+	// flying are the reads under way, by key. Flipping to a day fires THREE
+	// requests at once — the cards, the roster and the sprint pointers — and
+	// each of them missed the cache the others had not filled yet, so a cold
+	// day was read three times over, in parallel, for one answer.
+	flying map[string]*flight
+}
+
+// flight is one read others wait on: the first caller does the work and the
+// rest take its answer.
+type flight struct {
+	done chan struct{}
+	bd   board.Board
+	ok   bool
+	err  error
 }
 
 func newAsOfCache() *asOfCache {
-	return &asOfCache{kept: map[string]board.Board{}, deepened: map[string]time.Time{}}
+	return &asOfCache{kept: map[string]board.Board{}, deepened: map[string]time.Time{},
+		flying: map[string]*flight{}}
+}
+
+// begin joins the read of `key`: it returns the flight to wait on when one is
+// already under way, or the one to DO (mine) otherwise.
+func (c *asOfCache) begin(key string) (f *flight, mine bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if f, ok := c.flying[key]; ok {
+		return f, false
+	}
+	f = &flight{done: make(chan struct{})}
+	c.flying[key] = f
+	return f, true
+}
+
+// finish hands the answer to everyone waiting on it.
+func (c *asOfCache) finish(key string, f *flight, bd board.Board, ok bool, err error) {
+	c.mu.Lock()
+	delete(c.flying, key)
+	c.mu.Unlock()
+	f.bd, f.ok, f.err = bd, ok, err
+	close(f.done)
 }
 
 // get returns a kept board for the key, if there is one.

--- a/internal/server/asofflight_test.go
+++ b/internal/server/asofflight_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/aenix-io/aeman/pkg/board"
+)
+
+// Flipping to a past day fires three requests at once — the cards, the roster
+// and the sprint pointers — and each of them missed a cache the others had not
+// filled yet, so one cold day was read three times over, in parallel, for one
+// answer. The first read is the one the others wait on.
+func TestOneColdDayIsReadOnceForEveryoneAskingAtOnce(t *testing.T) {
+	c := newAsOfCache()
+	const key = "day\x00a-day"
+	answer := board.Board{Board: "acme"}
+
+	var reads int
+	var mu sync.Mutex
+	// The read is under way until the test lets it finish, which is what a
+	// cold day is: slow enough for the others to arrive while it runs.
+	release := make(chan struct{})
+	var arrived, done sync.WaitGroup
+	got := make([]board.Board, 8)
+
+	for i := range got {
+		arrived.Add(1)
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			fl, mine := c.begin(key)
+			arrived.Done()
+			if !mine {
+				<-fl.done
+				got[i] = fl.bd
+				return
+			}
+			mu.Lock()
+			reads++
+			mu.Unlock()
+			<-release
+			c.finish(key, fl, answer, true, nil)
+			got[i] = answer
+		}()
+	}
+	arrived.Wait() // everyone has asked
+	close(release) // now the one read finishes
+	done.Wait()
+
+	if reads != 1 {
+		t.Fatalf("%d reads for one day asked for by eight callers at once", reads)
+	}
+	for i, bd := range got {
+		if bd.Board != "acme" {
+			t.Fatalf("caller %d got %+v, want the answer the flight carried", i, bd)
+		}
+	}
+	// And nothing is left in flight afterwards.
+	if _, mine := c.begin(key); !mine {
+		t.Fatal("a finished flight is still held")
+	}
+}

--- a/internal/server/gitsync.go
+++ b/internal/server/gitsync.go
@@ -642,11 +642,30 @@ func (b *storeBackend) loadPast(ctx context.Context, kind string, at time.Time,
 	}
 	// A date flip reads the same day three times (cards, sprints, roster),
 	// and each read is a commit walk plus a full parse of every tree. The
-	// answer is kept until a commit lands.
+	// answer is kept until a commit lands — and the three arrive together,
+	// so the first read is the one the other two wait on rather than repeat.
 	key := kind + "\x00" + b.git.asOfKey(at)
 	if bd, kept := b.git.asOf.get(key); kept {
 		return bd, true, nil
 	}
+	fl, mine := b.git.asOf.begin(key)
+	if !mine {
+		select {
+		case <-fl.done:
+			return fl.bd, fl.ok, fl.err
+		case <-ctx.Done():
+			return board.Board{}, false, ctx.Err()
+		}
+	}
+	bd, ok, err := b.readPast(ctx, key, at, load)
+	b.git.asOf.finish(key, fl, bd, ok, err)
+	return bd, ok, err
+}
+
+// readPast is loadPast's own work, once the flight is ours: the cache, the
+// deepen-once pacing and the second try.
+func (b *storeBackend) readPast(ctx context.Context, key string, at time.Time,
+	load func(context.Context) (board.Board, bool, error)) (board.Board, bool, error) {
 	bd, ok, err := load(ctx)
 	if err != nil {
 		return bd, ok, err

--- a/pkg/gitstore/asof.go
+++ b/pkg/gitstore/asof.go
@@ -3,8 +3,10 @@ package gitstore
 import (
 	"errors"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/aenix-io/aeman/pkg/board"
@@ -22,33 +24,54 @@ import (
 // the board's first commit is not that case: the board existed and was
 // empty, and that is an answer.
 func LoadAsOf(r *Repo, at time.Time) (Snapshot, bool, error) {
+	h, ok, err := commitAsOf(r, at)
+	if err != nil || !ok {
+		return Snapshot{}, ok, err
+	}
+	if h.IsZero() {
+		// Before the board's first commit: it existed and was empty.
+		return Snapshot{}, true, nil
+	}
+	s, err := LoadAt(r, h)
+	return s, err == nil, err
+}
+
+// commitAsOf is the newest commit made at or before `at`. A zero hash with ok
+// means the board had not begun yet; ok is false when the answer is behind the
+// clone's horizon. The walk starts at the closest moment already resolved
+// (r.asOfStart), so stepping back through the days costs each day once rather
+// than the whole history every time.
+func commitAsOf(r *Repo, at time.Time) (plumbing.Hash, bool, error) {
 	head := r.Head()
 	if head.IsZero() {
-		return Snapshot{}, false, ErrEmptyRepository
+		return plumbing.ZeroHash, false, ErrEmptyRepository
 	}
 	shallow, err := r.shallows()
 	if err != nil {
-		return Snapshot{}, false, err
+		return plumbing.ZeroHash, false, err
 	}
-	h := head
+	horizon := horizonOf(shallow)
+	start, known := r.asOfStart(at, head, horizon)
+	if known != nil {
+		return known.hash, known.ok, nil
+	}
+	h := start
 	for {
 		c, err := object.GetCommit(r.s, h)
 		if err != nil {
-			return Snapshot{}, false, err
+			return plumbing.ZeroHash, false, err
 		}
 		if !c.Committer.When.After(at) {
-			s, err := LoadAt(r, h)
-			return s, err == nil, err
+			r.asOfResolved(at, head, horizon, h, true)
+			return h, true, nil
 		}
-		// Older than the boundary the clone was cut at: whatever came
-		// before is not here to read.
 		if shallow[h] {
-			return Snapshot{}, false, nil
+			r.asOfResolved(at, head, horizon, plumbing.ZeroHash, false)
+			return plumbing.ZeroHash, false, nil
 		}
 		if c.NumParents() == 0 {
-			// The board's own beginning: every commit is newer than the
-			// day asked for, so on that day the board was empty.
-			return Snapshot{}, true, nil
+			r.asOfResolved(at, head, horizon, plumbing.ZeroHash, true)
+			return plumbing.ZeroHash, true, nil
 		}
 		h = c.ParentHashes[0]
 	}
@@ -98,15 +121,19 @@ func cardsRemovedBetween(r *Repo, from, to time.Time, held map[string]bool) ([]b
 		return nil, err
 	}
 	// What the day BEGAN with: a writer that leaves no trailers still shows
-	// up here, as a card present at the start and absent at the end.
-	began, ok, err := LoadAsOf(r, from)
+	// up here, as a card present at the start and absent at the end. Only the
+	// IDS are wanted, and a card's id is in its path — so the day's first tree
+	// is listed, not parsed: reading 2400 card files to learn which ones exist
+	// cost more than the rest of the day put together.
+	began, ok, err := commitAsOf(r, from)
 	if err != nil {
 		return nil, err
 	}
-	start := map[string]board.Card{}
-	if ok {
-		for _, c := range began.Cards {
-			start[c.ItemID] = c
+	start := map[string]bool{}
+	if ok && !began.IsZero() {
+		start, err = cardIDsAt(r, began)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -132,14 +159,85 @@ func cardsRemovedBetween(r *Repo, from, to time.Time, held map[string]bool) ([]b
 		if !found {
 			// Never written during the day: it went with the day's first
 			// commit, and the state it went in is the one the day began with.
-			if was, ok := start[id]; ok {
-				out = append(out, was)
+			if start[id] {
+				was, ok, err := cardAt(r, began, id)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					out = append(out, was)
+				}
 			}
 			continue
 		}
 		out = append(out, c)
 	}
 	return out, nil
+}
+
+// horizonOf names a clone's shallow boundary — what it can and cannot reach.
+func horizonOf(shallow map[plumbing.Hash]bool) string {
+	if len(shallow) == 0 {
+		return ""
+	}
+	hs := make([]string, 0, len(shallow))
+	for h := range shallow {
+		hs = append(hs, h.String())
+	}
+	sort.Strings(hs)
+	return strings.Join(hs, ",")
+}
+
+// cardIDsAt lists the cards a commit's tree holds, by their paths alone: a
+// card's id IS its file name, so nothing is read but the trees.
+func cardIDsAt(r *Repo, h plumbing.Hash) (map[string]bool, error) {
+	c, err := object.GetCommit(r.s, h)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := c.Tree()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]bool{}
+	err = tree.Files().ForEach(func(f *object.File) error {
+		if kind, parts := ParsePath(f.Name); kind == PathCard {
+			out[parts[0]] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// cardAt reads one card from a commit's tree.
+func cardAt(r *Repo, h plumbing.Hash, id string) (board.Card, bool, error) {
+	p, err := CardPath(id)
+	if err != nil {
+		return board.Card{}, false, err
+	}
+	c, err := object.GetCommit(r.s, h)
+	if err != nil {
+		return board.Card{}, false, err
+	}
+	f, err := c.File(p)
+	if err != nil {
+		if errors.Is(err, object.ErrFileNotFound) || errors.Is(err, object.ErrDirectoryNotFound) {
+			return board.Card{}, false, nil
+		}
+		return board.Card{}, false, err
+	}
+	data, err := f.Contents()
+	if err != nil {
+		return board.Card{}, false, err
+	}
+	card, err := DecodeCard(id, []byte(data))
+	if err != nil {
+		return board.Card{}, false, nil //nolint:nilerr // not a card anyone saw
+	}
+	return card.Card, true, nil
 }
 
 // commitsOfDay is the day's commits, newest first, and the cards they name:

--- a/pkg/gitstore/commit.go
+++ b/pkg/gitstore/commit.go
@@ -63,6 +63,18 @@ type Repo struct {
 	snapMu   sync.Mutex
 	snapHead plumbing.Hash
 	snap     *Snapshot
+	// asOfMu guards the moments already resolved to a commit (asOfSeen),
+	// under the head they were resolved at. Finding "the newest commit at or
+	// before this evening" walks back from the head one commit at a time, so
+	// an old day costs the whole history — and a person stepping back through
+	// the days pays it again on every step. A moment already answered is the
+	// place the next walk STARTS from: the answer for a later moment is an
+	// ancestor of the head and no newer than the day being asked for, so the
+	// walk from it is the same walk, minus the part already done.
+	asOfMu      sync.Mutex
+	asOfHead    plumbing.Hash
+	asOfHorizon string
+	asOfSeen    []resolvedAt
 }
 
 // snapshotAt returns the memoized snapshot for a tip, if that is the tip it
@@ -156,6 +168,58 @@ func wrap(s storage.Storer, opts Options) *Repo {
 		opts.AuthorEmail = func(login string) string { return login + "@aeman" }
 	}
 	return &Repo{s: s, opts: opts, branch: opts.Branch}
+}
+
+// resolvedAt is a moment answered: the newest commit made at or before it,
+// and whether the history reaches back that far at all.
+type resolvedAt struct {
+	at   time.Time
+	hash plumbing.Hash
+	ok   bool
+}
+
+// asOfStart is where a walk for `at` should begin, and the answer itself when
+// it is already known. The head is the fallback.
+func (r *Repo) asOfStart(at time.Time, head plumbing.Hash, horizon string) (start plumbing.Hash, known *resolvedAt) {
+	r.asOfMu.Lock()
+	defer r.asOfMu.Unlock()
+	// The HORIZON is part of the answer as much as the head is: a deepen
+	// makes days readable that were refused a moment ago, and a memo that
+	// forgot it answered a day the clone did not hold with the day beside it.
+	if r.asOfHead != head || r.asOfHorizon != horizon {
+		r.asOfHead, r.asOfHorizon, r.asOfSeen = head, horizon, nil
+	}
+	start = head
+	var best *resolvedAt
+	for i := range r.asOfSeen {
+		e := &r.asOfSeen[i]
+		if e.at.Equal(at) {
+			return start, e
+		}
+		// The closest moment ABOVE the one asked for: its commit is at or
+		// before it, so nothing between it and here can be newer than `at`.
+		if e.ok && !e.at.Before(at) && (best == nil || e.at.Before(best.at)) {
+			best = e
+		}
+	}
+	if best != nil {
+		start = best.hash
+	}
+	return start, nil
+}
+
+// asOfResolved remembers a moment's answer, keeping the memo small.
+func (r *Repo) asOfResolved(at time.Time, head plumbing.Hash, horizon string, h plumbing.Hash, ok bool) {
+	r.asOfMu.Lock()
+	defer r.asOfMu.Unlock()
+	if r.asOfHead != head || r.asOfHorizon != horizon {
+		return // it moved under us: the answer is not ours to keep
+	}
+	const keep = 32
+	if len(r.asOfSeen) >= keep {
+		r.asOfSeen = r.asOfSeen[1:]
+	}
+	r.asOfSeen = append(r.asOfSeen, resolvedAt{at: at, hash: h, ok: ok})
 }
 
 // Storer exposes the underlying object store (for sync and tests).


### PR DESCRIPTION
Past days answered, but slowly: a cold day cost between half a second and nearly two, and it got worse the further back you looked. Three separate reasons, all measured on the production board.

**The walk started at the head every time.** Finding "the newest commit at or before this evening" walks the chain one commit at a time, so a day in July cost the whole history — and stepping back through the days paid it again on every step. A moment already answered is now where the next walk begins: the answer for a later moment is an ancestor of the head and no newer than the day being asked for, so the walk from it is the same walk minus the part already done. The memo is dropped when the head moves **or the horizon does** — a deepen makes days readable that were refused a moment ago, and a memo that forgot it would answer a day the clone does not hold with the day beside it.

**The day's start was parsed as a board.** It is needed only for the ids present when the day began, and a card's id is its file name — so the first tree is listed rather than read. 2400 card files parsed, for nothing.

**One flip was read four times.** Flipping to a day fires the cards, the weekly plan, the roster and the sprint pointers at once; each missed the cache the others had not filled yet. The first read is now the one the others wait on.

## Measured

On the production board (2400 cards, ~20k commits), a flip as the browser makes it — all requests together:

| | before | after |
|---|---|---|
| cold flip | 0.7–1.7s | 0.5–0.8s |
| the same day again | 0.01s | 0.01s |
| stepping back, per day | ~0.7s | **0.3s** |

Five days stepped back through in 1.15s.

## Testing

`TestOneColdDayIsReadOnceForEveryoneAskingAtOnce` pins the single flight (eight callers, one read), and the existing `TestReadingADayDoesNotCostTheWholeBoardPerCommit` still bounds what one day may read. The horizon case is what `TestAPastDayIsServedAsThatDaysOwnBoard` already covered — it caught the first version of the memo, which had forgotten it. `make lint`, `go test ./...` (with `-race` on the new test) are clean.
