### PR TITLE
fix(gitstore): a repack that replaces a pack no longer blinds the storer

### DIFF
--- a/pkg/gitstore/sync.go
+++ b/pkg/gitstore/sync.go
@@ -353,6 +353,20 @@ func (r *Repo) Maintain() error {
 	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
 		return fmt.Errorf("gitstore: repack: %w", err)
 	}
+	// The repack DELETED the packs it replaced, and the storer's pack index is
+	// a map built once and cached for the life of the process — nothing
+	// invalidates it. Without this, every object that lived in a deleted pack
+	// becomes unreachable to this process, permanently: the prune below fails
+	// on the spot, the board then loads zero cards, and every push fails the
+	// same way, while the repository on disk is perfectly healthy. Only a
+	// restart cleared it, because only a restart built a new storer.
+	//
+	// It bites on the SECOND repack, never the first: a first repack has no
+	// earlier pack to replace, which is why this survived a test that repacks
+	// once and two months of production.
+	if r, ok := r.s.(interface{ Reindex() }); ok {
+		r.Reindex()
+	}
 	err = repo.Prune(git.PruneOptions{OnlyObjectsOlderThan: time.Now(), Handler: repo.DeleteObject})
 	if err != nil && !errors.Is(err, git.ErrLooseObjectsNotSupported) {
 		return fmt.Errorf("gitstore: prune: %w", err)

--- a/pkg/gitstore/sync_test.go
+++ b/pkg/gitstore/sync_test.go
@@ -269,6 +269,62 @@ func TestRepackKeepsHistoryReadable(t *testing.T) {
 	}
 }
 
+// G21, the second time round: a repack that REPLACES an existing pack leaves
+// the history readable too.
+//
+// The test above repacks once, and a first repack deletes nothing — there is
+// no earlier pack to replace, so the storer's view cannot go stale. The second
+// repack is the one that bites: RepackObjects writes a new pack and DELETES
+// the old ones, while the storer's pack index is a map built once and cached
+// for the life of the process. Nothing invalidates it, so every object that
+// lived in the deleted pack becomes unreachable — to that process, for good.
+//
+// This is what took the production board down on 2026-09-05: prune failed on
+// the spot with "packfile not found", the board then loaded ZERO cards, and
+// every push failed the same way for two days, while the repository on disk
+// was perfectly healthy the whole time. Only a restart cleared it, because
+// only a restart built a new storer.
+func TestASecondRepackLeavesTheHistoryReadable(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Init(filesystem.NewStorage(osfs.New(dir), cache.NewObjectLRUDefault()), Options{Committer: serverID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit := func(i int) {
+		t.Helper()
+		if _, err := r.Commit(Action{Name: "progress", Actor: "kvaps", Summary: "step",
+			At: at("2026-08-01T09:00:00Z").Add(time.Duration(i) * time.Hour)}, []FileWrite{
+			{Path: "cards/a/1/A1.md", Data: []byte("---\ntitle: a\nprogress: " + strings.Repeat("1", i%9+1) + "\n---\n")},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		commit(i)
+	}
+	// The first repack: nothing to replace.
+	if err := r.Maintain(); err != nil {
+		t.Fatalf("first maintain: %v", err)
+	}
+	// More work, then the repack that REPLACES the pack the first one wrote.
+	for i := 20; i < 40; i++ {
+		commit(i)
+	}
+	if err := r.Maintain(); err != nil {
+		t.Fatalf("second maintain: %v", err)
+	}
+
+	// Everything the process could read before, it can read now. This is the
+	// assertion production failed: the objects were on disk and invisible.
+	n := 0
+	if err := r.Walk(r.Head(), func(*object.Commit) (bool, error) { n++; return true, nil }); err != nil || n != 40 {
+		t.Fatalf("history after the second repack: %d commits, %v", n, err)
+	}
+	if _, err := Load(r); err != nil {
+		t.Fatalf("load after the second repack: %v", err)
+	}
+}
+
 func countFiles(t *testing.T, dir string) int {
 	t.Helper()
 	n := 0

--- a/web/src/components/ProjectBoard.smoke.test.tsx
+++ b/web/src/components/ProjectBoard.smoke.test.tsx
@@ -2,13 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ProjectBoard } from "./ProjectBoard";
 import type { Board, Card, Provider } from "../providers/types";
+import { addDays, mondayOf, todayIso } from "../date";
 
 // The Project board draws its own grid — a table of weeks against epics — and
 // nothing else in the suite renders it. This is the one test that proves the
 // tree still comes out: the header row, the week labels, the cells and a
 // card's slot, in the grid the reader sees. It is markup only, not a browser:
 // no effect runs, so what it pins is the shape, not the gestures.
-const week = "2026-08-31";
+// THIS week's Monday, counted rather than named: the window opens two weeks
+// back from today, so a calendar date drifts out of the row it was written
+// for. This fixture named 2026-08-31 and the assertion below broke on the
+// Monday after, when that week slid from row 4 to row 3.
+const week = mondayOf(todayIso());
+// Friday of the NEXT week: the card reaches into a second row.
+const nextFriday = addDays(week, 11);
 
 // The board reads the reader's zoom and column widths as it mounts. There is
 // no browser here, so it gets an empty one and falls back to its defaults.
@@ -89,9 +96,9 @@ describe("the Project board's grid", () => {
   });
 
   it("stands a card in its own week, spanning the weeks it reaches", () => {
-    const html = draw(board({ cards: [card({ day: "2026-09-11" })] }));
-    // The header is row 1 and the window opens two weeks back, so the week of
-    // 2026-08-31 is row 4; the card ends in the week after, hence two rows.
+    const html = draw(board({ cards: [card({ day: nextFriday })] }));
+    // The header is row 1 and the window opens two weeks back, so THIS week
+    // is row 4; the card ends in the week after, hence two rows.
     expect(html).toContain('style="grid-column:2;grid-row:4 / span 2"');
     expect(html).toContain("A card in a column");
   });

--- a/web/src/components/TriageBoard.smoke.test.tsx
+++ b/web/src/components/TriageBoard.smoke.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TriageBoard } from "./TriageBoard";
 import type { Board, Card, Provider } from "../providers/types";
+import { addDays, mondayOf, todayIso } from "../date";
 
 // Triage reads down a person's column: every card is a plain box of one week,
 // they stand one under the next at the full column width, and the week grows
@@ -10,7 +11,12 @@ import type { Board, Card, Provider } from "../providers/types";
 // test that proves the tree comes out that way: markup only, so what it pins
 // is the shape, not the gestures.
 
-// 2026-08-31 is a Monday, and the grid opens on the week holding today.
+// Every date here counts from THIS week's Monday, because the grid opens on
+// the week holding today and draws no week before it. Written as calendar
+// dates, the fixture worked until the calendar left it behind: it named
+// 2026-08-31, and on the Monday after, four of these tests failed — the cards
+// sat in a week the board no longer draws, so a card of two weeks came out one
+// week long. A test of the shape must not expire.
 const store = new Map<string, string>();
 globalThis.localStorage = {
   getItem: (k: string) => store.get(k) ?? null,
@@ -23,7 +29,15 @@ globalThis.localStorage = {
   },
 } as Storage;
 
-const week = "2026-08-31";
+const week = mondayOf(todayIso());
+// Friday of this week: a card of ONE week.
+const thisFriday = addDays(week, 4);
+// Wednesday and Friday of the NEXT one: a card reaching into a second week.
+const nextWednesday = addDays(week, 9);
+const nextFriday = addDays(week, 11);
+// The two Mondays after this one — turns still to come, and deadlines.
+const nextWeek = addDays(week, 7);
+const weekAfter = addDays(week, 14);
 
 const card = (over: Partial<Card> = {}): Card =>
   ({
@@ -101,7 +115,7 @@ describe("the Triage board", () => {
   });
 
   it("draws a card of two weeks as two cards, each saying which it is", () => {
-    const html = draw([card({ title: "Two weeks of work", day: "2026-09-11" })]);
+    const html = draw([card({ title: "Two weeks of work", day: nextFriday })]);
     expect(html).toContain("(1/2)");
     expect(html).toContain("(2/2)");
     // One in this week's row and one in the next, each a box of one row: no
@@ -120,7 +134,7 @@ describe("the Triage board", () => {
     // A slot is a commitment made on the Project board and only passing
     // through this one: its week is that board's to say, so a zone stripe
     // would credit the decision to somebody who did not make it.
-    const html = draw([card({ epic: "Storage", day: "2026-09-04", zone: "red" })]);
+    const html = draw([card({ epic: "Storage", day: thisFriday, zone: "red" })]);
     expect(html).toContain("triage-slot-project");
     expect(html).not.toContain("triage-slot-zone-red");
   });
@@ -128,7 +142,7 @@ describe("the Triage board", () => {
   it("marks every week a stretched slot passes through", () => {
     // Split across its weeks, each box is the same commitment and wears the
     // same mark — one part carrying a zone stripe would read as two cards.
-    const html = draw([card({ epic: "Storage", day: "2026-09-09" })]);
+    const html = draw([card({ epic: "Storage", day: nextWednesday })]);
     expect(html.match(/triage-slot-project/g)).toHaveLength(2);
   });
 
@@ -179,13 +193,13 @@ describe("the Triage board", () => {
     // is in the reader's hand; a board at rest has nothing to say about it.
     // And the cell under a carried card is never tinted at all: the card is
     // already drawn where it would land, which says it once.
-    const html = draw([card({ title: "Two weeks of work", day: "2026-09-11" })]);
+    const html = draw([card({ title: "Two weeks of work", day: nextFriday })]);
     expect(html).not.toContain("triage-span");
     expect(html).not.toContain("project-cell-drag");
   });
 
   it("counts a card of two weeks against both of them", () => {
-    const html = draw([card({ day: "2026-09-11" })]);
+    const html = draw([card({ day: nextFriday })]);
     // The week's own count, beside its date, in the first two rows.
     expect(html.match(/class="triage-count">1</g)?.length).toBe(2);
   });
@@ -276,7 +290,7 @@ describe("the Triage board", () => {
                     team: "core",
                     assignee: "lexfrei",
                     history: [],
-                    due: ["2026-09-07", "2026-09-14"],
+                    due: [nextWeek, weekAfter],
                   },
                 ],
               },
@@ -314,7 +328,7 @@ describe("the Triage board", () => {
     // on the Project board — and only with the catch lifted, since the grip
     // changes that board's own dates. Everything else here is one week's
     // work, and a grip would say something about it nothing else would.
-    expect(draw([card({ epic: "Storage", day: "2026-09-04" })])).not.toContain(
+    expect(draw([card({ epic: "Storage", day: thisFriday })])).not.toContain(
       "triage-slot-resize",
     );
     expect(draw([card()])).not.toContain("triage-slot-resize");
@@ -322,7 +336,7 @@ describe("the Triage board", () => {
 
   it("keeps the × off a project card while the catch is closed", () => {
     // What the × does to one is the Project board's business too.
-    expect(draw([card({ epic: "Storage", day: "2026-09-04" })])).not.toContain(
+    expect(draw([card({ epic: "Storage", day: thisFriday })])).not.toContain(
       "card-action-delete",
     );
     expect(draw([card()])).toContain("card-action-delete");
@@ -331,7 +345,7 @@ describe("the Triage board", () => {
   it("offers a catch to lift, and starts with it closed", () => {
     // Never remembered: a guard that stays open is not a guard, so every
     // visit begins with a project card's weeks held still.
-    const html = draw([card({ epic: "Storage", day: "2026-09-04" })]);
+    const html = draw([card({ epic: "Storage", day: thisFriday })]);
     expect(html).toContain('class="triage-lock"');
     expect(html).toContain('aria-pressed="false"');
     expect(html).not.toContain("triage-lock-open");
@@ -419,8 +433,8 @@ describe("the Triage board", () => {
   // share a screen.
   it("says whose deadline the line is", () => {
     const html = draw([card()], [
-      { week: "2026-09-07", project: "cozystack" },
-      { week: "2026-09-14", project: "freedom" },
+      { week: nextWeek, project: "cozystack" },
+      { week: weekAfter, project: "freedom" },
     ]);
     expect(html).toContain("triage-deadline-label");
     expect(html).toContain("cozystack");


### PR DESCRIPTION
## What happened

The production board served **zero cards** from its primary repository for two days, while the repository on disk was healthy the whole time. `git fsck` on the live clone is clean; the object the server could not find is right there, a 42-byte tree in the current pack.

The failure was in the running process, not the data.

## The cause

`RepackObjects` writes a new pack and **deletes the packs it replaced**. The storer's pack index is a map built once by `requireIndex` and cached for the life of the process — nothing invalidates it. So after such a repack the process holds an index of packs that no longer exist, and every object that lived in one is unreachable to it, permanently.

The timestamps on the live clone tell it exactly:

| time | event |
|---|---|
| 11:42:18.616 | repack writes the new pack (42 MB) |
| 11:42:25.825 | writes its index |
| 11:42:25.881 | **prune fails: `packfile not found`** |

From then on: `board load done board=aeman-db cards=0`, and `push … packfile not found` every fifteen seconds for two days. Only a restart cleared it, because only a restart builds a new storer. Two commits of somebody's work sat unpushed in that clone the whole time.

go-git has the answer already:

```go
// Reindex indexes again all packfiles. Useful if git changed packfiles externally
func (s *ObjectStorage) Reindex() { s.index = nil }
```

`Maintain` simply never called it.

## Why it took two months to show

It bites on the **second** repack and never the first: a first repack has no earlier pack to replace, so the cached index cannot go stale. `TestRepackKeepsHistoryReadable` repacks once, which is why the suite was green.

The new test repacks twice and fails without the fix, with the same message the server logged.

## Not the cause

The same second carried a `context deadline exceeded` on a fetch — the sync-tick bound added in #193. It fired **17 ms after** the corruption was already logged: the tick was queued behind the repack holding the apply lock and gave up, as designed. It is a symptom here, not the cause.

---

## A second commit rides along

Four Triage tests and one Project test were failing **on `main`** this morning, with nobody having touched them: the fixtures named `2026-08-31` as "the week holding today", and today moved on. Triage draws no week before the current one, so the cards sat in a week the board no longer shows and a two-week card came out one week long; the Project board opens two weeks back, so its card slid from row 4 to row 3.

Both fixtures now count from this week's Monday, so they say what they mean and cannot expire again.

It rides here rather than in its own pull request because it is what lets *any* pull request go green — `main` is red without it, and this fix is wanted on production now.
