### PR TITLE
test: the drawer, the column, and five rules that survived deletion

### DIFF
--- a/internal/server/views_test.go
+++ b/internal/server/views_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aenix-io/aeman/pkg/board"
@@ -188,15 +189,29 @@ func TestTheCatalogNamesTheBoardsAndTheirGestures(t *testing.T) {
 	if out.Kind != "ViewList" || len(out.Items) != len(board.Views()) {
 		t.Fatalf("catalog = %+v", out)
 	}
+	// Every row, not the first one that matches: a client reads this in place
+	// of being told the surface, so the whole map is the contract.
+	got := map[string][]string{}
 	for _, v := range out.Items {
-		if v.Name == string(board.ViewTriage) {
-			if len(v.Gestures) != 3 {
-				t.Fatalf("the Triage board draws %v", v.Gestures)
-			}
-			return
+		got[v.Name] = v.Gestures
+	}
+	want := map[string][]string{
+		"me":       {"remove", "finished-earlier"},
+		"team":     {"remove", "finished-earlier"},
+		"triage":   {"remove", "place", "untriage"},
+		"backlog":  {"remove"},
+		"project":  {"remove"},
+		"personal": {"remove"},
+		"all":      {"remove", "place", "untriage", "finished-earlier"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("the catalog lists %v", got)
+	}
+	for name, gestures := range want {
+		if strings.Join(got[name], ",") != strings.Join(gestures, ",") {
+			t.Errorf("the %s board draws %v, want %v", name, got[name], gestures)
 		}
 	}
-	t.Fatal("the Triage board is missing from the catalog")
 }
 
 // WHICH CARD A ROUTE ADDRESSES is read in two places that both changed under
@@ -272,5 +287,29 @@ func TestTheDrawersCrossIsTheTriageBoards(t *testing.T) {
 	if rec := do(t, srv, http.MethodPost, "/api/v1/views/triage/cards/shelved/actions/remove?team=alpha",
 		`{"intent":"off-board"}`); rec.Code != http.StatusOK {
 		t.Fatalf("the drawer's × answered %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The other half of the same rule at the door: the PERSONAL column stands
+// beside the Me day, so its × is the Me board's ×.
+//
+// The card here carries NOBODY, which is the case the second listing exists
+// for: the Me day is a view of a person's work and finds a card by its
+// assignee, while the personal column is a view of a REPOSITORY and draws
+// everything in it. A card written straight into that repository with no
+// assignee is on the screen and in only one of the two listings.
+func TestThePersonalColumnsCrossIsTheMeBoards(t *testing.T) {
+	today := board.TodayIso()
+	fake := boardservicetest.New([]board.Card{
+		{ItemID: "own", Title: "read the paper", Author: "bob",
+			Zone: board.ZoneGray, Domain: board.PersonalDomain("bob"),
+			StartDate: today, Day: today},
+	}, nil)
+	srv := apiServer(t, Options{}, fake)
+	srv.apiTokens = func(*http.Request) (string, string, error) { return "tok", "bob", nil }
+
+	if rec := do(t, srv, http.MethodPost, "/api/v1/views/me/cards/own/actions/remove",
+		`{"intent":"off-board"}`); rec.Code != http.StatusOK {
+		t.Fatalf("the personal column's × answered %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/pkg/apiserver/drawn_test.go
+++ b/pkg/apiserver/drawn_test.go
@@ -1,6 +1,8 @@
 package apiserver
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/aenix-io/aeman/pkg/board"
@@ -71,5 +73,31 @@ func TestDrawnAsksTheSameQuestionTheListingAnswers(t *testing.T) {
 	// And a card nobody has is on no board.
 	if Drawn(b, Selector{View: "all"}, "nothing") {
 		t.Fatal("a card that does not exist was drawn")
+	}
+}
+
+// The parse of a selector whose BOARD came from the path: both its guards are
+// this package's, and pkg/apiserver is a public contract — an embedder calling
+// it directly has nothing else standing in front of them.
+func TestAViewSelectorTakesItsBoardFromThePath(t *testing.T) {
+	t.Parallel()
+	// A `view=` in the query asks for a board the answer would not come from,
+	// so it is refused rather than ignored, and the message says where the
+	// board goes now.
+	_, err := ParseViewSelector("me", url.Values{"view": {"team"}})
+	if err == nil || !strings.Contains(err.Error(), "path segment") {
+		t.Fatalf("a view in the query = %v, want a refusal naming the path", err)
+	}
+	// And a board nobody has is not a board.
+	if _, err := ParseViewSelector("process", nil); err == nil {
+		t.Fatal("an unknown board was parsed as one")
+	}
+	// The ordinary case still parses, with the segment as the view.
+	sel, err := ParseViewSelector("triage", url.Values{"team": {"portal"}, "weeks": {"9"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sel.View != "triage" || sel.Team != "portal" || sel.Weeks != 9 {
+		t.Fatalf("selector = %+v", sel)
 	}
 }

--- a/pkg/board/views_test.go
+++ b/pkg/board/views_test.go
@@ -60,3 +60,24 @@ func TestOnlySomeBoardsAreScopedByTeam(t *testing.T) {
 		}
 	}
 }
+
+// A BOARD can be drawn from more than one listing, and the gate has to count
+// them all: the × in the Triage board's DRAWER is the Triage board's, and the
+// personal column stands on the Me day. Collapsing this to "each board is its
+// own one listing" leaves every package green while every parked card and
+// every personal card loses its ×.
+func TestABoardCanBeDrawnFromMoreThanOneListing(t *testing.T) {
+	t.Parallel()
+	if got := Panes(ViewTriage); len(got) != 2 || got[0] != ViewTriage || got[1] != ViewBacklog {
+		t.Fatalf("the Triage board's panes = %v, want the grid and its drawer", got)
+	}
+	if got := Panes(ViewMe); len(got) != 2 || got[0] != ViewMe || got[1] != ViewPersonal {
+		t.Fatalf("the Me board's panes = %v, want the day and the personal column", got)
+	}
+	// Every other board is one listing, and it is its own.
+	for _, v := range []View{ViewTeam, ViewBacklog, ViewProject, ViewPersonal, ViewAll} {
+		if got := Panes(v); len(got) != 1 || got[0] != v {
+			t.Fatalf("%s is drawn from %v, want itself alone", v, got)
+		}
+	}
+}

--- a/pkg/boardservice/doors_test.go
+++ b/pkg/boardservice/doors_test.go
@@ -29,6 +29,12 @@ func TestTheServiceHoldsTheRulesTheHandlerHeld(t *testing.T) {
 		if _, err := f2svc(f).CreateCard(ctx, "acme", CreateCardArgs{Team: "alpha"}); err == nil {
 			t.Fatal("a card with no title was created; nothing on a board can be named nothing")
 		}
+		// Spaces are nothing too — a card called "   " is a blank row on
+		// every board, and the guard reads the title trimmed for exactly
+		// that reason.
+		if _, err := f2svc(f).CreateCard(ctx, "acme", CreateCardArgs{Team: "alpha", Title: "   "}); !errors.Is(err, ErrEmptyTitle) {
+			t.Fatalf("a card named in spaces = %v, want ErrEmptyTitle", err)
+		}
 	})
 
 	t.Run("defer moves a card forward, never back", func(t *testing.T) {
@@ -53,6 +59,9 @@ func TestTheServiceHoldsTheRulesTheHandlerHeld(t *testing.T) {
 		f := seed()
 		if _, err := f2svc(f).SendToReview(ctx, "acme", "c1", "", "2026-09-11", ""); err == nil {
 			t.Fatal("a review card was created with no reviewer; it is the artefact of asking somebody")
+		}
+		if _, err := f2svc(f).SendToReview(ctx, "acme", "c1", "  ", "2026-09-11", ""); !errors.Is(err, ErrNoReviewer) {
+			t.Fatalf("a reviewer named in spaces = %v, want ErrNoReviewer", err)
 		}
 	})
 
@@ -279,6 +288,18 @@ func TestTheServiceHoldsTheRulesOnlyTheBrowserHeld(t *testing.T) {
 		f2.get("i1").Week = board.AddDays(thisWeek, -21)
 		if err := f2svc(f2).Place(ctx, "acme", "i1", board.AddDays(thisWeek, 7)); !errors.Is(err, ErrOutsideCycle) {
 			t.Fatalf("sending an overdue turn into NEXT week = %v, want ErrOutsideCycle", err)
+		}
+	})
+
+	// The degenerate case beside the two exceptions: a turn that stands in NO
+	// week is in no occurrence, so nothing bounds it — it is being given its
+	// first week rather than carried out of one.
+	t.Run("a turn with no week yet is in no occurrence", func(t *testing.T) {
+		f := turns(monthly)
+		f.get("i1").Week = ""
+		far := board.AddDays(board.MondayOf(board.TodayIso()), 7*20)
+		if err := f2svc(f).SetWeek(ctx, "acme", "i1", far); err != nil {
+			t.Fatalf("giving a weekless turn a week = %v, want it taken", err)
 		}
 	})
 

--- a/pkg/boardservice/viewcreate_test.go
+++ b/pkg/boardservice/viewcreate_test.go
@@ -285,8 +285,14 @@ func TestAGestureIsOfferedByTheBoardThatDrawsIt(t *testing.T) {
 			t.Fatalf("view=all refused %s", g)
 		}
 	}
-	if len(Gestures(board.ViewTriage)) != 3 {
-		t.Fatalf("the Triage board draws %v", Gestures(board.ViewTriage))
+	// In a stable order, because a client reads this instead of being told
+	// the surface: the × first, then the board's own presses.
+	if got := Gestures(board.ViewTriage); len(got) != 3 ||
+		got[0] != GestureRemove || got[1] != GesturePlace || got[2] != GestureUntriage {
+		t.Fatalf("the Triage board draws %v, want remove, place, untriage in that order", got)
+	}
+	if got := Gestures(board.ViewProject); len(got) != 1 || got[0] != GestureRemove {
+		t.Fatalf("the Project board draws %v, want the × alone", got)
 	}
 }
 

--- a/pkg/mcpserver/mcpserver_test.go
+++ b/pkg/mcpserver/mcpserver_test.go
@@ -628,12 +628,17 @@ func TestAnAgentCreatesIntoABoard(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	mine := false
 	for _, c := range b.Cards {
 		if c.Title == "mine" {
+			mine = true
 			if len(c.Assignees) != 1 || c.Assignees[0] != "kvaps" {
 				t.Fatalf("a card created with no board named = %v, want the caller", c.Assignees)
 			}
 		}
+	}
+	if !mine {
+		t.Fatal("the card was never created, so the assignee was never checked")
 	}
 
 	// And a board refuses the fields it does not own, by name. A card filed

--- a/web/src/meboard.test.ts
+++ b/web/src/meboard.test.ts
@@ -122,11 +122,15 @@ describe("what a drag may do on the Me board", () => {
 
 // The Me board's add form stands in the unplanned zone alone — that is what
 // this board is FOR: something came up today, and the week's plan is made
-// elsewhere. It is the board's own offer and nothing more: the Team and
-// Triage grids are where planning is done, and they offer every zone in every
-// column, one's own included. The server holds no rule about it — it did
-// once, and because all three boards send the same create it refused a lead
-// putting a card in their own column.
+// elsewhere. The Team and Triage grids are where planning is done, and they
+// offer every zone in every column, one's own included.
+//
+// The SERVER holds the same rule now, and only for this board's create
+// (boardservice.addsUnplanned, `view=me` and the personal column beside it):
+// it could not before, because all three boards sent the same create and the
+// refusal reached a lead putting a card in their own column. The board is a
+// path segment now, so the rule reaches the add form it was written for. A
+// subtask is exempt on both sides — it takes its parent's band.
 describe("what the Me board offers, and how far that reaches", () => {
   it("adds in the unplanned zone and no other", () => {
     const zones: ZoneKey[] = ["red", "yellow", "gray", "green"];


### PR DESCRIPTION
The rest of the mutation pass over the view-scoped API. Same method as #204: delete or weaken the rule in a scratch copy, run the suite, and keep the cases where it stayed green.

- **`board.Panes` had no test anywhere.** Collapse it to one listing per board and all five packages pass, while every parked card and every unassigned personal card silently loses its x. It is pinned now as a unit and at the door. The personal half needed a card carrying nobody to bite, which is what that second listing is for: the Me day finds a card by its assignee, the personal column draws a repository, and a card written straight into that repository is on the screen and in only one of them.
- **A title and a reviewer of nothing but spaces.** The tests passed `""` and never `"   "`, while the note rule written against the same guard did.
- **`ParseViewSelector`'s two guards** — the `view=`-in-query refusal and the unknown board — had no test at all. It is a public contract with nothing else standing in front of it.
- **A process turn with no week yet**, the degenerate case beside the accumulate and overdue exceptions.
- **The order `Gestures` promises**, and the catalog read as the whole map rather than one row, since a client reads it in place of being told the surface.

Also: an MCP test that passed without the card being created, and a paragraph in `meboard.test.ts` that still said the server holds no rule about the Me board's band — it holds exactly that rule now, board-scoped, which is what let it come back.

## Checks

`make lint`, `go test ./...`, `npm run typecheck`, `npx vitest run`, plus each new test verified red with its rule removed.
